### PR TITLE
fix(B-02): guard against non-numeric release token in kernel list filename

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/list.py
+++ b/src/pds/naif_pds4_bundler/classes/list.py
@@ -379,10 +379,14 @@ class KernelList:
 
                 logging.info('-- Adding %s', kernel_list)
 
-                # TODO: BUG; If a file matching the release kernel-list glob
-                #       does not contain a numeric release token, int() raises
-                #      ValueError before the complete list can be validated.
-                release_list.append(int(kernel_list.replace("_", ".").split(".")[-3]))
+                token = kernel_list.replace("_", ".").split(".")[-3]
+                try:
+                    release_list.append(int(token))
+                except ValueError:
+                    handle_npb_error(
+                        f"Non-numeric release token '{token}' in kernel list filename "
+                        f"'{os.path.basename(kernel_list)}'."
+                    )
                 with open(kernel_list, "r", encoding='utf-8') as lst:
                     for line in lst:
                         c.write(line)

--- a/tests/npb/test_classes_kernel_list.py
+++ b/tests/npb/test_classes_kernel_list.py
@@ -1684,6 +1684,23 @@ class TestKernelListWriteCompleteList:
         # propagated.
         validate_complete_mock.assert_called_once_with(kernel_list)
 
+    def test_write_complete_list_raises_on_non_numeric_release_token(
+            self, tmp_path) -> None:
+        # Verify that a kernel list filename whose release token cannot be
+        # converted to int causes handle_npb_error to raise RuntimeError with
+        # a message that identifies both the bad token and the filename.
+
+        kernel_list, _, _ = self.make_kernel_list(tmp_path)
+        working_directory = Path(kernel_list.setup.working_directory)
+
+        # 'abc' is the token at position [-3] after replacing '_' with '.'
+        # in 'maven_release_abc.kernel_list'.
+        bad_release = working_directory / 'maven_release_abc.kernel_list'
+        bad_release.write_text('RELEASE BAD\n', encoding='utf-8')
+
+        with pytest.raises(RuntimeError, match="Non-numeric release token 'abc'"):
+            kernel_list.write_complete_list()
+
 
 class TestKernelListValidateComplete:
     """Tests for KernelList.validate_complete.


### PR DESCRIPTION
## 🗒️ Summary

Wraps the `int()` call on the release token in `write_complete_list` with a `try/except ValueError` that delegates to `handle_npb_error`, replacing an unhandled crash with a clear runtime error that identifies both the bad token and the offending filename.

## ⚙️ Test Data and/or Report

Regression test added: `TestKernelListWriteCompleteList::test_write_complete_list_raises_on_non_numeric_release_token` — exercises the new branch without mocking `handle_npb_error` and asserts the `RuntimeError` message names the bad token and filename.

## ♻️ Related Issues

Closes #267