### PR TITLE
Moved definition of instance attributes inside the init method

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/collection/collection.py
+++ b/src/pds/naif_pds4_bundler/classes/collection/collection.py
@@ -15,10 +15,11 @@ class Collection:
 
     def __init__(self, c_type: str, setup, bundle) -> None:
         """Constructor."""
-        self.product = []
-        self.name = c_type
-        self.setup = setup
         self.bundle = bundle
+        self.name = c_type
+        self.product = []
+        self.setup = setup
+        self.vid = ''
 
         #
         # To know whether if the collection has been updated or not.

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -25,6 +25,7 @@ class PDSLabel:
             except BaseException:
                 context_products = product.bundle.context_products
 
+        self.name = ''
         self.product = product
         self.setup = setup
 

--- a/src/pds/naif_pds4_bundler/classes/list.py
+++ b/src/pds/naif_pds4_bundler/classes/list.py
@@ -45,8 +45,10 @@ class KernelList:
         # if not setup.args.silent and not setup.args.verbose:
         #     print("-- " + line.split(" - ")[-1] + ".")
 
+        self.complete_list = ''
         self.files = []
         self.kernel_list = []
+        self.list_name = ''
         self.setup = setup
 
         #

--- a/src/pds/naif_pds4_bundler/classes/product/product_checksum.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_checksum.py
@@ -327,6 +327,7 @@ class ChecksumProduct(Product):
                     #
                     # Generate the MD5 checksum of the label.
                     #
+                    # TODO: hasattr(product, "label") will need to be removed.
                     if hasattr(product, "label") and product.label is not None:
                         label_checksum = md5(product.label.name)
                         self.md5_dict[product.label.name.split(archive_dir)[-1]] = (

--- a/src/pds/naif_pds4_bundler/classes/product/product_checksum.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_checksum.py
@@ -42,6 +42,7 @@ class ChecksumProduct(Product):
             self.setup.staging_directory + os.sep + "miscellaneous" + os.sep
         )
         self.file_records = 0
+        self.label = None
         self.new_product = True
         self.record_bytes = 0
         self.start_time = ''
@@ -326,7 +327,7 @@ class ChecksumProduct(Product):
                     #
                     # Generate the MD5 checksum of the label.
                     #
-                    if hasattr(product, "label"):
+                    if hasattr(product, "label") and product.label is not None:
                         label_checksum = md5(product.label.name)
                         self.md5_dict[product.label.name.split(archive_dir)[-1]] = (
                             label_checksum

--- a/src/pds/naif_pds4_bundler/classes/product/product_checksum.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_checksum.py
@@ -35,11 +35,17 @@ class ChecksumProduct(Product):
         # inventory file; the checksum file needs to be included in the
         # inventory file before the actual checksum file is generated.
         #
+        self.bytes = 0
         self.setup = setup
         self.collection = collection
         self.collection_path = (
             self.setup.staging_directory + os.sep + "miscellaneous" + os.sep
         )
+        self.file_records = 0
+        self.new_product = True
+        self.record_bytes = 0
+        self.start_time = ''
+        self.stop_time = ''
 
         line = f"Step {self.setup.step} - Generate checksum file"
         logging.info("")

--- a/src/pds/naif_pds4_bundler/classes/product/product_inventory.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_inventory.py
@@ -32,8 +32,13 @@ class InventoryProduct(Product):
             if not setup.args.silent and not setup.args.verbose:
                 print("-- " + line.split(" - ")[-1] + ".")
 
-        self.setup = setup
         self.collection = collection
+        self.column_bytes = []
+        self.column_start_bytes = []
+        self.file_types = []
+        self.rows = 0
+        self.row_bytes = 0
+        self.setup = setup
 
         if setup.pds_version == "3":
             self.path = f"{setup.staging_directory}/index/index.tab"

--- a/src/pds/naif_pds4_bundler/classes/setup.py
+++ b/src/pds/naif_pds4_bundler/classes/setup.py
@@ -31,6 +31,19 @@ class Setup:
 
     def __init__(self, args, version: str) -> None:
         """Constructor."""
+        self.bundle_directory = ''
+        self.current_release = 0
+        self.fks = None
+        self.increment = True
+        self.information_model_float = None
+        self.lsk = None
+        self.release = None
+        self.sclks = None
+        self.staging_directory = ''
+        self.template_files = []
+        self.working_directory = ''
+        self.xml_tab = 0
+
         try:
             #
             # Check that the configuration file validates with its schema

--- a/src/pds/naif_pds4_bundler/classes/setup.py
+++ b/src/pds/naif_pds4_bundler/classes/setup.py
@@ -38,6 +38,7 @@ class Setup:
         self.information_model_float = None
         self.lsk = None
         self.release = None
+        self.schema_location = ''
         self.sclks = None
         self.staging_directory = ''
         self.template_files = []
@@ -565,7 +566,7 @@ class Setup:
                 # Check if schema_location is provided via configuration, if so check
                 # its validity and if not generate it.
                 #
-                if hasattr(self, "schema_location"):
+                if hasattr(self, "schema_location") and self.schema_location:
                     schema_loc_version = self.schema_location.split("/PDS4_PDS_")[-1]
                     schema_loc_version = schema_loc_version.split(".xsd")[0]
 

--- a/src/pds/naif_pds4_bundler/classes/setup.py
+++ b/src/pds/naif_pds4_bundler/classes/setup.py
@@ -42,7 +42,8 @@ class Setup:
         self.sclks = None
         self.staging_directory = ''
         self.template_files = []
-        self.working_directory = ''
+        self.templates_directory = None
+        self.working_directory = None
         self.xml_model = ''
         self.xml_tab = 0
 
@@ -661,7 +662,7 @@ class Setup:
             templates_directory = f"{self.root_dir}templates/pds3/"
 
         template_files = []
-        if not hasattr(self, "templates_directory") and self.pds_version == "4":
+        if not self.templates_directory and self.pds_version == "4":
 
             self.templates_directory = self.working_directory
 

--- a/src/pds/naif_pds4_bundler/classes/setup.py
+++ b/src/pds/naif_pds4_bundler/classes/setup.py
@@ -544,6 +544,7 @@ class Setup:
                 # Check if xml_model is provided via configuration, if so check
                 # its validity and if not generate it.
                 #
+                # TODO: hasattr(self, "xml_model") will need to be removed.
                 if hasattr(self, "xml_model") and self.xml_model:
                     xml_model_version = self.xml_model.split("PDS4_PDS_")[-1]
                     xml_model_version = xml_model_version.split(".sch")[0]
@@ -568,6 +569,7 @@ class Setup:
                 # Check if schema_location is provided via configuration, if so check
                 # its validity and if not generate it.
                 #
+                # TODO: hasattr(self, "schema_location") will need to be removed.
                 if hasattr(self, "schema_location") and self.schema_location:
                     schema_loc_version = self.schema_location.split("/PDS4_PDS_")[-1]
                     schema_loc_version = schema_loc_version.split(".xsd")[0]

--- a/src/pds/naif_pds4_bundler/classes/setup.py
+++ b/src/pds/naif_pds4_bundler/classes/setup.py
@@ -43,6 +43,7 @@ class Setup:
         self.staging_directory = ''
         self.template_files = []
         self.working_directory = ''
+        self.xml_model = ''
         self.xml_tab = 0
 
         try:
@@ -542,7 +543,7 @@ class Setup:
                 # Check if xml_model is provided via configuration, if so check
                 # its validity and if not generate it.
                 #
-                if hasattr(self, "xml_model"):
+                if hasattr(self, "xml_model") and self.xml_model:
                     xml_model_version = self.xml_model.split("PDS4_PDS_")[-1]
                     xml_model_version = xml_model_version.split(".sch")[0]
 


### PR DESCRIPTION
## 🗒️ Summary

* The definition of all attributes reported by pylint has been moved to the __init__ method of their respective classes.
* The write_product and check_configuration methods belonging to the ProductChecksum and Setup classes respectively have been updated.

## ⚙️ Test Data and/or Report
No new test addded.

## ♻️ Related Issues
Fixes #90


