### PR TITLE
fix(B-04): set eol_pds4_len to 2 for CRLF line terminator

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/setup.py
+++ b/src/pds/naif_pds4_bundler/classes/setup.py
@@ -233,11 +233,9 @@ class Setup:
         else:
             handle_npb_error("End of Line provided via configuration is not CRLF nor LF.")
 
-        # TODO: The EOL setting for PDS4 is CRLF ("\r\n"), so the eol_pds4_len
-        #       variable should be 2 instead of 1. There is a bug.
         self.end_of_line_pds4 = "CRLF"
         self.eol_pds4 = "\r\n"
-        self.eol_pds4_len = 1
+        self.eol_pds4_len = 2
         self.eol_mk = "\n"
         self.eol_mk_len = 1
         self.eol_pds3 = "\r\n"

--- a/tests/npb/test_classes_setup.py
+++ b/tests/npb/test_classes_setup.py
@@ -229,11 +229,9 @@ class TestSetupInit:
         # The following values do not depend on the default configuration, but
         # are always assigned in the constructor. We therefore check that they
         # remain exactly as defined in the code.
-        # TODO: This test exposes a bug. The correct value for eol_pds4_len
-        #       should be 2 not 1, as the EOL for PDS4 is CRLF ("\r\n").
         assert setup_instance.end_of_line_pds4 == 'CRLF'
         assert setup_instance.eol_pds4 == '\r\n'
-        assert setup_instance.eol_pds4_len == 1
+        assert setup_instance.eol_pds4_len == 2
         assert setup_instance.eol_mk == '\n'
         assert setup_instance.eol_mk_len == 1
         assert setup_instance.eol_pds3 == '\r\n'


### PR DESCRIPTION
## 🗒️ Summary

`eol_pds4_len` was hardcoded to `1` in `Setup.__init__`, but the PDS4 end-of-line sequence is CRLF (`"\r\n"`), which is 2 characters. This commit corrects the value to `2` and removes the TODO comment that documented the bug. The corresponding test assertion is updated to match the corrected value.

## ⚙️ Test Data and/or Report

`pytest tests/npb -x -q` on branch `item/B-04-eol-pds4-len-crlf`:

```
1641 passed, 9 skipped in 61.04s
```

## ♻️ Related Issues

Fixes #269
