### PR TITLE
76 npb does not work on redhat 8 due to fips error

### DIFF
--- a/src/pds/naif_pds4_bundler/utils/files.py
+++ b/src/pds/naif_pds4_bundler/utils/files.py
@@ -64,12 +64,12 @@ def md5(fname):
     :return: Checksum value of the file
     :rtype: str
     """
-    h = hashlib.md5(usedforsecurity=False)
+    hash_md5 = hashlib.md5(usedforsecurity=False)
     with open(fname, "rb") as f:
         for chunk in iter(lambda: f.read(4096), b""):
-            h.update(chunk)
+            hash_md5.update(chunk)
 
-    return h.hexdigest()
+    return hash_md5.hexdigest()
 
 
 def copy(src, dest):


### PR DESCRIPTION
## 🗒️ Summary

Updates md5 function to address FIPS error on redhat 8. 

## ♻️ Related Issues

Fixes #76 


