### PR TITLE
Extend testing environments to Mac/Intel and Mac/ARM

### DIFF
--- a/.github/workflows/ci-builds-and-tests.yaml
+++ b/.github/workflows/ci-builds-and-tests.yaml
@@ -4,9 +4,9 @@ permissions:
 
 on:
   push:
-    branches: [ '*' ]
+    branches: [ main ]
   pull_request:
-    branches: [ '*' ]
+    branches: [ main ]
 
 jobs:
   test:


### PR DESCRIPTION
## 🗒️ Summary
Extended the list of `os` in the test jobs of the **NPB Testing** workflow to include `macos-15` and `macos-15-intel` (Mac/ARM and Mac/Intel respectively).

## ♻️ Related Issues
- Fixes #56, partially. This issue has been split in two, descoping the updates required for supporting Windows testing as the changes required to support Windows deserve their own PR and task. The new scope of task #56 is fully covered by this PR.
