### PR TITLE
Add NAIF issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "<system feature> <is not/does not> <expected behaviour>"
+labels: bug, needs:triage
+assignees: marcsit
+
+---
+
+## 🐛 Describe the bug
+<!-- A clear and concise description of what the bug is. -->
+
+## 📜 To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## 🕵️ Expected behavior
+<!-- A clear and concise description of what you expected to happen -->
+
+## 📚 Version of Software Used
+<!-- Software should have a `-V` or `--version` flag to get this information. -->
+
+## 🩺 Test Data / Additional context
+<!-- If applicable, Add test data or any other context about the problem here -->
+
+##  🏞Screenshots
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+## 🖥 System Info
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+---
+<!-- FOR DEV TEAM USE -->
+
+## 🦄 Related requirements
+
+
+## ⚙️ Engineering Details

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: PDS Help Desk
+    url: https://pds.nasa.gov/?feedback=true
+    about: Contact the PDS Help Desk with any additional questions you may have.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature request
+about: Suggest a new idea or new requirement for this project
+title: As a <what is the user's role?> I want to <what is the user trying to accomplish?>
+labels: needs:triage, requirement
+assignees: marcsit
+
+---
+
+<!--
+   For more information on how to populate this new feature request, see the PDS Wiki on User Story Development:
+   https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#user-story-development
+-->
+
+## 💪 Motivation
+...so that I can <!-- why do you want to do this? -->
+
+## 📖 Additional Details
+<!-- Please prove any additional details or information that could help provide some context for the user story. -->
+
+## ⚖️ Acceptance Criteria
+**Given** <!-- a condition -->
+**When I perform** <!-- an action -->
+**Then I expect** <!-- the result -->
+
+<!-- For Internal Dev Team Use -->
+
+## ⚙️ Engineering Details
+<!--
+    Provide some design / implementation details and/or a sub-task checklist as needed. 
+    Convert issue to Epic if estimate is outside the scope of 1 sprint.
+-->

--- a/.github/ISSUE_TEMPLATE/i-t-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/i-t-bug-report.md
@@ -1,0 +1,59 @@
+---
+name: I&T Bug Report
+about: Report a bug found or test case failure during PDS System I&T
+title: "<system feature> <is not/does not> <expected behaviour>"
+labels: B12.1, bug, I&T, needs:triage
+assignees: marcsit
+
+---
+
+## 🐛 Describe the bug identified during I&T
+<!-- A clear and concise description of what the bug is. -->
+
+
+## 🥼 Related Test Case(s)
+<!-- Document related test cases below -->
+
+
+## 🔁 : Related issues
+<!-- Reference related issues below, e.g.
+* for issues in this repo: #1 (remove back ticks)
+* for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/that_repo#2
+-->
+
+---
+
+## ➕ Additional Details
+<!-- Enter additional details to support the ticket if the info above is not sufficient to replicate -->
+
+### 📜 To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+### 🕵️ Expected behavior
+<!-- A clear and concise description of what you expected to happen -->
+
+### 📚 Version of Software Used
+<!-- Software should have a `-V` or `--version` flag to get this information. -->
+
+### 🩺 Test Data / Additional context
+<!-- If applicable, Add test data or any other context about the problem here -->
+
+###  🏞Screenshots
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+### 🖥 System Info
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+---
+<!-- FOR DEV TEAM USE -->
+
+## 🦄 Related requirements
+
+
+## ⚙️ Engineering Details

--- a/.github/ISSUE_TEMPLATE/pds4-standards-change-request.md
+++ b/.github/ISSUE_TEMPLATE/pds4-standards-change-request.md
@@ -1,0 +1,13 @@
+---
+name: PDS4 Standards Change Request
+about: Tasks related to PDS4 Standards Change Request in design and implementation
+  queue
+title: 'CCB-xxx: Copy SCR title here'
+labels: needs:triage, p.must-have, pending-scr, requirement
+assignees: marcsit
+
+---
+
+**Link to SCR:** _Insert URL here to PDS CCB JIRA ticket, if available_
+
+**SCR Details:** _Attach PDF export of issue details. If SCR design is not complete, leave blank for now_

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,17 @@
+---
+name: Task
+about: Low level task or action that is often too granular for testing, but helps
+  towards progress on an Epic or parent story
+title: ''
+labels: B13.0, skip-i&t, task
+assignees: ''
+
+---
+
+<!--
+   For more information on how to populate this Task, see the PDS Wiki on User Story Development:
+   https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#user-story-development
+-->
+
+## 💡 Description
+<!-- Enter description here. Make it detailed enough someone could actually know what you are doing, but if you spend too much time on this, it probably deserves it's own story -->

--- a/.github/ISSUE_TEMPLATE/vulnerability-issue.md
+++ b/.github/ISSUE_TEMPLATE/vulnerability-issue.md
@@ -1,0 +1,14 @@
+---
+name: Vulnerability Issue
+about: Describe security vulnerability
+title: "[SECURITY] Title Here"
+labels: bug, needs:triage, security
+assignees: marcsit
+
+---
+
+## Vulnerability
+_Describe the vulnerability_
+
+## Software Version
+_Version_

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## 🗒️ Summary
+Brief summary of changes if not sufficiently described by commit messages.
+
+## ⚙️ Test Data and/or Report
+One of the following should be included here:
+* Reference to regression test included in code (preferred wherever reasonable)
+* Attach test data here + outputs of tests
+
+## ♻️ Related Issues
+<!--
+    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.
+
+    * for issues in this repo:
+        - fixes #1
+        - fixes #2
+        - refs #3
+    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
+-->
+
+


### PR DESCRIPTION
## 🗒️ Summary
The organization issue templates assign @jordanpadams by default to all newly created issues. This should really be the repo owner @marcsit.
