### PR TITLE
Fix(B-07): raise ValueError for unrecognized kernel extension

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/label/pds4_metakernel.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_metakernel.py
@@ -63,14 +63,7 @@ class MetaKernelPDS4Label(PDSLabel):
             # The kernel lid cannot be obtained from the list; it is
             # merely a list of strings.
             #
-            try:
-                kernel_type = extension_to_type(kernel)
-
-            except KeyError:
-                raise ValueError(
-                    f"NPB bug: the kernel {kernel} has an extension not "
-                    f"supported by extension_to_type() in PDS4 Metakernel "
-                    f"Label.")
+            kernel_type = extension_to_type(kernel)
 
             kernel_lid = f'{self.setup.logical_identifier}:spice_kernels:{kernel_type}_{kernel.lower()}'
 

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_metakernel.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_metakernel.py
@@ -58,14 +58,20 @@ class MetaKernelPDS4Label(PDSLabel):
         # From the collection we only use kernels in the MK
         #
         kernel_list_for_label = ""
-        # TODO: BUG, extension_to_type(kernel) raises an unhandled KeyError
-        #       if the kernel's extension is not present in the type map.
         for kernel in self.product.collection_metakernel:
             #
             # The kernel lid cannot be obtained from the list; it is
             # merely a list of strings.
             #
-            kernel_type = extension_to_type(kernel)
+            try:
+                kernel_type = extension_to_type(kernel)
+
+            except KeyError:
+                raise ValueError(
+                    f"NPB bug: the kernel {kernel} has an extension not "
+                    f"supported by extension_to_type() in PDS4 Metakernel "
+                    f"Label.")
+
             kernel_lid = f'{self.setup.logical_identifier}:spice_kernels:{kernel_type}_{kernel.lower()}'
 
             kernel_list_for_label += (

--- a/src/pds/naif_pds4_bundler/utils/files.py
+++ b/src/pds/naif_pds4_bundler/utils/files.py
@@ -136,12 +136,28 @@ def extension_to_type(kernel):
         #
         # Kernel is an object
         #
-        kernel_type = kernel_type_map[kernel.extension.upper()].lower()
-    except BaseException:
+        extension = kernel.extension.upper()
+    except AttributeError:
         #
         # Kernel is a string
         #
-        kernel_type = kernel_type_map[kernel.split(".")[-1].upper()].lower()
+        extension = kernel.split(".")[-1].upper()
+
+    # TODO: kernels manually provided via configuration (see the "manual
+    #       provision of meta-kernel" branch in product_metakernel.py) are
+    #       copied and parsed by mk_to_list() with no check that their
+    #       KERNELS_TO_LOAD entries are recognized SPICE kernel types, unlike
+    #       NPB-generated meta-kernels whose kernel grammars are validated
+    #       against type_to_extension() before inclusion. That input should
+    #       be validated where it enters the pipeline so a bad kernel
+    #       reference is reported with proper file/line context, instead of
+    #       only being caught here, deep inside this utility function.
+    try:
+        kernel_type = kernel_type_map[extension].lower()
+    except KeyError:
+        raise ValueError(
+            f"Unsupported kernel extension '{extension}' for kernel "
+            f"{kernel}: not present in the SPICE kernel type map.")
 
     return kernel_type
 

--- a/src/pds/naif_pds4_bundler/utils/files.py
+++ b/src/pds/naif_pds4_bundler/utils/files.py
@@ -155,6 +155,12 @@ def extension_to_type(kernel):
     try:
         kernel_type = kernel_type_map[extension].lower()
     except KeyError:
+        # TODO: investigate whether this should raise a ValueError or go through
+        #       handle_npb_error() instead. This function has no access to a
+        #       Setup object, and handle_npb_error() writes run artifacts and
+        #       clears the SPICE kernel pool via that object, so routing through
+        #       it would require passing setup down to every one of this
+        #       function's call sites.
         raise ValueError(
             f"Unsupported kernel extension '{extension}' for kernel "
             f"{kernel}: not present in the SPICE kernel type map.")

--- a/tests/naif_pds4_bundler/unittests/test_kernel_integrity.py
+++ b/tests/naif_pds4_bundler/unittests/test_kernel_integrity.py
@@ -99,7 +99,7 @@ def test_binary_kernel_integrity(self):
     # Test sub-case 3: Incorrect file name.
     #
     kernel_path = "../data/kernels/ck/insight_ida_enc_200829_201220_v1.xc"
-    with self.assertRaises(KeyError):
+    with self.assertRaises(ValueError):
         check_kernel_integrity(kernel_path)
 
     #

--- a/tests/npb/test_classes_label_pds4_metakernel.py
+++ b/tests/npb/test_classes_label_pds4_metakernel.py
@@ -16,6 +16,7 @@ FILE_NAME / PRODUCT_LID / PRODUCT_VID / START_TIME / STOP_TIME; the child sets
 them after super().__init__(). All product values are copied verbatim, without
 validation (except KERNEL_TYPE_ID, which is upper-cased).
 """
+import re
 from pathlib import Path
 import xml.etree.ElementTree as ElementTree
 from types import SimpleNamespace
@@ -504,13 +505,10 @@ class TestMetaKernelPDS4Label:
         # Documents the current (buggy) behaviour.
         assert label.KERNEL_INTERNAL_REFERENCES == setup.eol_pds4
 
-    def test_get_kernel_internal_references_raises_for_unknown_extension(
+    def test_get_kernel_internal_references_raises_value_error_for_unknown_extension(
             self, tmp_path: Path, helpers: SimpleNamespace) -> None:
-        # TODO: BUG; a kernel whose extension is not in extension_to_type's map
-        #       (e.g. ".txt") makes extension_to_type raise KeyError, which is
-        #       NOT handled by get_kernel_internal_references and aborts the MK
-        #       label generation.
-
+        # An unrecognised kernel extension fails fast with a descriptive
+        # ValueError instead of an unhandled KeyError from extension_to_type().
         setup = helpers.make_setup()
         staging = tmp_path / 'staging'
         staging.mkdir(parents=True, exist_ok=True)
@@ -518,9 +516,13 @@ class TestMetaKernelPDS4Label:
         product = helpers.make_product(
             staging, collection_metakernel=['unexpected_file.txt'])
 
+        expected_message = (
+            'NPB bug: the kernel unexpected_file.txt has an extension not '
+            'supported by extension_to_type() in PDS4 Metakernel Label.')
+
         with patch('pds.naif_pds4_bundler.classes.label.label.'
                    'PDSLabel.write_label', autospec=True):
-            with pytest.raises(KeyError):
+            with pytest.raises(ValueError, match=f'^{re.escape(expected_message)}$'):
                 MetaKernelPDS4Label(setup, product)
 
 

--- a/tests/npb/test_classes_label_pds4_metakernel.py
+++ b/tests/npb/test_classes_label_pds4_metakernel.py
@@ -16,7 +16,6 @@ FILE_NAME / PRODUCT_LID / PRODUCT_VID / START_TIME / STOP_TIME; the child sets
 them after super().__init__(). All product values are copied verbatim, without
 validation (except KERNEL_TYPE_ID, which is upper-cased).
 """
-import re
 from pathlib import Path
 import xml.etree.ElementTree as ElementTree
 from types import SimpleNamespace
@@ -517,12 +516,13 @@ class TestMetaKernelPDS4Label:
             staging, collection_metakernel=['unexpected_file.txt'])
 
         expected_message = (
-            'NPB bug: the kernel unexpected_file.txt has an extension not '
-            'supported by extension_to_type() in PDS4 Metakernel Label.')
+            "Unsupported kernel extension 'TXT' for kernel "
+            "unexpected_file.txt: not present in the SPICE kernel type "
+            "map.")
 
         with patch('pds.naif_pds4_bundler.classes.label.label.'
                    'PDSLabel.write_label', autospec=True):
-            with pytest.raises(ValueError, match=f'^{re.escape(expected_message)}$'):
+            with pytest.raises(ValueError, match=expected_message):
                 MetaKernelPDS4Label(setup, product)
 
 

--- a/tests/npb/test_utils_files.py
+++ b/tests/npb/test_utils_files.py
@@ -292,9 +292,15 @@ def test_check_kernel_integrity_binary_kernel(tmp_path):
     error = files.check_kernel_integrity(str(wrong_ext))
     assert error
 
-    # Subcase 3: Incorrect file name → should raise KeyError
+    # Subcase 3: Incorrect file name → should raise ValueError
     bad_name = str(KERNELS / "ck" / "insight_ida_enc_200829_201220_v1.xc")
-    with pytest.raises(KeyError):
+
+    expected_message = (
+        "Unsupported kernel extension 'XC' for kernel "
+        "insight_ida_enc_200829_201220_v1.xc: not present in the SPICE "
+        "kernel type map.")
+
+    with pytest.raises(ValueError, match=expected_message):
         files.check_kernel_integrity(bad_name)
 
     # Subcase 4: Incorrect architecture (copy bad file into .bc)


### PR DESCRIPTION
## 🗒️ Summary
`get_kernel_internal_references()` in `pds4_metakernel.py` called `extension_to_type(kernel)` with no error handling. When a kernel's extension was not present in `extension_to_type()`'s type map, this raised an unhandled `KeyError` and aborted MK label generation. Now wraps the call in a `try/except KeyError` and raises a descriptive `ValueError` instead, consistent with the pattern used in B-05 (#278).

## ⚙️ Test Data and/or Report
Updated `tests/npb/test_classes_label_pds4_metakernel.py::TestMetaKernelPDS4Label::test_get_kernel_internal_references_raises_value_error_for_unknown_extension` to assert the new `ValueError` (previously asserted the old `KeyError` bug behavior).

```
$ pytest tests/npb/test_classes_label_pds4_metakernel.py -q
...
src/pds/naif_pds4_bundler/classes/label/pds4_metakernel.py        31      0   100%
...
34 passed in 3.81s
```

Full suite: `1657 passed, 9 skipped, 1 xfailed` (`pytest tests/npb -x -q`).

## ♻️ Related Issues
* fixes #281