### PR TITLE
Refactor of Product class

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/collection/collection.py
+++ b/src/pds/naif_pds4_bundler/classes/collection/collection.py
@@ -1,6 +1,8 @@
 """Collection Class amd Child Classes Implementation."""
 import glob
 import logging
+import re
+from typing import Tuple
 
 
 class Collection:
@@ -9,6 +11,7 @@ class Collection:
     :param c_type:   Collection type: kernels, documents or miscellaneous
     :param setup:  Setup object
     """
+    list = None
 
     def __init__(self, c_type: str, setup, bundle) -> None:
         """Constructor."""
@@ -37,6 +40,86 @@ class Collection:
         # must be updated.
         #
         self.updated = True
+
+    # TODO: This is probably not the right place for this method, but currently it is
+    #       required by the SpiceKernelsCollection and the MiscellaneousCollection.
+    #       Further analysis is required to see if it can be removed from the
+    #       MiscellaneousCollection class.
+    #       NOTE: the "list" class attribute defined in this class will be set to the
+    #             appropriated value by the SpiceKernelsCollection and MiscellaneousCollection
+    #             init methods. In any other cases, this method is not called, making the
+    #             list attribute irrelevant for the DocumentCollection class.
+    def get_mission_and_observer_and_target(self, name: str) -> Tuple[str, str, str]:
+        """Read the configuration to extract the missions, observers and the
+        targets.
+
+        :param name: The name of the kernel or OrbNum file.
+        :return: missions and observers and targets
+        """
+        missions = []
+        observers = []
+        targets = []
+
+        for pattern in self.list.json_config.values():
+
+            #
+            # If the pattern is matched for the kernel name, extract
+            # the target and observer from the kernel list
+            # configuration.
+            #
+            if re.match(pattern["@pattern"], name):
+
+                ker_config = self.setup.kernel_list_config[pattern["@pattern"]]
+
+                #
+                # Check if the kernel has specified missions.
+                # Note the 'primary' mission will not be used in this case.
+                #
+                if "missions" in ker_config:
+                    missions = ker_config["missions"]["mission_name"]
+                #
+                # If the kernel has no other missions then the primary mission
+                # is used.
+                #
+                else:
+                    missions = [self.setup.mission_name]
+
+                #
+                # Check if the kernel has specified targets.
+                # Note that the mission target will not be used in this case.
+                #
+                if "targets" in ker_config:
+                    targets = ker_config["targets"]["target"]
+                #
+                # If the kernel has no targets then the mission target is used.
+                #
+                else:
+                    targets = [self.setup.target]
+
+                #
+                # Check if the kernel has specified observers.
+                # Note that the mission observer will not be used in this case.
+                #
+                if "observers" in ker_config:
+                    observers = ker_config["observers"]["observer"]
+                #
+                # If the kernel has no observers then the mission observer is
+                # used.
+                #
+                else:
+                    observers = [self.setup.observer]
+
+                break
+            #
+            # If the product is not in the kernel list (such as the orbnum
+            # file), then use the mission observers and targets.
+            #
+            else:
+                missions = [self.setup.mission_name]
+                observers = [self.setup.observer]
+                targets = [self.setup.target]
+
+        return missions, observers, targets
 
     def set_collection_lid(self):
         """Set the Bundle LID."""

--- a/src/pds/naif_pds4_bundler/classes/product/product.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product.py
@@ -17,7 +17,7 @@ class Product:
     def __init__(self) -> None:
         """Constructor."""
         stat_info = os.stat(self.path)
-        self.size = str(stat_info.st_size)
+        self._size = str(stat_info.st_size)
 
         #
         # If specified via configuration, try to obtain the checksum from a
@@ -59,3 +59,8 @@ class Product:
         if self.new_product:
             self.setup.add_file(self.path.split(archive_dir)[-1])
             self.setup.add_checksum(self.path, checksum)
+
+    @property
+    def size(self) -> str:
+        """Returns the size of the product."""
+        return self._size

--- a/src/pds/naif_pds4_bundler/classes/product/product.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product.py
@@ -62,12 +62,12 @@ class Product:
             self.setup.add_file(self.path.split(archive_dir)[-1])
             self.setup.add_checksum(self.path, checksum)
 
-    def get_mission_and_observer_and_target(self) -> Tuple[str, str, str]:
+    def get_mission_and_observer_and_target(self, name: str) -> Tuple[str, str, str]:
         """Read the configuration to extract the missions, observers and the
         targets.
 
+        :param name: The name of the kernel or OrbNum file.
         :return: missions and observers and targets
-        :rtype: tuple
         """
         missions = []
         observers = []
@@ -80,7 +80,7 @@ class Product:
             # the target and observer from the kernel list
             # configuration.
             #
-            if re.match(pattern["@pattern"], self.name):
+            if re.match(pattern["@pattern"], name):
 
                 ker_config = self.setup.kernel_list_config[pattern["@pattern"]]
 

--- a/src/pds/naif_pds4_bundler/classes/product/product.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product.py
@@ -12,10 +12,42 @@ class Product:
 
     Assigns value to the common attributes for all Products: file size,
     creation time and date, and file extension.
+
+    Subclasses must call ``register()`` once the product file exists on disk.
     """
 
+    # TODO: update this method to have path and setup as input arguments.
+    #
+    #   def __init__(self, path: str, setup) -> None:
+    #       """Constructor. Initialises attributes derivable without I/O.
+    #
+    #       :param path:  Absolute path to the product file
+    #       :param setup: NPB execution setup object
+    #       """
     def __init__(self) -> None:
         """Constructor."""
+        if hasattr(self.setup, "creation_date_time"):
+            self.creation_time = self.setup.creation_date_time
+        else:
+            self.creation_time = creation_time(time_format=self.setup.date_format)
+
+        self.creation_date = self.creation_time.split("T")[0]
+        self.extension = self.path.split(os.sep)[-1].split(".")[-1]
+
+        # These attributes will be assigned (computed) by the register method.
+        self.checksum = None
+        self._size = None
+
+        # TODO: remove this call. It should be done by the subclasses instead.
+        self.register()
+
+    def register(self) -> None:
+        """Finalize file-derived attributes and register the product.
+
+        Must be called once the product file exists on disk. Reads file size,
+        resolves or computes the checksum, and registers the file and checksum
+        with the pipeline.
+        """
         stat_info = os.stat(self.path)
         self._size = str(stat_info.st_size)
 
@@ -43,20 +75,13 @@ class Product:
 
         self.checksum = checksum
 
-        if self.setup.pds_version == "4":
-            archive_dir = f"{self.setup.mission_acronym}_spice/"
-        else:
-            archive_dir = f"{self.setup.volume_id}/"
-
-        if hasattr(self.setup, "creation_date_time"):
-            self.creation_time = self.setup.creation_date_time
-        else:
-            self.creation_time = creation_time(time_format=self.setup.date_format)
-
-        self.creation_date = self.creation_time.split("T")[0]
-        self.extension = self.path.split(os.sep)[-1].split(".")[-1]
-
         if self.new_product:
+
+            if self.setup.pds_version == "4":
+                archive_dir = f"{self.setup.mission_acronym}_spice/"
+            else:
+                archive_dir = f"{self.setup.volume_id}/"
+
             self.setup.add_file(self.path.split(archive_dir)[-1])
             self.setup.add_checksum(self.path, checksum)
 

--- a/src/pds/naif_pds4_bundler/classes/product/product.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product.py
@@ -1,7 +1,5 @@
 """Implementation of the Product base class."""
 import os
-import re
-from typing import Tuple
 
 from ...utils import checksum_from_label
 from ...utils import checksum_from_registry
@@ -61,75 +59,3 @@ class Product:
         if self.new_product:
             self.setup.add_file(self.path.split(archive_dir)[-1])
             self.setup.add_checksum(self.path, checksum)
-
-    def get_mission_and_observer_and_target(self, name: str) -> Tuple[str, str, str]:
-        """Read the configuration to extract the missions, observers and the
-        targets.
-
-        :param name: The name of the kernel or OrbNum file.
-        :return: missions and observers and targets
-        """
-        missions = []
-        observers = []
-        targets = []
-
-        for pattern in self.collection.list.json_config.values():
-
-            #
-            # If the pattern is matched for the kernel name, extract
-            # the target and observer from the kernel list
-            # configuration.
-            #
-            if re.match(pattern["@pattern"], name):
-
-                ker_config = self.setup.kernel_list_config[pattern["@pattern"]]
-
-                #
-                # Check if the kernel has specified missions.
-                # Note the 'primary' mission will not be used in this case.
-                #
-                if "missions" in ker_config:
-                    missions = ker_config["missions"]["mission_name"]
-                #
-                # If the kernel has no other missions then the primary mission
-                # is used.
-                #
-                else:
-                    missions = [self.setup.mission_name]
-
-                #
-                # Check if the kernel has specified targets.
-                # Note that the mission target will not be used in this case.
-                #
-                if "targets" in ker_config:
-                    targets = ker_config["targets"]["target"]
-                #
-                # If the kernel has no targets then the mission target is used.
-                #
-                else:
-                    targets = [self.setup.target]
-
-                #
-                # Check if the kernel has specified observers.
-                # Note that the mission observer will not be used in this case.
-                #
-                if "observers" in ker_config:
-                    observers = ker_config["observers"]["observer"]
-                #
-                # If the kernel has no observers then the mission observer is
-                # used.
-                #
-                else:
-                    observers = [self.setup.observer]
-
-                break
-            #
-            # If the product is not in the kernel list (such as the orbnum
-            # file), then use the mission observers and targets.
-            #
-            else:
-                missions = [self.setup.mission_name]
-                observers = [self.setup.observer]
-                targets = [self.setup.target]
-
-        return missions, observers, targets

--- a/src/pds/naif_pds4_bundler/classes/product/product_kernel.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_kernel.py
@@ -148,7 +148,7 @@ class SpiceKernelProduct(Product):
         # Extract the required information from the kernel list read from
         # configuration for the product.
         #
-        (missions, observers, targets) = self.get_mission_and_observer_and_target()
+        (missions, observers, targets) = self.get_mission_and_observer_and_target(self.name)
 
         self.missions = missions
         self.targets = targets

--- a/src/pds/naif_pds4_bundler/classes/product/product_kernel.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_kernel.py
@@ -148,7 +148,7 @@ class SpiceKernelProduct(Product):
         # Extract the required information from the kernel list read from
         # configuration for the product.
         #
-        (missions, observers, targets) = self.get_mission_and_observer_and_target(self.name)
+        (missions, observers, targets) = self.collection.get_mission_and_observer_and_target(self.name)
 
         self.missions = missions
         self.targets = targets

--- a/src/pds/naif_pds4_bundler/classes/product/product_metakernel.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_metakernel.py
@@ -223,7 +223,7 @@ class MetaKernelProduct(Product):
             # Extract the required information from the kernel list read from
             # configuration for the product.
             #
-            (missions, observers, targets) = self.get_mission_and_observer_and_target(self.name)
+            (missions, observers, targets) = self.collection.get_mission_and_observer_and_target(self.name)
 
             self.missions = missions
             self.targets = targets

--- a/src/pds/naif_pds4_bundler/classes/product/product_metakernel.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_metakernel.py
@@ -223,7 +223,7 @@ class MetaKernelProduct(Product):
             # Extract the required information from the kernel list read from
             # configuration for the product.
             #
-            (missions, observers, targets) = self.get_mission_and_observer_and_target()
+            (missions, observers, targets) = self.get_mission_and_observer_and_target(self.name)
 
             self.missions = missions
             self.targets = targets

--- a/src/pds/naif_pds4_bundler/classes/product/product_orbnum.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_orbnum.py
@@ -125,7 +125,7 @@ class OrbnumFileProduct(Product):
             # Extract the required information from the kernel list read from
             # configuration for the product.
             #
-            (missions, observers, targets) = self.get_mission_and_observer_and_target()
+            (missions, observers, targets) = self.get_mission_and_observer_and_target(self.name)
 
             self.missions = missions
             self.targets = targets

--- a/src/pds/naif_pds4_bundler/classes/product/product_orbnum.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_orbnum.py
@@ -125,7 +125,7 @@ class OrbnumFileProduct(Product):
             # Extract the required information from the kernel list read from
             # configuration for the product.
             #
-            (missions, observers, targets) = self.get_mission_and_observer_and_target(self.name)
+            (missions, observers, targets) = self.collection.get_mission_and_observer_and_target(self.name)
 
             self.missions = missions
             self.targets = targets

--- a/src/pds/naif_pds4_bundler/classes/product/product_pds3doc.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_pds3doc.py
@@ -39,11 +39,11 @@ class PDS3DocumentProduct(Product):
         else:
             self.new_product = True
 
-            self.validate()
+            self._validate()
 
         super().__init__()
 
-    def validate(self) -> None:
+    def _validate(self) -> None:
         """Try to validate the PDS3 document.
 
         The outcome of the validation is an INFO or a WARNING log message.

--- a/src/pds/naif_pds4_bundler/classes/product/product_readme.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_readme.py
@@ -49,7 +49,7 @@ class ReadmeProduct(Product):
             self.new_product = False
         else:
             logging.info("-- Generating readme file...")
-            self.write_product()
+            self._write_product()
             self.new_product = True
 
             #
@@ -70,7 +70,7 @@ class ReadmeProduct(Product):
         logging.info("-- Generating bundle label...")
         self.label = BundlePDS4Label(setup, self)
 
-    def write_product(self) -> None:
+    def _write_product(self) -> None:
         """Write the Readme product."""
         line_length = 0
 

--- a/src/pds/naif_pds4_bundler/classes/product/product_spiceds.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_spiceds.py
@@ -118,7 +118,7 @@ class SpicedsProduct(Product):
         # added and the file timestamp is updated. Note that if the file
         # already had CRs the original timestamp is preserved.
         #
-        self.check_cr()
+        self._check_cr()
 
         #
         # Kernels are already generated products but Inventories are not.
@@ -129,14 +129,14 @@ class SpicedsProduct(Product):
         #
         # Check if the spiceds has not changed.
         #
-        self.generated = self.check_product()
+        self.generated = self._check_product()
 
         #
         # Validate the product by comparing it and then generate the label.
         #
         if self.generated:
             if self.setup.diff:
-                self.compare()
+                self._compare()
 
             self.label = DocumentPDS4Label(setup, collection, self)
 
@@ -148,7 +148,7 @@ class SpicedsProduct(Product):
         """Set the Product VID."""
         self.vid = "{}.0".format(int(self.version))
 
-    def check_cr(self) -> None:
+    def _check_cr(self) -> None:
         """Determine whether if ``<CR>`` has to be added to the SPICEDS."""
         #
         # We add the date to the temporary file to have a unique name.
@@ -175,7 +175,7 @@ class SpicedsProduct(Product):
                 "-- Carriage Return has been added to lines in the spiceds file."
             )
 
-    def check_product(self) -> bool:
+    def _check_product(self) -> bool:
         """Check if the SPICEDS product needs to be generated.
 
         :return: True if the SPICEDS products needs to be generated, False otherwise
@@ -211,7 +211,7 @@ class SpicedsProduct(Product):
 
         return generate_spiceds
 
-    def compare(self) -> None:
+    def _compare(self) -> None:
         """**Compare the SPICEDS Product with another SPICEDS**.
 
         The SPICEDS Product is compared with the previous


### PR DESCRIPTION
## 🗒️ Summary
- Moved the `get_mission_and_observer_and_target` method from the `Product` to the `Collection` class.
- Added the `size` property to the `Product` class, and renamed the "size" attribute to be _size.
- Split of `Product` init method in two: removed side effects and I/O from init method.
- Renamed some methods to indicate that they are "helper methods."
 
## ⚙️ Test Data and/or Report
No new tests.

## ♻️ Related Issues
None.


