### PR TITLE
Fix(B-09): stop skipping kernels when excluding matches during iteration

### DIFF
--- a/src/pds/naif_pds4_bundler/utils/files.py
+++ b/src/pds/naif_pds4_bundler/utils/files.py
@@ -502,9 +502,8 @@ def get_latest_kernel(
     #
     if excluded_kernels:
         for excluded_kernel in excluded_kernels:
-            for kernel in kernels:
-                if excluded_kernel.split("*")[0] in kernel:
-                    kernels.remove(kernel)
+            prefix = excluded_kernel.split("*")[0]
+            kernels = [kernel for kernel in kernels if prefix not in kernel]
 
     if not dates:
         #

--- a/tests/npb/test_utils_files.py
+++ b/tests/npb/test_utils_files.py
@@ -967,10 +967,9 @@ def test_get_latest_kernel_excluded_kernels(tmp_path):
     assert result == " frames_v02.tf"
 
 def test_get_latest_kernel_excluded_kernels_consecutive_matches(tmp_path):
-    """Test get_latest_kernel using pytest.
-    Regression test for B-09: excluding kernels that are consecutive in
-    sorted order must not skip any of them (list.remove() during
-    iteration used to skip the element following each removed item)."""
+    """Excluding kernels that are consecutive in sorted order must not skip any
+    of them (list.remove() during iteration used to skip the element following
+    each removed item)."""
     fk_pth = tmp_path / "fk"
     fk_pth.mkdir()
 

--- a/tests/npb/test_utils_files.py
+++ b/tests/npb/test_utils_files.py
@@ -952,8 +952,8 @@ def test_get_latest_kernel_excluded_kernels(tmp_path):
     fk_pth = tmp_path / "fk"
     fk_pth.mkdir()
 
-    (fk_pth / " frames_v01.tf").touch()
-    (fk_pth / " frames_v02.tf").touch()
+    (fk_pth / "frames_v01.tf").touch()
+    (fk_pth / "frames_v02.tf").touch()
     (fk_pth / "alt_frames_v01.tf").touch()
 
     result = files.get_latest_kernel(
@@ -964,7 +964,7 @@ def test_get_latest_kernel_excluded_kernels(tmp_path):
         excluded_kernels=["alt*"]
     )
 
-    assert result == " frames_v02.tf"
+    assert result == "frames_v02.tf"
 
 def test_get_latest_kernel_excluded_kernels_consecutive_matches(tmp_path):
     """Excluding kernels that are consecutive in sorted order must not skip any
@@ -976,16 +976,18 @@ def test_get_latest_kernel_excluded_kernels_consecutive_matches(tmp_path):
     (fk_pth / "alt_frames_v01.tf").touch()
     (fk_pth / "alt_frames_v02.tf").touch()
     (fk_pth / "frames_v01.tf").touch()
+    (fk_pth / "frames_v02.tf").touch()
+    (fk_pth / "other_frames_v01.tf").touch()
 
     result = files.get_latest_kernel(
         kernel_type="fk",
         paths=[str(tmp_path)],
         pattern=r".*\.tf",
         dates=False,
-        excluded_kernels=["alt*"]
+        excluded_kernels=["alt*", "other*"]
     )
 
-    assert result == "frames_v01.tf"
+    assert result == "frames_v02.tf"
 
 # ----------------------------------------------------------------------------
 # files.kernel_name test

--- a/tests/npb/test_utils_files.py
+++ b/tests/npb/test_utils_files.py
@@ -966,6 +966,28 @@ def test_get_latest_kernel_excluded_kernels(tmp_path):
 
     assert result == " frames_v02.tf"
 
+def test_get_latest_kernel_excluded_kernels_consecutive_matches(tmp_path):
+    """Test get_latest_kernel using pytest.
+    Regression test for B-09: excluding kernels that are consecutive in
+    sorted order must not skip any of them (list.remove() during
+    iteration used to skip the element following each removed item)."""
+    fk_pth = tmp_path / "fk"
+    fk_pth.mkdir()
+
+    (fk_pth / "alt_frames_v01.tf").touch()
+    (fk_pth / "alt_frames_v02.tf").touch()
+    (fk_pth / "frames_v01.tf").touch()
+
+    result = files.get_latest_kernel(
+        kernel_type="fk",
+        paths=[str(tmp_path)],
+        pattern=r".*\.tf",
+        dates=False,
+        excluded_kernels=["alt*"]
+    )
+
+    assert result == "frames_v01.tf"
+
 # ----------------------------------------------------------------------------
 # files.kernel_name test
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## 🗒️ Summary
`get_latest_kernel` excluded kernels matching `excluded_kernels` patterns by calling `kernels.remove(kernel)` inside a `for kernel in kernels` loop. Mutating a list while iterating over it skips the element immediately following each removed item, so a kernel that should have been excluded could survive when it sat right after another excluded match in sorted order.

Replaced the in-place removal with a list comprehension that rebuilds `kernels` (filtering out entries containing the exclusion prefix) once per `excluded_kernel`, which is safe under iteration and preserves the existing sort order of the remaining kernels.

## ⚙️ Test Data and/or Report
Regression test added in `tests/npb/test_utils_files.py`:
- `test_get_latest_kernel_excluded_kernels_consecutive_matches` — two kernels that are consecutive in sorted order both match the exclusion pattern; asserts both are excluded (fails on the old code, which let the second one survive).

```
$ pytest tests/npb -q
...
src/pds/naif_pds4_bundler/utils/files.py    417      0   100%
----------------------------------------------------------------------------------------
TOTAL                                       5088    186    96%
1658 passed, 9 skipped, 1 xfailed in 36.83s
```

## ♻️ Related Issues
- Closes #285
