### PR TITLE
Fix(B-08): index never incremented in get_context_products, all updates write to [0]

### DIFF
--- a/src/pds/naif_pds4_bundler/utils/files.py
+++ b/src/pds/naif_pds4_bundler/utils/files.py
@@ -349,13 +349,15 @@ def get_context_products(setup):
         for product in context_products_list:
             if product:
                 updated_product = False
-                index = 0
                 for registered_product in context_products:
-                    if registered_product["name"][0] == product["@name"]:
+
+                    if (registered_product["name"][0] == product["@name"]
+                            and registered_product["type"][0].lower() == product["type"].lower()):
+
                         updated_product = True
-                        context_products[index]["type"] = [product["type"]]
-                        context_products[index]["lidvid"] = product["lidvid"]
-                    # index += 1
+                        registered_product["type"] = [product["type"]]
+                        registered_product["lidvid"] = product["lidvid"]
+
                 if not updated_product:
                     appended_products.append(
                         {

--- a/src/pds/naif_pds4_bundler/utils/files.py
+++ b/src/pds/naif_pds4_bundler/utils/files.py
@@ -351,6 +351,11 @@ def get_context_products(setup):
                 updated_product = False
                 for registered_product in context_products:
 
+                    # Registered products are uniquely identified by name and
+                    # type together, not name alone, so matching on name only
+                    # would let one override overwrite the other. Type casing is
+                    # compared case-insensitively because the registry and
+                    # configs do not always agree on it.
                     if (registered_product["name"][0] == product["@name"]
                             and registered_product["type"][0].lower() == product["type"].lower()):
 

--- a/src/pds/naif_pds4_bundler/utils/files.py
+++ b/src/pds/naif_pds4_bundler/utils/files.py
@@ -338,7 +338,8 @@ def get_context_products(setup):
 
     #
     # Overwrite the default context products with the ones provided in the
-    # configuration file.
+    # configuration file. Both "type" and "lidvid" are overwritten with the
+    # values given in the configuration file for the matched entry.
     #
     appended_products = []
     if hasattr(setup, "context_products"):

--- a/src/pds/naif_pds4_bundler/utils/files.py
+++ b/src/pds/naif_pds4_bundler/utils/files.py
@@ -356,13 +356,18 @@ def get_context_products(setup):
                     # type together, not name alone, so matching on name only
                     # would let one override overwrite the other. Type casing is
                     # compared case-insensitively because the registry and
-                    # configs do not always agree on it.
+                    # configs do not always agree on it. (name, type) is still
+                    # not guaranteed unique across the registry (e.g. ULYSSES
+                    # has both an ESA PSA and a NASA PDS "Mission" entry), so
+                    # stop at the first match -- otherwise every entry sharing
+                    # the key would get overwritten too.
                     if (registered_product["name"][0] == product["@name"]
                             and registered_product["type"][0].lower() == product["type"].lower()):
 
                         updated_product = True
                         registered_product["type"] = [product["type"]]
                         registered_product["lidvid"] = product["lidvid"]
+                        break
 
                 if not updated_product:
                     appended_products.append(

--- a/tests/npb/test_utils_files.py
+++ b/tests/npb/test_utils_files.py
@@ -810,6 +810,83 @@ def test_get_context_products_overwrite_and_append(tmp_path):
     assert obs_prod["type"] == ["Rover"]
     assert obs_prod["lidvid"] == "urn:nasa:pds:context:instrument_host:spacecraft.mars2020::1.3"
 
+
+def test_get_context_products_overwrite_updates_matched_entry(tmp_path):
+    """Regression test for B-08: the override must land on the registered
+    product that actually matches by name, not on an unrelated entry.
+    Uses override values that differ from the registered defaults, so a
+    version of the code that writes to the wrong entry would leave this
+    entry with its stale (pre-override) values and fail the assertions."""
+    setup = MagicMock()
+    setup.mission_name = "MARS 2020"
+    setup.observer = "Perseverance"
+    setup.target = "MARS"
+
+    setup.context_products = {
+        "product": [
+            {"@name": "Perseverance", "type": "Rover", "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.mars2020::9.9"},
+        ]
+    }
+
+    result = files.get_context_products(setup)
+
+    obs_prod = next(cp for cp in result if cp["name"][0] == "Perseverance")
+    assert obs_prod["type"] == ["Rover"]
+    assert obs_prod["lidvid"] == "urn:nasa:pds:context:instrument_host:spacecraft.mars2020::9.9"
+
+
+def test_get_context_products_same_name_different_type():
+    """Regression test: a mission and its own spacecraft/observer commonly
+    share a name in real configs (e.g. LADEE, MAVEN) but differ in type.
+    Overriding one must not clobber the other -- matching must be keyed on
+    (name, type), not name alone."""
+    setup = MagicMock()
+    setup.mission_name = "LADEE"
+    setup.observer = "LADEE"
+    setup.target = "MOON"
+
+    setup.context_products = {
+        "product": [
+            {"@name": "LADEE", "type": "Mission", "lidvid": "urn:nasa:pds:context:investigation:mission.ladee::1.3"},
+            {"@name": "LADEE", "type": "Spacecraft", "lidvid": "urn:nasa:pds:context:instrument_host:spacecraft.ladee::1.2"},
+        ]
+    }
+
+    result = files.get_context_products(setup)
+
+    ladee_entries = [cp for cp in result if cp["name"][0] == "LADEE"]
+    assert len(ladee_entries) == 2
+
+    mission = next(cp for cp in ladee_entries if cp["type"] == ["Mission"])
+    spacecraft = next(cp for cp in ladee_entries if cp["type"] == ["Spacecraft"])
+    assert mission["lidvid"] == "urn:nasa:pds:context:investigation:mission.ladee::1.3"
+    assert spacecraft["lidvid"] == "urn:nasa:pds:context:instrument_host:spacecraft.ladee::1.2"
+
+
+def test_get_context_products_type_match_is_case_insensitive():
+    """Regression test: the registry and configs don't always agree on type
+    casing (e.g. registry stores MOON as 'SATELLITE', configs say
+    'Satellite'). A case-sensitive type match would treat this as no match
+    and append a spurious duplicate entry instead of updating the existing
+    one."""
+    setup = MagicMock()
+    setup.mission_name = "MISSION"
+    setup.observer = "OBSERVER"
+    setup.target = "MOON"
+
+    setup.context_products = {
+        "product": [
+            {"@name": "MOON", "type": "Satellite", "lidvid": "urn:nasa:pds:context:target:satellite.earth.moon::9.9"},
+        ]
+    }
+
+    result = files.get_context_products(setup)
+
+    moon_entries = [cp for cp in result if cp["name"][0] == "MOON"]
+    assert len(moon_entries) == 1
+    assert moon_entries[0]["lidvid"] == "urn:nasa:pds:context:target:satellite.earth.moon::9.9"
+
+
 def test_get_context_products_overwrite_and_append_2(tmp_path):
     """Test get_context_products using pytest. Default products match products via setup.context_products."""
     setup = MagicMock()

--- a/tests/npb/test_utils_files.py
+++ b/tests/npb/test_utils_files.py
@@ -886,6 +886,45 @@ def test_get_context_products_type_match_is_case_insensitive():
     assert moon_entries[0]["lidvid"] == "urn:nasa:pds:context:target:satellite.earth.moon::9.9"
 
 
+def test_get_context_products_override_does_not_corrupt_other_matching_entries():
+    """(name, type) is not a unique key in the registry -- e.g. ULYSSES has both
+    an ESA PSA and a NASA PDS 'Mission' entry with different lidvids. Without a
+    break after the match is applied, the loop keeps scanning and overwrites
+    every registered entry sharing that key, not just the one it matched --
+    silently corrupting the other entry.
+
+    Which of the two registered entries the override lands on depends on their
+    order in the registry file, so this only asserts on the invariant that
+    must hold either way: exactly one of the two originally-registered
+    lidvids must survive untouched. A version of the code without the break
+    overwrites both, leaving zero original lidvids in the result."""
+    setup = MagicMock()
+    setup.mission_name = "ULYSSES"
+    setup.observer = "OBSERVER"
+    setup.target = "TARGET"
+
+    original_lidvids = {
+        "urn:esa:psa:context:investigation:mission.ulysses::1.0",
+        "urn:nasa:pds:context:investigation:mission.ulysses::1.0",
+    }
+    override_lidvid = "urn:nasa:pds:context:investigation:mission.ulysses::9.9"
+
+    setup.context_products = {
+        "product": [
+            {"@name": "ULYSSES", "type": "Mission", "lidvid": override_lidvid},
+        ]
+    }
+
+    result = files.get_context_products(setup)
+
+    mission_entries = [cp for cp in result if cp["name"][0] == "ULYSSES" and cp["type"] == ["Mission"]]
+    assert len(mission_entries) == 2
+
+    lidvids = {cp["lidvid"] for cp in mission_entries}
+    assert override_lidvid in lidvids
+    assert len(lidvids & original_lidvids) == 1
+
+
 def test_get_context_products_overwrite_and_append_2(tmp_path):
     """Test get_context_products using pytest. Default products match products via setup.context_products."""
     setup = MagicMock()

--- a/tests/npb/test_utils_files.py
+++ b/tests/npb/test_utils_files.py
@@ -811,12 +811,12 @@ def test_get_context_products_overwrite_and_append(tmp_path):
     assert obs_prod["lidvid"] == "urn:nasa:pds:context:instrument_host:spacecraft.mars2020::1.3"
 
 
-def test_get_context_products_overwrite_updates_matched_entry(tmp_path):
-    """Regression test for B-08: the override must land on the registered
-    product that actually matches by name, not on an unrelated entry.
-    Uses override values that differ from the registered defaults, so a
-    version of the code that writes to the wrong entry would leave this
-    entry with its stale (pre-override) values and fail the assertions."""
+def test_get_context_products_overwrite_updates_matched_entry():
+    """The override must land on the registered product that actually matches by
+    name, not on an unrelated entry. Uses override values that differ from the
+    registered defaults, so a version of the code that writes to the wrong
+    entry would leave this entry with its stale (pre-override) values and fail
+    the assertions."""
     setup = MagicMock()
     setup.mission_name = "MARS 2020"
     setup.observer = "Perseverance"
@@ -836,10 +836,10 @@ def test_get_context_products_overwrite_updates_matched_entry(tmp_path):
 
 
 def test_get_context_products_same_name_different_type():
-    """Regression test: a mission and its own spacecraft/observer commonly
-    share a name in real configs (e.g. LADEE, MAVEN) but differ in type.
-    Overriding one must not clobber the other -- matching must be keyed on
-    (name, type), not name alone."""
+    """A mission and its own spacecraft/observer commonly share a name in real
+    configs (e.g. LADEE, MAVEN) but differ in type. Overriding one must not
+    clobber the other -- matching must be keyed on (name, type), not name
+    alone."""
     setup = MagicMock()
     setup.mission_name = "LADEE"
     setup.observer = "LADEE"
@@ -864,11 +864,10 @@ def test_get_context_products_same_name_different_type():
 
 
 def test_get_context_products_type_match_is_case_insensitive():
-    """Regression test: the registry and configs don't always agree on type
-    casing (e.g. registry stores MOON as 'SATELLITE', configs say
-    'Satellite'). A case-sensitive type match would treat this as no match
-    and append a spurious duplicate entry instead of updating the existing
-    one."""
+    """The registry and configs don't always agree on type casing (e.g. registry
+    stores MOON as 'SATELLITE', configs say 'Satellite'). A case-sensitive type
+    match would treat this as no match and append a spurious duplicate entry
+    instead of updating the existing one."""
     setup = MagicMock()
     setup.mission_name = "MISSION"
     setup.observer = "OBSERVER"


### PR DESCRIPTION
## 🗒️ Summary
`get_context_products` tracked the matched entry with a manual index counter whose increment statement was disabled, so every config-driven context product update wrote to `context_products[0]` instead of the entry that was actually matched. Replaced the counter with direct mutation of the matched registry entry.

Fixing this exposed a second, related defect: the match only compared `name`, not `type`. Several real mission configs (LADEE, MAVEN, etc.) declare a Mission-type and a Spacecraft-type product sharing the same name, so once writes landed on the correct entry, the last-processed override would silently clobber the other same-named entry. Matching is now keyed on `name` and `type` together, with `type` compared case-insensitively since the registry and configs don't always agree on casing (e.g. registry `SATELLITE` vs. config `Satellite`).

## ⚙️ Test Data and/or Report
Regression tests added in `tests/npb/test_utils_files.py`:
- `test_get_context_products_overwrite_updates_matched_entry` — override lands on the actually-matched entry, not `context_products[0]`.
- `test_get_context_products_same_name_different_type` — a Mission and Spacecraft override sharing a name each update their own entry instead of colliding.
- `test_get_context_products_type_match_is_case_insensitive` — a type-casing mismatch between config and registry still updates in place instead of appending a duplicate.

```
$ pytest tests/npb -q
...
src/pds/naif_pds4_bundler/utils/files.py    417      0   100%
----------------------------------------------------------------------------------------
TOTAL                                       5088    186    96%
1660 passed, 9 skipped, 1 xfailed in 37.74s
```

Also verified against the legacy suite that originally surfaced this as a regression (23 errors, all `RuntimeError: LID has not been obtained for mission <X>` for LADEE/MAVEN):
```
$ coverage run -m unittest discover tests/naif_pds4_bundler
...
Ran 141 tests in 115.319s

OK
```

## ♻️ Related Issues
- Closes #283