### PR TITLE
Update stable-cicd.yaml

### DIFF
--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -31,7 +31,7 @@ name: 😌 Stable integration & delivery
 
 on:
     push:
-        branches:
+        tags:
             - 'release/*'
 
 


### PR DESCRIPTION
Update to trigger tagging of releases used `tags` instead of `branches`.

See https://github.com/NASA-PDS/roundup-action/pull/91 for details
