### PR TITLE
124 move logging of steps out of the different classes modules into the run pipeline

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/bundle.py
+++ b/src/pds/naif_pds4_bundler/classes/bundle.py
@@ -720,15 +720,6 @@ class Bundle:
         release number.
         """
         logging.info("")
-        line = f"Step {self.setup.step} - Validate bundle history with checksum files"
-        logging.info("")
-        logging.info(line)
-        logging.info("-" * len(line))
-        self.setup.step += 1
-        if not self.setup.args.silent and not self.setup.args.verbose:
-            print("-- " + line.split(" - ")[-1] + ".")
-
-        logging.info("")
         logging.info("-- Display the list of files that belong to each release.")
         logging.info("")
 

--- a/src/pds/naif_pds4_bundler/classes/bundle.py
+++ b/src/pds/naif_pds4_bundler/classes/bundle.py
@@ -173,15 +173,6 @@ class Bundle:
 
     def copy_to_bundle(self):
         """Copy files from ``staging_directory`` to the ``bundle_directory``."""
-        line = f"Step {self.setup.step} - Copy files to the bundle area"
-        logging.info("")
-        logging.info(line)
-        logging.info("-" * len(line))
-        logging.info("")
-        self.setup.step += 1
-        if not self.setup.args.silent and not self.setup.args.verbose:
-            print("-- " + line.split(" - ")[-1] + ".")
-
         copied_files = []
         for file in self._new_files:
             src = file

--- a/src/pds/naif_pds4_bundler/classes/bundle.py
+++ b/src/pds/naif_pds4_bundler/classes/bundle.py
@@ -125,15 +125,6 @@ class Bundle:
 
     def files_in_staging(self):
         """Lists all the files in the staging area."""
-        line = f"Step {self.setup.step} - Recap files in staging area"
-        logging.info("")
-        logging.info(line)
-        logging.info("-" * len(line))
-        logging.info("")
-        self.setup.step += 1
-        if not self.setup.args.silent and not self.setup.args.verbose:
-            print("-- " + line.split(" - ")[-1] + ".")
-
         #
         # A list of the new files in the staging area is generated first.
         #

--- a/src/pds/naif_pds4_bundler/classes/bundle.py
+++ b/src/pds/naif_pds4_bundler/classes/bundle.py
@@ -37,18 +37,6 @@ class Bundle:
 
     def __init__(self, setup) -> None:
         """Constructor."""
-        line = (
-            f"Step {setup.step} - Bundle/data set structure generation "
-            f"at staging area"
-        )
-        logging.info("")
-        logging.info(line)
-        logging.info("-" * len(line))
-        logging.info("")
-        setup.step += 1
-        if not setup.args.silent and not setup.args.verbose:
-            print("-- " + line.split(" - ")[-1] + ".")
-
         logging.info("-- Directory structure generation occurs if reported.")
         logging.info("")
 

--- a/src/pds/naif_pds4_bundler/classes/collection/collection_docs.py
+++ b/src/pds/naif_pds4_bundler/classes/collection/collection_docs.py
@@ -1,6 +1,5 @@
 """Implementation of the Document Collection Class."""
 import glob
-import logging
 
 from .collection import Collection
 from ..product import PDS3DocumentProduct

--- a/src/pds/naif_pds4_bundler/classes/collection/collection_docs.py
+++ b/src/pds/naif_pds4_bundler/classes/collection/collection_docs.py
@@ -24,14 +24,6 @@ class DocumentCollection(Collection):
 
     def get_pds3_documents(self):
         """Collects the updated PDS3 documents for the increment."""
-        line = f"Step {self.setup.step} - Generation of PDS3 products"
-        logging.info("")
-        logging.info(line)
-        logging.info("-" * len(line))
-        self.setup.step += 1
-        if not self.setup.args.silent and not self.setup.args.verbose:
-            print("-- " + line.split(" - ")[-1] + ".")
-
         for file in glob.glob(
             f"{self.setup.staging_directory}/**/*[.]*", recursive=True
         ):

--- a/src/pds/naif_pds4_bundler/classes/collection/collection_kernels.py
+++ b/src/pds/naif_pds4_bundler/classes/collection/collection_kernels.py
@@ -21,15 +21,6 @@ class SpiceKernelsCollection(Collection):
 
     def __init__(self, setup, bundle, kernels) -> None:
         """Constructor."""
-        line = f"Step {setup.step} - SPICE kernel collection/data processing"
-        logging.info("")
-        logging.info(line)
-        logging.info("-" * len(line))
-        logging.info("")
-        setup.step += 1
-        if not setup.args.silent and not setup.args.verbose:
-            print("-- " + line.split(" - ")[-1] + ".")
-
         self.bundle = bundle
         self.list = kernels
         self.type = "spice_kernels"
@@ -49,15 +40,6 @@ class SpiceKernelsCollection(Collection):
                  user or not.
         :rtype: dictionary.
         """
-        line = f"Step {self.setup.step} - Generation of meta-kernel(s)"
-        logging.info("")
-        logging.info(line)
-        logging.info("-" * len(line))
-        logging.info("")
-        self.setup.step += 1
-        if not self.setup.args.silent and not self.setup.args.verbose:
-            print("-- " + line.split(" - ")[-1] + ".")
-
         meta_kernels = {}
         #
         # First check if a meta-kernel has been provided via configuration by
@@ -183,18 +165,6 @@ class SpiceKernelsCollection(Collection):
         SPK or CK kernel. Alternatively it can be provided as a parameter of the
         execution.
         """
-        line = (
-            f"Step {self.setup.step} - Determine archive increment "
-            f"start and finish times"
-        )
-        logging.info("")
-        logging.info(line)
-        logging.info("-" * len(line))
-        logging.info("")
-        self.setup.step += 1
-        if not self.setup.args.silent and not self.setup.args.verbose:
-            print("-- " + line.split(" - ")[-1] + ".")
-
         increment_start = ""
         increment_finish = ""
         #
@@ -351,15 +321,6 @@ class SpiceKernelsCollection(Collection):
              ``file_name``, ``file_size``, ``md5_checksum``, ``object_length``,
              ``kernel_type``, and ``encoding_type``.
         """
-        line = f"Step {self.setup.step} - Validate SPICE kernel collection generation"
-        logging.info("")
-        logging.info(line)
-        logging.info("-" * len(line))
-        logging.info("")
-        self.setup.step += 1
-        if not self.setup.args.silent and not self.setup.args.verbose:
-            print("-- " + line.split(" - ")[-1] + ".")
-
         #
         # Check that all the kernels from the list are present
         #

--- a/src/pds/naif_pds4_bundler/classes/list.py
+++ b/src/pds/naif_pds4_bundler/classes/list.py
@@ -775,16 +775,6 @@ class KernelList:
          * validate kernel architecture
          * check endianness and permissions of binary kernels
         """
-        line = f"Step {self.setup.step} - Check kernel list products"
-        logging.info("")
-        logging.info(line)
-        logging.info("-" * len(line))
-        logging.info("")
-        self.setup.step += 1
-        if not self.setup.args.silent and not self.setup.args.verbose:
-            print("-- " + line.split(" - ")[-1] + ".")
-
-        #
         # A products errors list and a warnings list will be created these
         # will be stored in a product dictionary. The error list will stop
         # the execution while the warnings list will only display warning

--- a/src/pds/naif_pds4_bundler/classes/list.py
+++ b/src/pds/naif_pds4_bundler/classes/list.py
@@ -359,15 +359,6 @@ class KernelList:
 
     def write_complete_list(self):
         """Write the complete Kernel List using the former ones."""
-        line = f"Step {self.setup.step} - Generation of complete kernel list"
-        logging.info("")
-        logging.info(line)
-        logging.info("-" * len(line))
-        logging.info("")
-        self.setup.step += 1
-        if not self.setup.args.silent and not self.setup.args.verbose:
-            print("-- " + line.split(" - ")[-1] + ".")
-
         kernel_lists = glob.glob(
             self.setup.working_directory
             + os.sep

--- a/src/pds/naif_pds4_bundler/classes/list.py
+++ b/src/pds/naif_pds4_bundler/classes/list.py
@@ -33,18 +33,6 @@ class KernelList:
 
     def __init__(self, setup) -> None:
         """Constructor."""
-        # TODO: Remove this commented out code or uncomment it. The decision will
-        #       depend on whether we want to have a "step" for the generation of
-        #       the release plan or not.
-        # line = f"Step {setup.step} - Kernel List generation"
-        # logging.info("")
-        # logging.info(line)
-        # logging.info("-" * len(line))
-        # logging.info("")
-        # setup.step += 1
-        # if not setup.args.silent and not setup.args.verbose:
-        #     print("-- " + line.split(" - ")[-1] + ".")
-
         self.complete_list = ''
         self.files = []
         self.kernel_list = []

--- a/src/pds/naif_pds4_bundler/classes/plan.py
+++ b/src/pds/naif_pds4_bundler/classes/plan.py
@@ -20,15 +20,6 @@ class ReleasePlan:
         self.json_config = self.setup.kernel_list_config
         self._kernel_list = []
 
-        line = f"Step {setup.step} - Kernel List generation"
-        logging.info("")
-        logging.info(line)
-        logging.info("-" * len(line))
-        logging.info("")
-        setup.step += 1
-        if not setup.args.silent and not setup.args.verbose:
-            print("-- " + line.split(" - ")[-1] + ".")
-
     # ------------------------------------------------------------------
     # Public interface
     # ------------------------------------------------------------------

--- a/src/pds/naif_pds4_bundler/classes/product/product_checksum.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_checksum.py
@@ -48,15 +48,6 @@ class ChecksumProduct(Product):
         self.start_time = ''
         self.stop_time = ''
 
-        line = f"Step {self.setup.step} - Generate checksum file"
-        logging.info("")
-        logging.info(line)
-        logging.info("-" * len(line))
-        logging.info("")
-        self.setup.step += 1
-        if not self.setup.args.silent and not self.setup.args.verbose:
-            print("-- " + line.split(" - ")[-1] + ".")
-
         #
         # We generate the kernel directory if not present
         #

--- a/src/pds/naif_pds4_bundler/classes/product/product_inventory.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_inventory.py
@@ -22,15 +22,6 @@ class InventoryProduct(Product):
 
     def __init__(self, setup, collection) -> None:
         """Constructor."""
-        if collection.name != "miscellaneous":
-            line = f"Step {setup.step} - Generation of {collection.name} collection"
-            logging.info("")
-            logging.info(line)
-            logging.info("-" * len(line))
-            logging.info("")
-            setup.step += 1
-            if not setup.args.silent and not setup.args.verbose:
-                print("-- " + line.split(" - ")[-1] + ".")
 
         self.collection = collection
         self.column_bytes = []

--- a/src/pds/naif_pds4_bundler/classes/product/product_metakernel.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_metakernel.py
@@ -830,15 +830,6 @@ class MetaKernelProduct(Product):
              of the MK collection list attribute
            * check that line lengths are less than 80 characters
         """
-        line = f"Step {self.setup.step} - Meta-kernel {self.name} validation"
-        logging.info("")
-        logging.info(line)
-        logging.info("-" * len(line))
-        logging.info("")
-        self.setup.step += 1
-        if not self.setup.args.silent and not self.setup.args.verbose:
-            print("-- " + line.split(" - ")[-1] + ".")
-
         rel_path = self.path.split(f"/{self.setup.mission_acronym}_spice/")[-1]
         path = (
             self.setup.bundle_directory.split(f"{self.setup.mission_acronym}_spice")[0]

--- a/src/pds/naif_pds4_bundler/classes/product/product_readme.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_readme.py
@@ -20,15 +20,6 @@ class ReadmeProduct(Product):
 
     def __init__(self, setup, bundle) -> None:
         """Constructor."""
-        line = f"Step {setup.step} - Generation of bundle products"
-        logging.info("")
-        logging.info(line)
-        logging.info("-" * len(line))
-        logging.info("")
-        setup.step += 1
-        if not setup.args.silent and not setup.args.verbose:
-            print("-- " + line.split(" - ")[-1] + ".")
-
         self.name = "readme.txt"
         self.bundle = bundle
         self.path = setup.staging_directory + os.sep + self.name

--- a/src/pds/naif_pds4_bundler/classes/product/product_spiceds.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_spiceds.py
@@ -31,15 +31,6 @@ class SpicedsProduct(Product):
         except BaseException:
             spiceds = ""
 
-        line = f"Step {self.setup.step} - Processing spiceds file"
-        logging.info("")
-        logging.info(line)
-        logging.info("-" * len(line))
-        logging.info("")
-        self.setup.step += 1
-        if not self.setup.args.silent and not self.setup.args.verbose:
-            print("-- " + line.split(" - ")[-1] + ".")
-
         if not spiceds:
             logging.info("-- No spiceds file provided.")
 

--- a/src/pds/naif_pds4_bundler/classes/setup.py
+++ b/src/pds/naif_pds4_bundler/classes/setup.py
@@ -867,16 +867,6 @@ class Setup:
 
     def set_release(self):
         """Determine the Bundle release number."""
-        line = f"Step {self.step} - Setup the archive generation"
-        logging.info("")
-        logging.info("")
-        logging.info(line)
-        logging.info("-" * len(line))
-        logging.info("")
-        self.step += 1
-        if not self.args.silent and not self.args.verbose:
-            print("-- " + line.split(" - ")[-1] + ".")
-
         #
         # PDS4 release increment (implies inventory and meta-kernel).
         #

--- a/src/pds/naif_pds4_bundler/classes/setup.py
+++ b/src/pds/naif_pds4_bundler/classes/setup.py
@@ -966,15 +966,6 @@ class Setup:
         required memory is not much, we stay on the safe side by loading
         additional kernels.
         """
-        line = f"Step {self.step} - Load LSK, PCK, FK and SCLK kernels"
-        logging.info("")
-        logging.info(line)
-        logging.info("-" * len(line))
-        logging.info("")
-        self.step += 1
-        if not self.args.silent and not self.args.verbose:
-            print("-- " + line.split(" - ")[-1] + ".")
-
         #
         # To get the appropriate kernels, use the kernel list config.
         # First extract the patterns for each kernel type of interest.

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -459,6 +459,7 @@ def run_pipeline(args: PipelineArgs) -> None:
         #
         # * Generate the Bundle label and if necessary the readme file.
         #
+        log_step(setup, title='Generation of bundle products')
         bundle.readme = ReadmeProduct(setup, bundle)
 
         #

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -310,6 +310,8 @@ def run_pipeline(args: PipelineArgs) -> None:
     if spice_kernels_collection.updated:
         if setup.pds_version == "4":
             spice_kernels_collection.set_collection_vid()
+
+        log_step(setup, title=f'Generation of {spice_kernels_collection.name} collection')
         spice_kernels_collection_inventory = InventoryProduct(
             setup, spice_kernels_collection
         )
@@ -336,6 +338,8 @@ def run_pipeline(args: PipelineArgs) -> None:
             document_collection.add(spiceds)
 
             document_collection.set_collection_vid()
+
+            log_step(setup, title=f'Generation of {document_collection.name} collection')
             document_collection_inventory = InventoryProduct(setup, document_collection)
             document_collection.add(document_collection_inventory)
 
@@ -391,6 +395,10 @@ def run_pipeline(args: PipelineArgs) -> None:
                     miscellaneous_collection.add(release_checksum)
 
                     release_miscellaneous_collection.set_collection_vid()
+
+                    # The release_miscellaneous_collection name is "miscellaneous"
+                    # (PDS4 branch), therefore, we do not log the step, as we do
+                    # every other time we generate an InventoryProduct.
                     release_miscellaneous_collection_inventory = InventoryProduct(
                         setup, release_miscellaneous_collection
                     )
@@ -439,6 +447,10 @@ def run_pipeline(args: PipelineArgs) -> None:
         miscellaneous_collection.set_collection_vid()
 
         checksum.set_coverage()
+
+        # The miscellaneous_collection name is "miscellaneous" (PDS4 branch),
+        # therefore, we do not log the step, as we do every other time we
+        # generate an InventoryProduct.
         miscellaneous_collection_inventory = InventoryProduct(
             setup, miscellaneous_collection
         )

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -107,6 +107,7 @@ def run_pipeline(args: PipelineArgs) -> None:
     #
     # * Check the existence of a previous archive version.
     #
+    log_step(setup, title='Setup the archive generation')
     setup.set_release()
 
     #
@@ -127,7 +128,8 @@ def run_pipeline(args: PipelineArgs) -> None:
 
     #
     # * Generate the Release Plan object.
-    #
+    # TODO: Should this one be renamed to 'Release Plan generation'?
+    log_step(setup, title='Kernel List generation')
     release_plan = ReleasePlan(setup)
 
     #
@@ -160,8 +162,11 @@ def run_pipeline(args: PipelineArgs) -> None:
     #
     #   If a release plan was either generated or loaded during the previous
     #   step, load the obtained kernel_list into the KernelList object.
-    #
     # TODO: Add kernel_list argument to the KernelList constructor.
+    # TODO: Remove this commented out code or uncomment it. The decision will
+    #       depend on whether we want to have a "step" for the generation of
+    #       the release plan or not.
+    # log_step(setup, title='Kernel List generation')
     k_list = KernelList(setup)
     k_list.kernel_list = release_plan.kernel_list
 

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -273,6 +273,7 @@ def run_pipeline(args: PipelineArgs) -> None:
         #
         # * List the files present in the staging area.
         #
+        log_step(setup, title='Recap files in staging area')
         bundle.files_in_staging()
 
         #
@@ -474,6 +475,7 @@ def run_pipeline(args: PipelineArgs) -> None:
     #
     # * List the files present in the staging area.
     #
+    log_step(setup, title='Recap files in staging area')
     bundle.files_in_staging()
 
     #

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -542,6 +542,7 @@ def run_pipeline(args: PipelineArgs) -> None:
     #
     for kernel in spice_kernels_collection.product:
         if isinstance(kernel, MetaKernelProduct):
+            log_step(setup, title=f'Meta-kernel {kernel.name} validation')
             kernel.validate()
 
     finish_execution(setup, log)

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -279,6 +279,7 @@ def run_pipeline(args: PipelineArgs) -> None:
         #
         # * Copy files to the bundle area.
         #
+        log_step(setup, title='Copy files to the bundle area')
         bundle.copy_to_bundle()
 
         finish_execution(setup, log)
@@ -498,6 +499,7 @@ def run_pipeline(args: PipelineArgs) -> None:
     #
     # * Copy files to the bundle area.
     #
+    log_step(setup, title='Copy files to the bundle area')
     bundle.copy_to_bundle()
 
     #

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -366,6 +366,7 @@ def run_pipeline(args: PipelineArgs) -> None:
             )
             if not isdir(checksum_dir):
                 for release in bundle.history.items():
+                    log_step(setup, title='Generate checksum file')
                     release_checksum = ChecksumProduct(
                         setup, miscellaneous_collection, add_previous_checksum=False
                     )
@@ -423,6 +424,7 @@ def run_pipeline(args: PipelineArgs) -> None:
         #    * The miscellaneous collection is the one to be guaranteed to be
         #      updated.
         #
+        log_step(setup, title='Generate checksum file')
         checksum = ChecksumProduct(setup, miscellaneous_collection)
 
         #
@@ -467,6 +469,7 @@ def run_pipeline(args: PipelineArgs) -> None:
         bundle.add(document_collection)
         bundle.add(miscellaneous_collection)
 
+        log_step(setup, title='Generate checksum file')
         checksum = ChecksumProduct(
             setup, miscellaneous_collection, add_previous_checksum=False
         )

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -1,10 +1,9 @@
 """Implementation of the NAIF PDS4 Bundler pipeline.
 """
-import logging
 from os.path import isdir
 from pathlib import Path
 
-from .runtime import clear_run, finish_execution
+from .runtime import clear_run, finish_execution, log_step
 from .. import __version__
 from ..classes.bundle import Bundle
 from ..classes.collection import DocumentCollection
@@ -344,14 +343,7 @@ def run_pipeline(args: PipelineArgs) -> None:
         #
 
         # Report the Collection generation step.
-        line = f"Step {setup.step} - Generation of {miscellaneous_collection.kind} collection"
-        logging.info("")
-        logging.info(line)
-        logging.info("-" * len(line))
-        logging.info("")
-        setup.step += 1
-        if not setup.args.silent and not setup.args.verbose:
-            print("-- " + line.split(" - ")[-1] + ".")
+        log_step(setup, title=f'Generation of {miscellaneous_collection.kind} collection')
 
         if setup.increment:
             checksum_dir = (

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -533,6 +533,7 @@ def run_pipeline(args: PipelineArgs) -> None:
     #   Bundle history and checking the bundle times.
     #
     if setup.pds_version == "4":
+        log_step(setup, title='Validate bundle history with checksum files')
         bundle.validate()
 
     #

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -184,8 +184,9 @@ def run_pipeline(args: PipelineArgs) -> None:
         return
 
     #
-    #    * Check the products present in the list (SPICE kernels and ORBNUM
+    #    * Check the products present in the list (SPICE kernels and OrbNum
     #      files)
+    log_step(setup, title='Check kernel list products')
     k_list.check_products()
 
     #
@@ -199,17 +200,19 @@ def run_pipeline(args: PipelineArgs) -> None:
     #
     # * Generate the PDS4 Bundle structure.
     #
+    log_step(setup, title='Bundle/data set structure generation at staging area')
     bundle = Bundle(setup)
 
     #
     # * Load LSK, FK and SCLK kernels for time conversions and coverage
     #   computations.
     #
+    log_step(setup, title='Load LSK, PCK, FK and SCLK kernels')
     setup.load_kernels()
 
     #
     # * Initialize the SPICE Kernels Collection.
-    #
+    log_step(setup, title='SPICE kernel collection/data processing')
     spice_kernels_collection = SpiceKernelsCollection(setup, bundle, k_list)
 
     #
@@ -245,6 +248,7 @@ def run_pipeline(args: PipelineArgs) -> None:
     #
     # * Generate the Meta-kernel(s).
     #
+    log_step(setup, title='Generation of meta-kernel(s)')
     meta_kernels = spice_kernels_collection.determine_meta_kernels()
     if meta_kernels:
         for mk in sorted(meta_kernels):
@@ -283,6 +287,7 @@ def run_pipeline(args: PipelineArgs) -> None:
     # * Determine the SPICE kernels Collection increment times and VID.
     #
     if setup.pds_version == "4":
+        log_step(setup, title='Determine archive increment start and finish times')
         spice_kernels_collection.set_increment_times()
         spice_kernels_collection.set_collection_vid()
 
@@ -293,6 +298,7 @@ def run_pipeline(args: PipelineArgs) -> None:
     #      from at object initialization.
     #    * Check if there is an XML label for each file under spice_kernels.
     #
+    log_step(setup, title='Validate SPICE kernel collection generation')
     spice_kernels_collection.validate()
 
     #
@@ -317,6 +323,7 @@ def run_pipeline(args: PipelineArgs) -> None:
         #
         # * Generate of SPICEDS document.
         #
+        log_step(setup, title='Processing spiceds file')
         spiceds = SpicedsProduct(setup, document_collection)
 
         #
@@ -450,6 +457,8 @@ def run_pipeline(args: PipelineArgs) -> None:
     elif setup.pds_version == "3":
 
         document_collection = DocumentCollection(setup, bundle)
+
+        log_step(setup, title='Generation of PDS3 products')
         document_collection.get_pds3_documents()
 
         bundle.add(spice_kernels_collection)

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -493,6 +493,7 @@ def run_pipeline(args: PipelineArgs) -> None:
     # kernel list.
     #
     # OnlyFor PDS3
+    # log_step(setup, title='Generation of complete kernel list')
     # list.write_complete_list()
     # spice_kernels_collection_inventory.write_index()
 

--- a/src/pds/naif_pds4_bundler/pipeline/runtime.py
+++ b/src/pds/naif_pds4_bundler/pipeline/runtime.py
@@ -82,14 +82,7 @@ def finish_execution(setup: Setup, log_manager: Log) -> None:
         if os.path.exists(template):
             os.remove(template)
 
-    step_message = f"Step {setup.step} - Generate run by-product files"
-    logging.info("")
-    logging.info(step_message)
-    logging.info("-" * len(step_message))
-    logging.info("")
-    setup.step += 1
-    if not setup.args.silent and not setup.args.verbose:
-        print("-- " + step_message.split(" - ")[-1] + ".")
+    log_step(setup, title='Generate run by-product files')
 
     # Business Logic: Generate Artifacts
     #

--- a/src/pds/naif_pds4_bundler/pipeline/runtime.py
+++ b/src/pds/naif_pds4_bundler/pipeline/runtime.py
@@ -144,6 +144,23 @@ def handle_npb_error(message: str, setup: Optional[Setup] = None) -> None:
     raise RuntimeError(message)
 
 
+def log_step(setup: Setup, title: str) -> None:
+    """Logs the current execution step and increments the counter.
+
+    :param setup: NPB configuration.
+    :param title: Step title
+    """
+    message = f"Step {setup.step} - {title}"
+    logging.info("")
+    logging.info(message)
+    logging.info("-" * len(message))
+    logging.info("")
+
+    if not setup.args.silent and not setup.args.verbose:
+        print(f"-- {title}.")
+
+    setup.step += 1
+
 # ---------------------------------------------------------------------------
 # runtime utility functions
 # ---------------------------------------------------------------------------

--- a/tests/npb/test_pipeline_runtime.py
+++ b/tests/npb/test_pipeline_runtime.py
@@ -65,6 +65,10 @@ def file_list_with_byproducts(dirs):
     path.write_text(content)
     return str(path)
 
+@pytest.fixture
+def mock_setup():
+    return Setup(step=1)
+
 # ---------------------------------------------------------------------------
 # runtime.clean_run tests
 #
@@ -464,6 +468,48 @@ def test_handle_error_handles_missing_templates(monkeypatch):
     with pytest.raises(RuntimeError):
         runtime.handle_npb_error("Error with missing template", setup=mock_setup)
 
+# ---------------------------------------------------------------------------
+# runtime.log_step tests
+# ---------------------------------------------------------------------------
+
+@patch("logging.info")
+def test_log_step_increments_counter(_mock_log, mock_setup):
+    """Verify that the step counter increments every time the function is called."""
+    initial_step = mock_setup.step
+    runtime.log_step(mock_setup, title="Test Title")
+    assert mock_setup.step == initial_step + 1
+
+
+def test_log_step_formatting(caplog, mock_setup):
+    """Verify the formatting of the logs and that they include the title."""
+    # Set level to INFO since caplog defaults to WARNING
+    caplog.set_level(logging.INFO)
+
+    title = "Initialize Database"
+    expected_header = "Step 1 - Initialize Database"
+    expected_separator =  "----------------------------"
+
+    runtime.log_step(mock_setup, title)
+
+    assert caplog.messages == ["", expected_header, expected_separator, ""]
+
+
+@pytest.mark.parametrize("silent, verbose, stdout", [
+    (False, False, '-- Conditional Print Test.\n'),  # Standard mode: should print
+    (True, False, ''),  # Silent mode: should not print
+    (False, True, ''),  # Verbose mode: should not print
+    (True, True, ''),  # Both: should not print
+])
+@patch("logging.info")
+def test_log_step_print_conditions(_mock_log, silent, verbose, stdout, capsys):
+    """Test the logic that determines if 'print' is called based on args."""
+    setup = Setup(step=5, silent=silent, verbose=verbose)
+    title = "Conditional Print Test"
+
+    runtime.log_step(setup, title)
+
+    captured = capsys.readouterr()
+    assert stdout == captured.out
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -504,3 +550,10 @@ def _make_setup(
         mission_acronym=mission_acronym,
         run_type=run_type,
         args=args or _make_args(clear=""))
+
+
+class Setup:
+    """Mock of the Setup class, for testing the `log_step` method."""
+    def __init__(self, step=1, silent=False, verbose=False):
+        self.step = step
+        self.args = MagicMock(silent=silent, verbose=verbose)


### PR DESCRIPTION
## 🗒️ Summary
- Created a "standalone" function to log each of the steps in the pipeline, using the common code present across the different methods/classes that were logging such steps.
- Remove the logging code from those classes/methods and place it at the right location within the `run_pipeline` function.
- Updated the `finish_execution` function to use the newly created `log_step` function.

Note: the current location of the `log_step` function might not be the right place, but this PR should be considered just as an intermediate step towards the refactoring of the code.

## ⚙️ Test Data and/or Report
No tests have been added.

## ♻️ Related Issues
Fixes #124.


