### PR TITLE
Add re-install of certificates to workflows

### DIFF
--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -46,6 +46,11 @@ jobs:
         name: 🐴 Stable Assembly
         runs-on: ubuntu-latest
         steps:
+            - name: Update CA certificates
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install --reinstall ca-certificates
+                  sudo update-ca-certificates
             -
                 name: 💳 Checkout
                 uses: actions/checkout@v3

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -49,6 +49,11 @@ jobs:
         if: github.actor != 'pdsen-ci'
         runs-on: ubuntu-latest
         steps:
+            - name: Update CA certificates
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install --reinstall ca-certificates
+                  sudo update-ca-certificates
             -
                 name: 💳 Checkout
                 uses: actions/checkout@v3


### PR DESCRIPTION
## 🗒️ Summary
The NPB Git unstable integration and delivery automation ran into an issue –
https://github.com/NASA-PDS/naif-pds4-bundler/actions/runs/15739957628

```
Downloading CSPICE for PC_Linux_GCC_64bit... 
Download failed with URLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1129), trying again after 15 seconds! 
Download failed with URLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1129), trying again after 15 seconds! 
Download failed with URLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate 
…etc… 
```

We had new certificates deployed on our server this week and these need to be updated somewhere in PDS GITHubs automation. 

The solution we have advertised to fix this is to update the client system's CA certificates, typically by reinstalling the ca-certificates package using the client system's package manager.


## ⚙️ Test Data and/or Report
Verify software compiles


