### PR TITLE
Tests ensured to remove temporary directories only

### DIFF
--- a/tests/naif_pds4_bundler/functional/test_insight.py
+++ b/tests/naif_pds4_bundler/functional/test_insight.py
@@ -22,7 +22,6 @@ def test_insight_basic(self):
         "working/insight_release_07.kernel_list",
     )
     shutil.copytree("../data/insight", "insight")
-    shutil.rmtree("kernels", ignore_errors=True)
     shutil.copytree("../data/kernels", "kernels")
 
     with open("../data/insight.list", "r") as i:
@@ -171,7 +170,7 @@ def test_insight_files_in_staging(self):
     for file in glob.glob("../data/insight_release_0[0-7].kernel_list"):
         shutil.copy2(file, "working")
 
-    shutil.rmtree("staging")
+    shutil.move("staging", "staging_old")
     shutil.copytree("../data/insight", "staging")
     os.makedirs("insight", exist_ok=True)
 

--- a/tests/naif_pds4_bundler/functional/test_ladee.py
+++ b/tests/naif_pds4_bundler/functional/test_ladee.py
@@ -16,10 +16,7 @@ def tearDown(self):
 
     dirs = ["working", "staging", "ladee", "kernels"]
     for dir in dirs:
-        shutil.rmtree(dir, ignore_errors=True)
-
-    if os.path.exists("staging"):
-        os.remove("staging")
+        shutil.move(dir, f"{dir}_old")
 
 
 def test_ladee_update_input_mk_name(self):

--- a/tests/naif_pds4_bundler/functional/test_m2020.py
+++ b/tests/naif_pds4_bundler/functional/test_m2020.py
@@ -108,7 +108,7 @@ def test_m2020_duplicated_kernel(self):
     Test is successful if NPB is executed without errors.
     """
     post_setup(self)
-    shutil.rmtree("kernels")
+    shutil.move("kernels", "kernels_old")
     shutil.copytree(
         "../data/regression/mars2020_spice/spice_kernels",
         "kernels",

--- a/tests/naif_pds4_bundler/functional/test_mro.py
+++ b/tests/naif_pds4_bundler/functional/test_mro.py
@@ -44,10 +44,10 @@ def test_mro_basic(self):
     )
 
     shutil.copytree("../data/kernels", "kernels")
-    shutil.rmtree("misc")
+    shutil.move("misc", "misc_old")
     shutil.copytree("../data/misc", "misc")
     shutil.copytree("../data/mro", "bundle")
-    shutil.rmtree("staging")
+    shutil.move("staging", "staging_old")
     shutil.copytree("../data/mro", "staging")
 
     shutil.copy2(

--- a/tests/naif_pds4_bundler/regression/test_pds3.py
+++ b/tests/naif_pds4_bundler/regression/test_pds3.py
@@ -59,7 +59,7 @@ def compare(self):
                 self.assertTrue(False)
     dirs = ["working", "staging", "kernels", mis]
     for dir in dirs:
-        shutil.rmtree(dir, ignore_errors=True)
+        shutil.move(dir, f"{dir}_old")
         pass
 
 

--- a/tests/naif_pds4_bundler/regression/test_pds4.py
+++ b/tests/naif_pds4_bundler/regression/test_pds4.py
@@ -45,11 +45,6 @@ def compare(self):
             if fromlines != tolines:
                 print(f"Assertion False for: {product}")
                 self.assertTrue(False)
-    dirs = ["working", "staging", "kernels", mis]
-    for dir in dirs:
-        shutil.move(dir, f"{dir}_old")
-
-        pass
 
 
 def post_setup(self):
@@ -94,8 +89,8 @@ def test_insight(self):
         "../data/insight_release_basic.kernel_list",
         "working/insight_release_07.kernel_list",
     )
-    shutil.copytree("../data/insight", "insight")
-    shutil.copytree("../data/kernels", "kernels")
+    shutil.copytree("../data/insight", "insight", dirs_exist_ok=True)
+    shutil.copytree("../data/kernels", "kernels", dirs_exist_ok=True)
 
     #
     # Remove the MK used for other tests. MK will be generated
@@ -119,6 +114,7 @@ def test_ladee(self):
         "../data/regression/ladee_spice/spice_kernels",
         "kernels",
         ignore=shutil.ignore_patterns("*.xml", "*.csv"),
+        dirs_exist_ok=True
     )
 
     main(self.updated_config, silent=self.silent, log=self.log)
@@ -135,6 +131,7 @@ def test_kplo(self):
         "../data/regression/kplo_spice/spice_kernels",
         "kernels",
         ignore=shutil.ignore_patterns("*.xml", "*.csv"),
+        dirs_exist_ok=True
     )
 
     main(self.updated_config, silent=self.silent, log=self.log)
@@ -157,6 +154,7 @@ def test_m2020(self):
         "../data/regression/mars2020_spice/spice_kernels",
         "kernels",
         ignore=shutil.ignore_patterns("*.xml", "*.csv"),
+        dirs_exist_ok=True
     )
 
     plan = '../data/mars2020_release_01.plan'

--- a/tests/naif_pds4_bundler/regression/test_pds4.py
+++ b/tests/naif_pds4_bundler/regression/test_pds4.py
@@ -47,7 +47,7 @@ def compare(self):
                 self.assertTrue(False)
     dirs = ["working", "staging", "kernels", mis]
     for dir in dirs:
-        shutil.rmtree(dir, ignore_errors=True)
+        shutil.move(dir, f"{dir}_old")
 
         pass
 

--- a/tests/naif_pds4_bundler/test_functional.py
+++ b/tests/naif_pds4_bundler/test_functional.py
@@ -36,7 +36,10 @@ class TestFunctional(TestCase):
         shutil.copytree(os.sep.join(cls.test_dir.split(os.sep)[:-2]) +
                         "/src/pds/naif_pds4_bundler/templates/1.5.0.0",
                         cls.tmp_dir.name + '/naif_pds4_bundler/templates/1.5.0.0')
-        os.chdir(cls.tmp_dir.name + "/naif_pds4_bundler/functional/")
+
+        tests_dir = cls.tmp_dir.name + "/naif_pds4_bundler/functional/"
+        print(f"      Tests data on: {cls.tmp_dir.name}")
+        os.chdir(tests_dir)
 
     @classmethod
     def tearDownClass(cls):
@@ -71,10 +74,11 @@ class TestFunctional(TestCase):
         This method will be executed after each test function.
         """
         unittest.TestCase.tearDown(self)
-        dirs = next(os.walk('.'))[1]
+        test_dir = self.tmp_dir.name + "/naif_pds4_bundler/functional/"
+        dirs = next(os.walk(test_dir))[1]
         for dir in dirs:
             try:
-                shutil.rmtree(dir, ignore_errors=True)
+                shutil.rmtree(test_dir + dir)
             except BaseException:
                 pass
 

--- a/tests/naif_pds4_bundler/test_regression.py
+++ b/tests/naif_pds4_bundler/test_regression.py
@@ -18,7 +18,7 @@ class TestRegression(TestCase):
         Method that will be executed once for this test case class.
         It will execute before all tests methods.
         """
-        print(f"NPB - Functional Tests - {cls.__name__}")
+        print(f"NPB - Regression Tests - {cls.__name__}")
 
         cls.test_dir = os.path.dirname(__file__)
         cls.silent = True
@@ -31,7 +31,9 @@ class TestRegression(TestCase):
         shutil.copytree(os.sep.join(cls.test_dir.split(os.sep)[:-2]) +
                         "/src/pds/naif_pds4_bundler/templates/1.5.0.0",
                         cls.tmp_dir.name + '/naif_pds4_bundler/templates/1.5.0.0')
-        os.chdir(cls.tmp_dir.name + "/naif_pds4_bundler/functional/")
+        tests_dir = cls.tmp_dir.name + "/naif_pds4_bundler/regression/"
+        print(f"       Tests data on: {cls.tmp_dir.name}")
+        os.chdir(tests_dir)
 
     @classmethod
     def tearDownClass(cls):
@@ -65,10 +67,11 @@ class TestRegression(TestCase):
         This method will be executed after each test function.
         """
         unittest.TestCase.tearDown(self)
+        test_dir = self.tmp_dir.name + "/naif_pds4_bundler/regression/"
         dirs = next(os.walk('.'))[1]
         for dir in dirs:
             try:
-                shutil.rmtree(dir, ignore_errors=True)
+                shutil.rmtree(test_dir + dir)
             except BaseException:
                 pass
 

--- a/tests/naif_pds4_bundler/test_unittests.py
+++ b/tests/naif_pds4_bundler/test_unittests.py
@@ -47,7 +47,10 @@ class TestUnitTests(TestCase):
         shutil.copytree(os.sep.join(cls.test_dir.split(os.sep)[:-2]) +
                         "/src/pds/naif_pds4_bundler/templates/1.5.0.0",
                         cls.tmp_dir.name + '/naif_pds4_bundler/templates/1.5.0.0')
-        os.chdir(cls.tmp_dir.name + "/naif_pds4_bundler/unittests/")
+
+        tests_dir = cls.tmp_dir.name + "/naif_pds4_bundler/unittests/"
+        print(f"       Tests data on: {cls.tmp_dir.name}")
+        os.chdir(tests_dir)
 
     @classmethod
     def tearDownClass(cls):
@@ -84,10 +87,11 @@ class TestUnitTests(TestCase):
         This method will be executed after each test function.
         """
         unittest.TestCase.tearDown(self)
-        dirs = next(os.walk('.'))[1]
+        test_dir = self.tmp_dir.name + "/naif_pds4_bundler/unittests/"
+        dirs = next(os.walk(test_dir))[1]
         for dir in dirs:
             try:
-                shutil.rmtree(dir, ignore_errors=True)
+                shutil.rmtree(test_dir + dir)
             except BaseException:
                 pass
 

--- a/tests/naif_pds4_bundler/unittests/test_checksums.py
+++ b/tests/naif_pds4_bundler/unittests/test_checksums.py
@@ -60,7 +60,7 @@ def test_checksum_from_labels(self):
 
     dirs = ["working", "mars2020"]
     for dir in dirs:
-        shutil.rmtree(dir, ignore_errors=True)
+        shutil.move(dir, f"{dir}_old")
     try:
         os.mkdir("working")
         os.mkdir("mars2020")

--- a/tests/naif_pds4_bundler/unittests/test_clear.py
+++ b/tests/naif_pds4_bundler/unittests/test_clear.py
@@ -18,9 +18,9 @@ def test_insight_basic(self):
         "../data/insight_release_basic.kernel_list",
         "working/insight_release_07.kernel_list",
     )
-    shutil.rmtree("insight", ignore_errors=True)
+    shutil.move("insight", "insight_old")
     shutil.copytree("../data/insight", "insight")
-    shutil.rmtree("kernels", ignore_errors=True)
+    shutil.move("kernels", "kernels_old")
     shutil.copytree("../data/kernels", "kernels")
 
     with open("../data/insight.list", "r") as i:
@@ -72,9 +72,9 @@ def test_insight_error(self):
 
     plan = "../data/insight_release_08.plan"
 
-    shutil.rmtree("insight")
+    shutil.move("insight", "insight_old")
     shutil.copytree("../data/insight", "insight")
-    shutil.rmtree("kernels")
+    shutil.move("kernels", "kernels_old")
     shutil.copytree("../data/kernels", "kernels")
 
     #
@@ -109,7 +109,7 @@ def test_clear_label_mode(self):
 
     Test is successful if NPB is executed without errors.
     """
-    shutil.rmtree("kernels")
+    shutil.move("kernels", "kernels_old")
     shutil.copytree(
         "../data/regression/ladee_spice/spice_kernels",
         "kernels",

--- a/tests/naif_pds4_bundler/unittests/test_endianness.py
+++ b/tests/naif_pds4_bundler/unittests/test_endianness.py
@@ -142,7 +142,7 @@ def test_pds3_ltl_endianness(self):
         "../data/kernels/spk/mro_psp60.bsp",
         "kernels/spk/"
     )
-    shutil.rmtree("bundle")
+    shutil.move("bundle", "bundle_old")
     shutil.copytree("../data/mro", "bundle")
 
     try:
@@ -164,7 +164,7 @@ def test_pds3_ltl_endianness_config(self):
         "../data/kernels/spk/mro_psp60.bsp",
         "kernels/spk/"
     )
-    shutil.rmtree("bundle")
+    shutil.move("bundle", "bundle_old")
     shutil.copytree("../data/mro", "bundle")
 
     config = "../config/mro.xml"
@@ -194,7 +194,7 @@ def test_pds3_big_endianness(self):
         "../data/kernels/spk/mro_psp60.big.bsp",
         "kernels/spk/mro_psp60.bsp"
     )
-    shutil.rmtree("bundle")
+    shutil.move("bundle", "bundle_old")
     shutil.copytree("../data/mro", "bundle")
 
     try:

--- a/tests/naif_pds4_bundler/unittests/test_orbnum.py
+++ b/tests/naif_pds4_bundler/unittests/test_orbnum.py
@@ -8,7 +8,7 @@ from pds.naif_pds4_bundler.utils.files import string_in_file
 
 def post_setup(self):
     """Post Setup Test."""
-    shutil.rmtree("kernels")
+    shutil.move("kernels", "kernels_old")
     shutil.copytree("../data/kernels", "kernels")
     shutil.copytree("../data/misc", "misc")
 

--- a/tests/naif_pds4_bundler/unittests/test_plan.py
+++ b/tests/naif_pds4_bundler/unittests/test_plan.py
@@ -23,7 +23,10 @@ def post_setup(self):
         "kernels/mk",
     ]
     for dir in dirs:
-        shutil.rmtree(dir, ignore_errors=True)
+        try:
+            shutil.move(dir, f"{dir}_old")
+        except BaseException:
+            pass
         os.mkdir(dir)
 
 

--- a/tests/naif_pds4_bundler/unittests/zz_test_slicer.py
+++ b/tests/naif_pds4_bundler/unittests/zz_test_slicer.py
@@ -32,7 +32,7 @@ class ZzTestSlicer(TestCase):
 
         os.chdir(os.path.dirname(__file__))
 
-        shutil.rmtree("kernels_sliced", ignore_errors=True)
+        shutil.move("kernels_sliced", ignore_errors=True)
 
     def setUp(self):
         """Setup Test.


### PR DESCRIPTION
## 🗒️ Summary
Updated tests to remove any possible bug to delete non-testing related directories.

## ⚙️ Test Data and/or Report

```
NPB - Functional Tests - TestFunctional
      Tests data on: /var/folders/sw/74bj2rqn0rbgsjl6gms7yt8c0000gn/T/tmp4xxx0vls
    * test_dart_host_type
.    * test_dart_multiple_obs_tar
.    * test_insight_basic
.    * test_insight_diff_previous_all
.    * test_insight_diff_previous_files
.    * test_insight_diff_previous_log
.    * test_insight_diff_previous_none
.    * test_insight_diff_templates
.    * test_insight_extra_mk_pattern
.    * test_insight_files_in_staging
.    * test_insight_generate_mk
.    * test_insight_incorrect_times
.    * test_insight_increment_with_misc
.    * test_insight_mk_input
.    * test_insight_mks_coverage_in_final
.    * test_insight_mks_input
.    * test_insight_mks_inputs_coverage
.    * test_insight_no_kernels
.    * test_insight_no_kernels_with_bundle
.    * test_insight_no_readme
.    * test_insight_no_readme_in_config
.    * test_insight_no_spiceds
.    * test_insight_no_spiceds_in_conf
.    * test_insight_only_checksums
.    * test_insight_previous_spiceds
.    * test_insight_readme_incomplete_in_config
.    * test_insight_start_finish
.    * test_ladee_checksum_registry
.    * test_ladee_date_format
.    * test_ladee_label_mode
.    * test_ladee_label_mode_ker_bun_dir
.    * test_ladee_label_mode_ker_input
.    * test_ladee_label_mode_plan_input
.    * test_ladee_update_input_mk_name
.    * test_m2020_duplicated_kernel
.    * test_m2020_empty_spk
.    * test_m2020_incorrect_mission_times
.    * test_m2020_incorrect_start_time
.    * test_m2020_increment_finish_time
.    * test_m2020_increment_start_time
.    * test_m2020_kernel_list
.    * test_m2020_kernel_list_dir
.    * test_m2020_mks_incorrect_path
.    * test_m2020_mks_inputs_coverage
.    * test_m2020_spk_with_unrelated_id
.    * test_maven_generate_mk
.    * test_maven_increment_times_from_yearly_mks
.    * test_maven_load_kernels
.    * test_maven_mks_input
.    * test_maven_mks_list
.    * test_maven_mks_list_config_in_kernels
.    * test_maven_mks_list_config_in_kernels_and_config
.    * test_maven_mks_list_in_kernels
.    * test_maven_no_mk
.    * test_mro_basic
.NPB - Regression Tests - TestRegression
       Tests data on: /var/folders/sw/74bj2rqn0rbgsjl6gms7yt8c0000gn/T/tmpk_co_8qm
    * test_em16
.    * test_insight
.    * test_kplo
.    * test_ladee
.    * test_m2020
.    * test_msl
.NPB - Unit Tests - TestUnitTests
       Tests data on: /var/folders/sw/74bj2rqn0rbgsjl6gms7yt8c0000gn/T/tmpwi4xopwc
    * test_binary_kernel_integrity
.    * test_checksum_from_labels
.    * test_checksum_from_record
.    * test_ck
.    * test_clear_label_mode
.    * test_dsk_coverage
.    * test_im_format
.    * test_im_schema_incoherent
.    * test_im_templates
.    * test_im_templates_11
.    * test_im_templates_14
.    * test_im_templates_16
.    * test_im_version_ascii
.    * test_im_version_ascii_incorrect
.    * test_im_xml_incoherent
.    * test_insight_basic
.    * test_insight_error
.    * test_insight_history
.    * test_insight_mk_double_keyword_in_pattern
.    * test_insight_mk_double_keyword_in_pattern_no_gen
.    * test_insight_mk_error_extra_pattern
.    * test_insight_mk_error_wrong_name
.    * test_match_patterns_basic
.    * test_mk_to_list
.    * test_pds3_big_endianness
.    * test_pds3_juno_list
.    * test_pds3_ltl_endianness
.    * test_pds3_ltl_endianness_config
.    * test_pds3_m01_list
.    * test_pds3_mro_list
.    * test_pds3_msl_list
.    * test_pds3_orbnum_files
.    * test_pds4_big_endianness
.    * test_pds4_big_endianness_config
.    * test_pds4_hyb2_list
.    * test_pds4_insight_list
.    * test_pds4_insight_plan
.    * test_pds4_ltl_endianness
.    * test_pds4_ltl_endianness_config
.    * test_pds4_mars2020_list
.    * test_pds4_mars2020_no_plan
.    * test_pds4_maven_list
.    * test_pds4_orbnum_blank_records
.    * test_pds4_orbnum_blank_records_no_former
.    * test_pds4_orbnum_blank_records_no_version
.    * test_pds4_orbnum_coverage_archived_spk
.    * test_pds4_orbnum_coverage_estimate
.    * test_pds4_orbnum_coverage_increment_spk
.    * test_pds4_orbnum_coverage_lookup_table
.    * test_pds4_orbnum_coverage_lookup_table_multiple
.    * test_pds4_orbnum_coverage_user_spk
.    * test_pds4_orbnum_eol_line_feed
.    * test_pds4_orbnum_generated_list
.    * test_pds4_orbnum_multiple_files
.    * test_pds4_orbnum_multiple_files_in_spk_dir
.    * test_pds4_orbnum_multiple_files_incorrect_spk
.    * test_pds4_orbnum_new_im
.    * test_pds4_orbnum_with_former
.    * test_pds4_orbnum_with_former_version
.    * test_pds4_orex_list
.    * test_pds4_vco_list
.    * test_spk_coverage
.    * test_text_kernel_integrity
.    * test_xml_reader
.
----------------------------------------------------------------------
Ran 125 tests in 140.271s

OK
```

## ♻️ Related Issues
None.


