### PR TITLE
fix(B-01): remove unconditional [:-1] from kernel name truncation

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/list.py
+++ b/src/pds/naif_pds4_bundler/classes/list.py
@@ -350,9 +350,7 @@ class KernelList:
         with open(kernel_list, "r", encoding='utf-8') as lst:
             for line in lst:
                 if "FILE             =" in line:
-                    # TODO: BUG; If a FILE line has no trailing EOL, [:-1]
-                    #      truncates the kernel name.
-                    kernels.append(line.split(os.sep)[-1][:-1])
+                    kernels.append(line.split(os.sep)[-1].rstrip("\r\n"))
 
         self.kernel_list = kernels
 

--- a/tests/npb/test_classes_kernel_list.py
+++ b/tests/npb/test_classes_kernel_list.py
@@ -948,13 +948,9 @@ class TestKernelListReadList:
          'MAKLABEL_OPTIONS = SCLK\n',
          ['maven_frames_v01.tf', 'maven_clock_v02.tsc']),
         (f'FILE             = {os.path.join("spice_kernels", "spk", "maven_orbit_v01.bsp")}',
-         ['maven_orbit_v01.bs'])])
+         ['maven_orbit_v01.bsp'])])
     def test_read_list_builds_kernel_list_from_file_entries_only(
             self, mocker, tmp_path, content, expected_kernels) -> None:
-        # TODO: The last example demonstrates the bug whereby, if there is no
-        #       EOL on the FILE line, the code removes the last character from
-        #       the line.
-
         # Verify read_list parsing rules with several inputs: ignore non-FILE
         # lines, build kernel_list only from FILE entries and preserve the
         # original order.


### PR DESCRIPTION
## Spec

`classes/list.py` line 353 used `[:-1]` unconditionally to strip the last character of a kernel name. This was intended to remove a trailing EOL character, but it fired on every name regardless of whether one was present — silently truncating the last character of any kernel name that did not end with a newline.

Fix: replace `[:-1]` with `.rstrip("\r\n")` so the strip only fires when the last character is actually a newline or carriage-return.

## Files in scope

- `src/pds/naif_pds4_bundler/classes/list.py` (line 353)
- `tests/npb/test_classes_kernel_list.py` (parametrised test case that documented the bug)

## Changes

- `list.py`: replace `line.split(os.sep)[-1][:-1]` with `line.split(os.sep)[-1].rstrip("\r\n")`
- `test_classes_kernel_list.py`: correct expected value from `'maven_orbit_v01.bs'` to `'maven_orbit_v01.bsp'` and remove the TODO comment that described the (now-fixed) bug

## Acceptance criteria

- [x] `pytest -x -q` green with zero new failures (1734 passed, 9 skipped)
- [x] No remaining unconditional `[:-1]` on kernel name at line 353
- [x] Kernel names without a trailing newline are no longer truncated

Closes #265