### PR TITLE
Fix(B-05): raise ValueError for unrecognized collection.name

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/label/pds4_bundle.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_bundle.py
@@ -38,38 +38,27 @@ class BundlePDS4Label(PDSLabel):
         # is generated and there have been previous releases.)
         #
         for collection in self.product.bundle.collections:
-            if collection.name == "spice_kernels":
-                self.COLL_NAME = "spice_kernel"
-                self.COLL_LIDVID = collection.lid + "::" + collection.vid
-                if collection.updated:
-                    self.COLL_STATUS = "Primary"
-                else:
-                    self.COLL_STATUS = "Secondary"
-            if collection.name == "miscellaneous":
-                if setup.information_model_float >= 1011001000.0:
-                    self.COLL_NAME = "miscellaneous"
-                else:
-                    self.COLL_NAME = "member"
-                self.COLL_LIDVID = collection.lid + "::" + collection.vid
-                if collection.updated:
-                    self.COLL_STATUS = "Primary"
-                else:
-                    self.COLL_STATUS = "Secondary"
-            if collection.name == "document":
-                self.COLL_NAME = "document"
-                self.COLL_LIDVID = collection.lid + "::" + collection.vid
-                if collection.updated:
-                    self.COLL_STATUS = "Primary"
-                else:
-                    self.COLL_STATUS = "Secondary"
 
-            # TODO: BUG, COLL_NAME, COLL_LIDVID, and COLL_STATUS are only
-            #   assigned inside the three named if-blocks above. If
-            #   collection.name does not match any of the three recognised
-            #   values ('spice_kernels', 'miscellaneous', 'document'), none of
-            #   the blocks run and the f-string below reads stale values from
-            #   the previous iteration (or raises AttributeError on the first
-            #   iteration, when the attributes have never been set).
+            if collection.name == 'spice_kernels':
+
+                # This value is singular ( spice_kernel(s) ).
+                coll_name = 'spice_kernel'
+
+            elif collection.name == 'document':
+                coll_name = 'document'
+
+            elif collection.name == "miscellaneous":
+                coll_name = "miscellaneous" if setup.information_model_float >= 1011001000.0 else "member"
+
+            else:
+                raise ValueError(
+                    f'NPB bug: the collection name {collection.name} is not '
+                    f'supported in PDS4 Bundle Label.')
+
+            self.COLL_NAME = coll_name
+            self.COLL_LIDVID = collection.lid + "::" + collection.vid
+            self.COLL_STATUS = "Primary" if collection.updated else "Secondary"
+
             self.BUNDLE_MEMBER_ENTRIES += (
                 f"{' ' * tab}<Bundle_Member_Entry>{eol}"
                 f"{' ' * 2 * tab}<lidvid_reference>"

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_bundle.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_bundle.py
@@ -41,7 +41,9 @@ class BundlePDS4Label(PDSLabel):
 
             if collection.name == 'spice_kernels':
 
-                # This value is singular ( spice_kernel(s) ).
+                # TODO: Is "spice_kernels" needed or can it be changed to
+                #       "spice_kernel" in order to simplify the code? Open for
+                #       discussion.
                 coll_name = 'spice_kernel'
 
             elif collection.name == 'document':

--- a/tests/npb/test_classes_label_pds4_bundle.py
+++ b/tests/npb/test_classes_label_pds4_bundle.py
@@ -27,6 +27,7 @@ Why BundlePDS4Label differs from the other PDS4 label classes:
   For the ``miscellaneous`` collection, the reference-type suffix also depends
   on ``setup.information_model_float`` vs the threshold 1011001000.0.
 """
+import re
 from pathlib import Path
 from types import SimpleNamespace
 import xml.etree.ElementTree as ElementTree
@@ -431,32 +432,31 @@ class TestBundlePDS4Label:
         assert label.BUNDLE_MEMBER_ENTRIES == expected
 
     # ------------------------------------------------------------------
-    # Edge cases / known bugs
+    # Edge cases
     # ------------------------------------------------------------------
 
-    def test_unknown_collection_name_on_first_iteration_raises_attribute_error(
+    def test_unknown_collection_name_raises_value_error(
             self, tmp_path: Path, helpers: SimpleNamespace) -> None:
-        # TODO: BUG, COLL_NAME, COLL_LIDVID, and COLL_STATUS are only assigned
-        #       inside the three named if-blocks. When the first collection has
-        #       an unrecognised name, none of those blocks run, so the
-        #       subsequent f-string that reads self.COLL_LIDVID raises
-        #       AttributeError.
+        # An unrecognised collection.name fails fast with a descriptive
+        # ValueError instead of silently reading stale/missing scratch state.
         unknown = helpers.make_collection(
             name='unexpected_collection',
             lid='urn:nasa:pds:maven_spice:unexpected', updated=True)
         readme = helpers.make_readme(tmp_path / 'staging',
                                      collections=[unknown])
 
-        with pytest.raises(AttributeError, match='COLL_LIDVID'):
+        expected_message = (
+            'NPB bug: the collection name unexpected_collection is not '
+            'supported in PDS4 Bundle Label.')
+        with pytest.raises(ValueError, match=f'^{re.escape(expected_message)}$'):
             _build_label(helpers.make_setup(), readme)
 
-    def test_unknown_collection_name_reuses_previous_iteration_state(
+    def test_unknown_collection_name_after_known_collection_raises_value_error(
             self, tmp_path: Path, helpers: SimpleNamespace) -> None:
-        # TODO: BUG, when an unrecognised collection follows a recognised one,
-        #       COLL_NAME/COLL_LIDVID/COLL_STATUS retain the values from the
-        #       previous iteration and the f-string silently emits a duplicate
-        #       entry for that previous collection instead of failing or
-        #       skipping.
+        # An unrecognised collection.name following a recognised one must
+        # still raise immediately, rather than silently reusing the
+        # previous iteration's COLL_NAME/COLL_LIDVID/COLL_STATUS to emit a
+        # duplicate entry.
         known = helpers.make_collection(
             name='document',
             lid='urn:nasa:pds:maven_spice:document', updated=False)
@@ -466,20 +466,11 @@ class TestBundlePDS4Label:
         readme = helpers.make_readme(tmp_path / 'staging',
                                      collections=[known, unknown])
 
-        label = _build_label(helpers.make_setup(), readme)
-
-        # Both entries carry the stale document state; the unknown LID never
-        # appears because COLL_LIDVID was never updated for the second iteration.
-        doc_entry = (
-            ' <Bundle_Member_Entry>\n'
-            '  <lidvid_reference>'
-            'urn:nasa:pds:maven_spice:document::1.0</lidvid_reference>\n'
-            '  <member_status>Secondary</member_status>\n'
-            '  <reference_type>'
-            'bundle_has_document_collection</reference_type>\n'
-            ' </Bundle_Member_Entry>\n'
-        )
-        assert label.BUNDLE_MEMBER_ENTRIES == doc_entry + doc_entry
+        expected_message = (
+            'NPB bug: the collection name unexpected_collection is not '
+            'supported in PDS4 Bundle Label.')
+        with pytest.raises(ValueError, match=f'^{re.escape(expected_message)}$'):
+            _build_label(helpers.make_setup(), readme)
 
     @pytest.mark.parametrize('updated_value, expected_status', [
         (True, 'Primary'),

--- a/tests/npb/test_classes_label_pds4_bundle.py
+++ b/tests/npb/test_classes_label_pds4_bundle.py
@@ -27,7 +27,6 @@ Why BundlePDS4Label differs from the other PDS4 label classes:
   For the ``miscellaneous`` collection, the reference-type suffix also depends
   on ``setup.information_model_float`` vs the threshold 1011001000.0.
 """
-import re
 from pathlib import Path
 from types import SimpleNamespace
 import xml.etree.ElementTree as ElementTree
@@ -449,7 +448,7 @@ class TestBundlePDS4Label:
         expected_message = (
             'NPB bug: the collection name unexpected_collection is not '
             'supported in PDS4 Bundle Label.')
-        with pytest.raises(ValueError, match=f'^{re.escape(expected_message)}$'):
+        with pytest.raises(ValueError, match=f'^{expected_message}$'):
             _build_label(setup, readme)
 
     def test_unknown_collection_name_after_known_collection_raises_value_error(
@@ -471,7 +470,7 @@ class TestBundlePDS4Label:
         expected_message = (
             'NPB bug: the collection name unexpected_collection is not '
             'supported in PDS4 Bundle Label.')
-        with pytest.raises(ValueError, match=f'^{re.escape(expected_message)}$'):
+        with pytest.raises(ValueError, match=f'^{expected_message}$'):
             _build_label(setup, readme)
 
     @pytest.mark.parametrize('updated_value, expected_status', [

--- a/tests/npb/test_classes_label_pds4_bundle.py
+++ b/tests/npb/test_classes_label_pds4_bundle.py
@@ -445,11 +445,12 @@ class TestBundlePDS4Label:
         readme = helpers.make_readme(tmp_path / 'staging',
                                      collections=[unknown])
 
+        setup = helpers.make_setup()
         expected_message = (
             'NPB bug: the collection name unexpected_collection is not '
             'supported in PDS4 Bundle Label.')
         with pytest.raises(ValueError, match=f'^{re.escape(expected_message)}$'):
-            _build_label(helpers.make_setup(), readme)
+            _build_label(setup, readme)
 
     def test_unknown_collection_name_after_known_collection_raises_value_error(
             self, tmp_path: Path, helpers: SimpleNamespace) -> None:
@@ -466,11 +467,12 @@ class TestBundlePDS4Label:
         readme = helpers.make_readme(tmp_path / 'staging',
                                      collections=[known, unknown])
 
+        setup = helpers.make_setup()
         expected_message = (
             'NPB bug: the collection name unexpected_collection is not '
             'supported in PDS4 Bundle Label.')
         with pytest.raises(ValueError, match=f'^{re.escape(expected_message)}$'):
-            _build_label(helpers.make_setup(), readme)
+            _build_label(setup, readme)
 
     @pytest.mark.parametrize('updated_value, expected_status', [
         (True, 'Primary'),


### PR DESCRIPTION
## 🗒️ Summary
`COLL_NAME`, `COLL_LIDVID`, and `COLL_STATUS` were only assigned inside the three named if-blocks in the bundle-collection loop in `BundlePDS4Label`. When `collection.name` didn't match any of the three recognised values (`spice_kernels`, `miscellaneous`, `document`), the loop either raised an unhelpful `AttributeError` (first iteration) or silently reused stale values from the previous iteration, producing a duplicated `Bundle_Member_Entry`.

The loop now uses an explicit `if/elif/elif/else` and raises a descriptive `ValueError` when `collection.name` is unrecognized, instead of failing with a confusing error or corrupting the bundle label.

## ⚙️ Test Data and/or Report
`tests/npb/test_classes_label_pds4_bundle.py` updated: `test_unknown_collection_name_raises_value_error` and `test_unknown_collection_name_after_known_collection_raises_value_error` now assert the new `ValueError` (matched against the exact message) instead of the old crash/stale-duplicate behavior.

Full suite result:
```
1657 passed, 9 skipped, 1 xfailed in 18.74s
```

## ♻️ Related Issues
fixes #276