### PR TITLE
119 fix calls to spiceypy.scard in time module

### DIFF
--- a/src/pds/naif_pds4_bundler/utils/time.py
+++ b/src/pds/naif_pds4_bundler/utils/time.py
@@ -288,42 +288,36 @@ def dsk_coverage(path, date_format="infomod2", system="UTC"):
     :return: start and finish coverage
     :rtype: list of str
     """
-    found = True
     beget = []
     endet = []
 
-    #
     # Open the DSK file.
-    #
     handle = spiceypy.dasopr(path)
 
-    #
-    # Search the first segment in the file, obtain the segment's DLA
-    # descriptor
-    #
-    nxtdsc = spiceypy.dlabfs(handle)
-    dladsc = nxtdsc
+    try:
+        # Search the first segment in the file, obtain the segment's DLA
+        # descriptor.
+        dladsc = spiceypy.dlabfs(handle)
 
-    #
-    #  Loop through segments to get the earliest starting epoch and the
-    #  latest ending epoch.
-    #
-    while found:
-        dskdsc = spiceypy.dskgd(handle, dladsc)
+        #  Loop through segments to get the earliest starting epoch and the
+        #  latest ending epoch.
+        while True:
+            dskdsc = spiceypy.dskgd(handle, dladsc)
 
-        beget.append(dskdsc.start)
-        endet.append(dskdsc.stop)
+            beget.append(dskdsc.start)
+            endet.append(dskdsc.stop)
 
-        currnt = dladsc
-        try:
-            (dladsc, found) = spiceypy.dlafns(handle, currnt)
-        except BaseException:
-            #
-            # Close the DSK file
-            #
-            spiceypy.dascls(handle)
+            try:
+                (dladsc, _) = spiceypy.dlafns(handle, dladsc)
 
-            break
+            # SpiceyPy's dlafns raises a NotFoundError, if it cannot find a
+            # segment following a specified segment in a DLA file. That
+            # means that we are at the end of the file.
+            except spiceypy.exceptions.NotFoundError:
+                break
+    finally:
+        # Close the DSK file
+        spiceypy.dascls(handle)
 
     start_time = min(beget)
     stop_time = max(endet)

--- a/src/pds/naif_pds4_bundler/utils/time.py
+++ b/src/pds/naif_pds4_bundler/utils/time.py
@@ -116,7 +116,8 @@ def spk_coverage(path, main_name="", date_format="infomod2", system="UTC"):
 
     for i in ids:
 
-        spiceypy.scard, 0, coverage
+        # Initialize the coverage SPICE window, setting its cardinality to zero.
+        spiceypy.scard(incard=0, cell=coverage)
         spiceypy.spkcov(spk=path, idcode=i, cover=coverage)
 
         num_inter = spiceypy.wncard(coverage)
@@ -169,7 +170,10 @@ def ck_coverage(path, timsys="TDB", date_format="infomod2", system="UTC"):
 
     for i in ids:
         coverage = spiceypy.support_types.SPICEDOUBLE_CELL(winsiz)
-        spiceypy.scard, 0, coverage
+
+        # Initialize the coverage SPICE window, setting its cardinality to zero.
+        spiceypy.scard(incard=0, cell=coverage)
+
         coverage = spiceypy.ckcov(
             ck=path,
             idcode=i,
@@ -240,7 +244,8 @@ def pck_coverage(path, date_format="infomod2", system="UTC"):
 
     for i in ids:
 
-        spiceypy.scard, 0, coverage
+        # Initialize the coverage SPICE window, setting its cardinality to zero.
+        spiceypy.scard(incard=0, cell=coverage)
         spiceypy.pckcov(pck=path, idcode=i, cover=coverage)
 
         num_inter = spiceypy.wncard(coverage)

--- a/tests/npb/test_utils_time.py
+++ b/tests/npb/test_utils_time.py
@@ -190,6 +190,10 @@ def test_pck_coverage(lsk, date_format, system, expected):
 @pytest.mark.parametrize("inputs, expected", [
     ("PRODUCT_CREATION_TIME        = 2026-03-10T11:08:04", "2026-03-10T11:08:04"),
     ("","N/A"),
+    ("PDS_VERSION_ID                = PDS3\n"
+     "RECORD_TYPE                   = FIXED_LENGTH\n"
+     "[..the rest of the label without the product creation time..]"
+     "END", "N/A")
  ])
 def test_pds3_label_gen_date(mocker, inputs, expected):
     """Test pds3 label generation date function."""


### PR DESCRIPTION
## 🗒️ Summary
- Updated all the calls to the spiceypy.scard function within the time module.
- Refactored the dsk_coverage function to improve the readability, simplify the logic, reduce the number of variables and fix a possible leak where the file is not closed if certain conditions occur.
- Completed 100% branch test coverage of the time module.

## ⚙️ Test Data and/or Report
Added one test cases to the `test_utils_time` test family, to achieve 100% branch coverage.

## ♻️ Related Issues
Fixes #119.


