### PR TITLE
Changed return type in __init__ method for Bundle and Setup classes to None.

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/bundle.py
+++ b/src/pds/naif_pds4_bundler/classes/bundle.py
@@ -31,7 +31,7 @@ class Bundle:
     :param setup: NPB execution Setup
     """
 
-    def __init__(self, setup) -> object:
+    def __init__(self, setup) -> None:
         """Constructor."""
         line = (
             f"Step {setup.step} - Bundle/data set structure generation "

--- a/src/pds/naif_pds4_bundler/classes/setup.py
+++ b/src/pds/naif_pds4_bundler/classes/setup.py
@@ -29,7 +29,7 @@ class Setup:
     :type version: str
     """
 
-    def __init__(self, args, version: str) -> object:
+    def __init__(self, args, version: str) -> None:
         """Constructor."""
         try:
             #


### PR DESCRIPTION
## 🗒️ Summary
Return type in __init__ method for Bundle and Setup classes has been changed to None.

## ⚙️ Test Data and/or Report
No new test addded.

## ♻️ Related Issues
Fixes #89

