### PR TITLE
Avoid using (object) in class declaration for classes that inherit directly from object

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/bundle.py
+++ b/src/pds/naif_pds4_bundler/classes/bundle.py
@@ -22,7 +22,7 @@ from .log import error_message
 from .product import ReadmeProduct
 
 
-class Bundle(object):
+class Bundle:
     """Class to generate the PDS4 Bundle structure.
 
     The class construction will generate the top level directory structure for

--- a/src/pds/naif_pds4_bundler/classes/log.py
+++ b/src/pds/naif_pds4_bundler/classes/log.py
@@ -9,7 +9,7 @@ import socket
 import spiceypy
 
 
-class Log(object):
+class Log:
     """Log class to write and output NPB's log.
 
     :param args: Parameter arguments from NPB's main function.

--- a/src/pds/naif_pds4_bundler/classes/object.py
+++ b/src/pds/naif_pds4_bundler/classes/object.py
@@ -1,7 +1,7 @@
 """Dummy Class Implementation."""
 
 
-class Object(object):
+class Object:
     """Dummy Class."""
 
     def __init__(self):

--- a/src/pds/naif_pds4_bundler/classes/product/product.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product.py
@@ -9,7 +9,7 @@ from ...utils import creation_time
 from ...utils import md5
 
 
-class Product(object):
+class Product:
     """Class that defines a generic archive product (or file).
 
     Assigns value to the common attributes for all Products: file size,

--- a/src/pds/naif_pds4_bundler/classes/setup.py
+++ b/src/pds/naif_pds4_bundler/classes/setup.py
@@ -22,7 +22,7 @@ from .log import error_message
 from .object import Object
 
 
-class Setup(object):
+class Setup:
     """Class that parses and processes the NPB XML configuration file.
 
     :param args: Parameters arguments from NPB main function


### PR DESCRIPTION
## 🗒️ Summary
Updated classes that inherit from object to Python3 style.

## ♻️ Related Issues
Fixes #88.
