### PR TITLE
Fixed issue identified by CodeQL: __all__ can only contain strings.

### DIFF
--- a/src/pds/naif_pds4_bundler/utils/__init__.py
+++ b/src/pds/naif_pds4_bundler/utils/__init__.py
@@ -3,91 +3,94 @@
 The utils module implements general utility capabilities used elsewhere in NPB.
 """
 from .decorators import spice_exception_handler
-from .files import add_carriage_return
-from .files import add_crs_to_file
-from .files import check_badchar
-from .files import check_binary_endianness
-from .files import check_consecutive
-from .files import check_eol
-from .files import check_kernel_integrity
-from .files import check_line_length
-from .files import check_list_duplicates
-from .files import check_permissions
-from .files import checksum_from_label
-from .files import checksum_from_registry
-from .files import compare_files
-from .files import copy
-from .files import etree_to_dict
-from .files import extension_to_type
-from .files import extract_comment
-from .files import fill_template
-from .files import format_multiple_values
-from .files import get_context_products
-from .files import get_latest_kernel
-from .files import kernel_name
-from .files import match_patterns
-from .files import md5
-from .files import mk_to_list
-from .files import product_mapping
-from .files import replace_string_in_file
-from .files import safe_make_directory
-from .files import string_in_file
-from .files import type_to_extension
-from .files import type_to_pds3_type
-from .files import utf8len
-from .time import ck_coverage
-from .time import creation_time
-from .time import current_date
-from .time import current_time
-from .time import dsk_coverage
-from .time import et_to_date
-from .time import get_years
-from .time import pck_coverage
-from .time import pds3_label_gen_date
-from .time import spk_coverage
-
-__all__ = [
+from .files import (
     add_carriage_return,
     add_crs_to_file,
+    check_badchar,
+    check_binary_endianness,
     check_consecutive,
+    check_eol,
+    check_kernel_integrity,
     check_line_length,
     check_list_duplicates,
+    check_permissions,
     checksum_from_label,
     checksum_from_registry,
     compare_files,
     copy,
     etree_to_dict,
     extension_to_type,
-    type_to_pds3_type,
     extract_comment,
     fill_template,
+    format_multiple_values,
     get_context_products,
     get_latest_kernel,
     kernel_name,
     match_patterns,
     md5,
     mk_to_list,
+    product_mapping,
+    replace_string_in_file,
     safe_make_directory,
+    string_in_file,
     type_to_extension,
-    utf8len,
+    type_to_pds3_type,
+    utf8len
+)
+from .time import (
     ck_coverage,
     creation_time,
     current_date,
     current_time,
     dsk_coverage,
+    et_to_date,
     get_years,
     pck_coverage,
     pds3_label_gen_date,
-    spk_coverage,
-    spice_exception_handler,
-    string_in_file,
-    et_to_date,
-    replace_string_in_file,
-    format_multiple_values,
-    product_mapping,
-    check_kernel_integrity,
-    check_binary_endianness,
-    check_badchar,
-    check_eol,
-    check_permissions,
+    spk_coverage
+)
+
+__all__ = [
+    'add_carriage_return',
+    'add_crs_to_file',
+    'check_badchar',
+    'check_binary_endianness',
+    'check_consecutive',
+    'check_eol',
+    'check_kernel_integrity',
+    'check_line_length',
+    'check_list_duplicates',
+    'check_permissions',
+    'checksum_from_label',
+    'checksum_from_registry',
+    'ck_coverage',
+    'compare_files',
+    'copy',
+    'creation_time',
+    'current_date',
+    'current_time',
+    'dsk_coverage',
+    'et_to_date',
+    'etree_to_dict',
+    'extension_to_type',
+    'extract_comment',
+    'fill_template',
+    'format_multiple_values',
+    'get_context_products',
+    'get_latest_kernel',
+    'get_years',
+    'kernel_name',
+    'match_patterns',
+    'md5',
+    'mk_to_list',
+    'pck_coverage',
+    'pds3_label_gen_date',
+    'product_mapping',
+    'replace_string_in_file',
+    'safe_make_directory',
+    'spk_coverage',
+    'string_in_file',
+    'type_to_extension',
+    'type_to_pds3_type',
+    'utf8len'
 ]


### PR DESCRIPTION
## 🗒️ Summary
Added double quotes, sorted and extended the list of function names provided by the __all__ variable in the utils __init__ file. Also, improved readability of imports.
