### PR TITLE
Add Google Analytics tracking to Sphinx documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -103,6 +103,12 @@ todo_include_todos = True
 #
 html_theme = 'sphinx_rtd_theme'
 
+# Theme options for sphinx_rtd_theme
+html_theme_options = {
+    'analytics_id': 'G-Q1K210DS5W',  # Google Analytics 4 tracking ID
+    'analytics_anonymize_ip': False,
+}
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".


### PR DESCRIPTION
## 🗒️ Summary
- Add Google Analytics 4 tracking ID (G-Q1K210DS5W) to Sphinx conf.py
- Configure html_theme_options with analytics_id for sphinx_rtd_theme
- Set anonymize_ip to false for full analytics tracking
- Google Analytics tracking code will be automatically injected into all generated HTML documentation pages

## ⚙️ Test Data and/or Report
Verify successful tox run in GitHub Actions

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Refs NASA-PDS/software-issues-repo#139