### PR TITLE
Fix(B-06): start_times[0] IndexError on empty list in InventoryPDS4Label

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/label/pds4_inventory.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_inventory.py
@@ -45,11 +45,15 @@ class InventoryPDS4Label(PDSLabel):
             start_times.sort()
             stop_times.sort()
 
-            # TODO: BUG; if no product in collection.product has 'checksum' in
-            #       its name, start_times and stop_times remain empty and
-            #       start_times[0] raises IndexError, aborting label generation.
-            #       The same failure occurs when collection.product is an empty
-            #       list.
+            # Without a checksum product there is no time source for this
+            # collection; fail loudly instead of IndexError below.
+            if not start_times:
+                raise ValueError(
+                    f'NPB bug: no checksum product found in collection '
+                    f'{collection.lid}::{collection.vid}; START_TIME and '
+                    f'STOP_TIME cannot be determined for the miscellaneous '
+                    f'label.')
+
             self.START_TIME = start_times[0]
             self.STOP_TIME = stop_times[-1]
 

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_inventory.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_inventory.py
@@ -42,8 +42,6 @@ class InventoryPDS4Label(PDSLabel):
                 if "checksum" in product.name:
                     start_times.append(product.start_time)
                     stop_times.append(product.stop_time)
-            start_times.sort()
-            stop_times.sort()
 
             # Without a checksum product there is no time source for this
             # collection; fail loudly instead of IndexError below.
@@ -51,8 +49,11 @@ class InventoryPDS4Label(PDSLabel):
                 raise ValueError(
                     f'NPB bug: no checksum product found in collection '
                     f'{collection.lid}::{collection.vid}; START_TIME and '
-                    f'STOP_TIME cannot be determined for the miscellaneous '
-                    f'label.')
+                    f'STOP_TIME cannot be determined for the PDS4 Collection '
+                    f'Inventory label.')
+
+            start_times.sort()
+            stop_times.sort()
 
             self.START_TIME = start_times[0]
             self.STOP_TIME = stop_times[-1]

--- a/tests/npb/test_classes_label_pds4_inventory.py
+++ b/tests/npb/test_classes_label_pds4_inventory.py
@@ -367,12 +367,11 @@ class TestInventoryPDS4Label:
         assert label.START_TIME == '2024-01-01T00:00:00'
         assert label.STOP_TIME == '2024-01-31T00:00:00'
 
-    def test_miscellaneous_branch_without_checksums_raises_index_error(
+    def test_miscellaneous_branch_without_checksums_raises_value_error(
             self, tmp_path: Path, helpers: SimpleNamespace) -> None:
-        # TODO: BUG; for the 'miscellaneous' collection, when no product name
-        #       contains 'checksum', start_times/stop_times stay empty and
-        #       start_times[0] raises IndexError. The constructor performs no
-        #       guard against an empty checksum set, aborting label generation.
+        # For the 'miscellaneous' collection, when no product name contains
+        # 'checksum', there is no time source: the constructor now raises a
+        # descriptive ValueError instead of IndexError.
         setup = helpers.make_setup()
         staging = tmp_path / 'staging'
         inventory = helpers.make_inventory(
@@ -381,30 +380,42 @@ class TestInventoryPDS4Label:
         # A collection whose products contain no 'checksum' in their names.
         non_checksum = helpers.make_checksum_product(
             'orbnum_v01.nrb', '2024-01-01T00:00:00', '2024-01-31T00:00:00')
+
         collection = helpers.make_collection(
             name='miscellaneous', coll_type='miscellaneous',
             products=[non_checksum])
 
+        expected_message = (
+            f'NPB bug: no checksum product found in collection '
+            f'{collection.lid}::{collection.vid}; START_TIME and '
+            f'STOP_TIME cannot be determined for the miscellaneous label.')
+
         with patch('pds.naif_pds4_bundler.classes.label.label.'
                    'PDSLabel.write_label', autospec=True):
-            with pytest.raises(IndexError):
+            with pytest.raises(ValueError, match=f'^{expected_message}$'):
                 InventoryPDS4Label(setup, collection, inventory)
 
-    def test_miscellaneous_branch_with_empty_product_list_raises_index_error(
+    def test_miscellaneous_branch_with_empty_product_list_raises_value_error(
             self, tmp_path: Path, helpers: SimpleNamespace) -> None:
-        # TODO: BUG; same root cause as above but with an entirely empty
-        #       collection.product list: the empty start_times still triggers
-        #       IndexError.
+        # Same root cause as above but with an entirely empty
+        # collection.product list: the empty start_times still triggers the
+        # descriptive ValueError.
         setup = helpers.make_setup()
         staging = tmp_path / 'staging'
         inventory = helpers.make_inventory(
             staging, name='collection_miscellaneous_inventory_v001.csv')
+
         collection = helpers.make_collection(
             name='miscellaneous', coll_type='miscellaneous', products=[])
 
+        expected_message = (
+            f'NPB bug: no checksum product found in collection '
+            f'{collection.lid}::{collection.vid}; START_TIME and '
+            f'STOP_TIME cannot be determined for the miscellaneous label.')
+
         with patch('pds.naif_pds4_bundler.classes.label.label.'
                    'PDSLabel.write_label', autospec=True):
-            with pytest.raises(IndexError):
+            with pytest.raises(ValueError, match=f'^{expected_message}$'):
                 InventoryPDS4Label(setup, collection, inventory)
 
     # ------------------------------------------------------------------

--- a/tests/npb/test_classes_label_pds4_inventory.py
+++ b/tests/npb/test_classes_label_pds4_inventory.py
@@ -388,7 +388,8 @@ class TestInventoryPDS4Label:
         expected_message = (
             f'NPB bug: no checksum product found in collection '
             f'{collection.lid}::{collection.vid}; START_TIME and '
-            f'STOP_TIME cannot be determined for the miscellaneous label.')
+            f'STOP_TIME cannot be determined for the PDS4 Collection '
+            f'Inventory label.')
 
         with patch('pds.naif_pds4_bundler.classes.label.label.'
                    'PDSLabel.write_label', autospec=True):
@@ -411,7 +412,8 @@ class TestInventoryPDS4Label:
         expected_message = (
             f'NPB bug: no checksum product found in collection '
             f'{collection.lid}::{collection.vid}; START_TIME and '
-            f'STOP_TIME cannot be determined for the miscellaneous label.')
+            f'STOP_TIME cannot be determined for the PDS4 Collection '
+            f'Inventory label.')
 
         with patch('pds.naif_pds4_bundler.classes.label.label.'
                    'PDSLabel.write_label', autospec=True):


### PR DESCRIPTION
## 🗒️ Summary
`InventoryPDS4Label` built `START_TIME`/`STOP_TIME` for the `miscellaneous` collection from `start_times[0]`/`stop_times[-1]`, indexed with no guard. When `collection.product` had no product with `"checksum"` in its name (or was empty), both lists stayed empty and `start_times[0]` raised an unhelpful `IndexError`, aborting label generation.

The constructor now checks for this case explicitly and raises a descriptive `ValueError` identifying the offending collection (`lid::vid`) instead of failing with a confusing `IndexError`.

## ⚙️ Test Data and/or Report
`tests/npb/test_classes_label_pds4_inventory.py` updated: `test_miscellaneous_branch_without_checksums_raises_value_error` and `test_miscellaneous_branch_with_empty_product_list_raises_value_error` now assert the new `ValueError` (previously asserted the `IndexError` crash).

`pds4_inventory.py` file coverage: 100% (no reduction).

Full suite result:
```
1657 passed, 9 skipped, 1 xfailed
```

## ♻️ Related Issues
fixes #279