### PR TITLE
Core pytest configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=75.3.3"]
+requires = ["setuptools>=75.3.4,<81"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     spiceypy>=6.0.0; python_version < '3.12'
     spiceypy>=8.0.1; python_version >= '3.12'
     beautifulsoup4>=4.9.3
-    setuptools>=75.3.3
+    setuptools>=75.3.4,<81
     xmlschema
     requests
 # Change this to False if you use things like __file__ or __path__—which you


### PR DESCRIPTION
## 🗒️ Summary
Added core pytest configuration to pyproject.toml file, removing them from the setup.cfg file and updating the setuptools version to the final stable release in the v75.x series that support Python3.8.

## ♻️ Related Issues
Fixes #62.


