### PR TITLE
Roundup mutex and Node12 → Node16

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -33,6 +33,7 @@ on:
     push:
         tags:
             - 'release/*'
+concurrency: roundup
 
 
 # What to Do
@@ -47,14 +48,14 @@ jobs:
         steps:
             -
                 name: 💳 Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
                 with:
                     lfs: true
                     token: ${{secrets.ADMIN_GITHUB_TOKEN}}
                     fetch-depth: 0
             -
                 name: 💵 Python Cache
-                uses: actions/cache@v2
+                uses: actions/cache@v3
                 with:
                     path: ~/.cache/pip
                     # The "key" used to indicate a set of cached files is the operating system runner

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -35,6 +35,7 @@ on:
         paths-ignore:
             - 'CHANGELOG.md'
             - 'docs/requirements/**'
+concurrency: roundup
 
 
 # What to Do
@@ -50,14 +51,14 @@ jobs:
         steps:
             -
                 name: 💳 Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
                 with:
                     lfs: true
                     token: ${{secrets.ADMIN_GITHUB_TOKEN}}
                     fetch-depth: 0
             -
                 name: 💵 Python Cache
-                uses: actions/cache@v2
+                uses: actions/cache@v3
                 with:
                     path: ~/.cache/pip
                     # The "key" used to indicate a set of cached files is the operating system runner


### PR DESCRIPTION
## 📜 Summary

Merge this and you'll close (where applicable):

- [roundup-action#98](https://github.com/NASA-PDS/roundup-action/issues/98) in those repositories that use the Roundup Action. This merge adds a [mutex](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) to Roundups so that only one can ever run at a time.
- [software-issues-repo#41](https://github.com/NASA-PDS/software-issues-repo/issues/41) in those repositories that use the `checkout` or `cache` actions. It upgrades those actions to version 3, as [version 2 is deprecated due to running older Node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).


## 🩺 Test Data and/or Report

None provided.


## 🧩 Related Issues

- [roundup-action#98](https://github.com/NASA-PDS/roundup-action/issues/98)
- [software-issues-repo#41](https://github.com/NASA-PDS/software-issues-repo/issues/41)
