### PR TITLE
Pytest/coverage utils decorators

### DIFF
--- a/src/pds/naif_pds4_bundler/utils/decorators.py
+++ b/src/pds/naif_pds4_bundler/utils/decorators.py
@@ -2,6 +2,8 @@
 import traceback
 from functools import wraps
 
+from spiceypy.utils.exceptions import SpiceyPyError
+
 from ..pipeline.runtime import handle_npb_error
 
 
@@ -18,7 +20,7 @@ def spice_exception_handler(func):
     def inner_function(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except Exception:
+        except SpiceyPyError:
             if hasattr(args[0], "setup"):
                 handle_npb_error(traceback.format_exc(), setup=args[0].setup)
             else:

--- a/src/pds/naif_pds4_bundler/utils/decorators.py
+++ b/src/pds/naif_pds4_bundler/utils/decorators.py
@@ -17,7 +17,7 @@ def spice_exception_handler(func):
     @wraps(func)
     def inner_function(*args, **kwargs):
         try:
-            func(*args, **kwargs)
+            return func(*args, **kwargs)
         except Exception:
             if hasattr(args[0], "setup"):
                 handle_npb_error(traceback.format_exc(), setup=args[0].setup)

--- a/tests/npb/test_utils_decorators.py
+++ b/tests/npb/test_utils_decorators.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import spiceypy.utils.exceptions as spice_exc
 
 from pds.naif_pds4_bundler.utils.decorators import spice_exception_handler
 
@@ -17,23 +18,27 @@ def test_preserves_metadata():
 
 
 @patch("pds.naif_pds4_bundler.utils.decorators.handle_npb_error")
-@patch("traceback.format_exc", return_value="mock_traceback")
-def test_handler_without_setup_attr(_mock_traceback, mock_handler):
+def test_handler_without_setup_attr(mock_handler):
     """Test case where args[0] does NOT have a 'setup' attribute."""
+    # Simulate a specific SpiceyPy 'File Not Found' exception."""
 
     @spice_exception_handler
-    def fail_func(x: str) -> None:
-        raise ValueError(x)
+    def mock_furnish(_):
+        # Manually raise a specific SpiceyPy exception
+        raise spice_exc.SpiceNOSUCHFILE("The file could not be located.")
 
-    fail_func("not_an_object_with_setup")
+    mock_furnish("missing_kernel.tm")
 
-    # Check if handler was called without the setup keyword
-    mock_handler.assert_called_once_with('mock_traceback')
+    # Verify handle_npb_error was triggered by the SpiceyPy error
+    assert mock_handler.called_once()
+
+    # The first argument to the handler is the formatted traceback string
+    traceback_arg = mock_handler.call_args[0][0]
+    assert "SpiceNOSUCHFILE" in traceback_arg
 
 
 @patch("pds.naif_pds4_bundler.utils.decorators.handle_npb_error")
-@patch("traceback.format_exc", return_value="mock_traceback")
-def test_handler_with_setup_attr(_mock_traceback, mock_handler):
+def test_handler_with_setup_attr(mock_handler):
     """Test case where args[0] DOES have a 'setup' attribute."""
 
     class MockObject:
@@ -41,14 +46,19 @@ def test_handler_with_setup_attr(_mock_traceback, mock_handler):
             self.setup = "mock_setup_config"
 
         @spice_exception_handler
-        def fail_method(self, x):
-            raise ValueError("Boom")
+        def mock_furnish(self, _):
+            # Manually raise a specific SpiceyPy exception
+            raise spice_exc.SpiceNOSUCHFILE("The file could not be located.")
 
     obj = MockObject()
-    obj.fail_method(obj, 123)
+    obj.mock_furnish("missing_kernel.tm")
 
-    # Check if handler was called WITH the setup keyword
-    mock_handler.assert_called_once_with("mock_traceback", setup="mock_setup_config")
+    # Verify handle_npb_error was triggered by the SpiceyPy error
+    assert mock_handler.called_once()
+
+    # The first argument to the handler is the formatted traceback string
+    traceback_arg = mock_handler.call_args[0][0]
+    assert "SpiceNOSUCHFILE" in traceback_arg
 
 
 def test_successful_execution_with_return_None():

--- a/tests/npb/test_utils_decorators.py
+++ b/tests/npb/test_utils_decorators.py
@@ -1,0 +1,70 @@
+from unittest.mock import patch
+
+
+from pds.naif_pds4_bundler.utils.decorators import spice_exception_handler
+
+
+def test_preserves_metadata():
+    """Verify @wraps is working to keep docstrings and names."""
+
+    @spice_exception_handler
+    def my_test_func():
+        """Original docstring."""
+        pass
+
+    assert my_test_func.__name__ == "my_test_func"
+    assert my_test_func.__doc__ == "Original docstring."
+
+
+@patch("pds.naif_pds4_bundler.utils.decorators.handle_npb_error")
+@patch("traceback.format_exc", return_value="mock_traceback")
+def test_handler_without_setup_attr(_mock_traceback, mock_handler):
+    """Test case where args[0] does NOT have a 'setup' attribute."""
+
+    @spice_exception_handler
+    def fail_func(x: str) -> None:
+        raise ValueError(x)
+
+    fail_func("not_an_object_with_setup")
+
+    # Check if handler was called without the setup keyword
+    mock_handler.assert_called_once_with('mock_traceback')
+
+
+@patch("pds.naif_pds4_bundler.utils.decorators.handle_npb_error")
+@patch("traceback.format_exc", return_value="mock_traceback")
+def test_handler_with_setup_attr(_mock_traceback, mock_handler):
+    """Test case where args[0] DOES have a 'setup' attribute."""
+
+    class MockObject:
+        def __init__(self):
+            self.setup = "mock_setup_config"
+
+        @spice_exception_handler
+        def fail_method(self, x):
+            raise ValueError("Boom")
+
+    obj = MockObject()
+    obj.fail_method(obj, 123)
+
+    # Check if handler was called WITH the setup keyword
+    mock_handler.assert_called_once_with("mock_traceback", setup="mock_setup_config")
+
+
+def test_successful_execution_with_return_None():
+    """Ensure the decorator doesn't interfere with successful calls."""
+
+    @spice_exception_handler
+    def success_func(a, b):
+        a + b
+
+    assert success_func(1, 2) is None
+
+def test_successful_execution_with_return_not_None():
+    """Ensure the decorator doesn't interfere with successful calls."""
+
+    @spice_exception_handler
+    def success_func(a, b):
+        return a + b
+
+    assert success_func(1, 2) == 3

--- a/tests/npb/test_utils_decorators.py
+++ b/tests/npb/test_utils_decorators.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import pytest
 import spiceypy.utils.exceptions as spice_exc
 
 from pds.naif_pds4_bundler.utils.decorators import spice_exception_handler
@@ -78,3 +79,13 @@ def test_successful_execution_with_return_not_None():
         return a + b
 
     assert success_func(1, 2) == 3
+
+def test_function_raises_a_non_SpiceyPyError_exception():
+    """Ensure the decorator doesn't interfere with non-SpiceyPyError."""
+
+    @spice_exception_handler
+    def raise_value_error():
+        raise ValueError("Invalid value")
+
+    with pytest.raises(ValueError):
+        raise_value_error()

--- a/tests/npb/test_utils_decorators.py
+++ b/tests/npb/test_utils_decorators.py
@@ -62,16 +62,16 @@ def test_handler_with_setup_attr(mock_handler):
     assert "SpiceNOSUCHFILE" in traceback_arg
 
 
-def test_successful_execution_with_return_None():
+def test_successful_execution_with_return_none():
     """Ensure the decorator doesn't interfere with successful calls."""
 
     @spice_exception_handler
     def success_func(a, b):
-        a + b
+        print(a + b)
 
     assert success_func(1, 2) is None
 
-def test_successful_execution_with_return_not_None():
+def test_successful_execution_with_return_not_none():
     """Ensure the decorator doesn't interfere with successful calls."""
 
     @spice_exception_handler
@@ -80,7 +80,7 @@ def test_successful_execution_with_return_not_None():
 
     assert success_func(1, 2) == 3
 
-def test_function_raises_a_non_SpiceyPyError_exception():
+def test_function_raises_a_non_spiceypy_error_exception():
     """Ensure the decorator doesn't interfere with non-SpiceyPyError."""
 
     @spice_exception_handler


### PR DESCRIPTION
## 🗒️ Summary
- Added a new test family for the `utils.decorators` module.
- Updated the `spice_exception_handler` to propagate the value returned by the wrapped function/method.
- Updated the `spice_exception_handler` to only catch and handle `SpiceyPyError` exceptions.

## ⚙️ Test Data and/or Report
- Added a total of 6 new test cases.

## ♻️ Related Issues
None.


