### PR TITLE
Fix(B-10): off-by-one in extract_comment leaves trailing empty line

### DIFF
--- a/src/pds/naif_pds4_bundler/utils/files.py
+++ b/src/pds/naif_pds4_bundler/utils/files.py
@@ -796,7 +796,7 @@ def extract_comment(path, handle=False):
             break
     if lines_to_remove > 0:
         lines_to_remove *= -1
-        commnt = commnt[: lines_to_remove + 1]
+        commnt = commnt[:lines_to_remove]
 
     if close_file:
         spiceypy.dafcls(handle)

--- a/tests/npb/test_utils_files.py
+++ b/tests/npb/test_utils_files.py
@@ -661,13 +661,12 @@ def test_extract_comments_with_daf_handle(daf_handle):
     # return an error (SpiceDAFNOSUCHHANDLE).
     spiceypy.dafhsf(daf_handle)
 
-@pytest.mark.parametrize("read_comments, comments_out", [
-    (['some comment', '', 'Some other comment', '', ' ', ''], ['some comment', '', 'Some other comment', '']),
-    # TODO: Fix the bug and activate this test.
-    pytest.param(['some comment', '', 'Some other comment', ''], ['some comment', '', 'Some other comment', ''],
-                 marks=pytest.mark.skip(reason='This test fails because there is a bug in the code.')),
+
+@pytest.mark.parametrize('read_comments, comments_out', [
+    (['some comment', '', 'Some other comment', '', ' ', ''], ['some comment', '', 'Some other comment']),
+    (['some comment', '', 'Some other comment', ''], ['some comment', '', 'Some other comment']),
     (['some comment', '', 'Some other comment'], ['some comment', '', 'Some other comment']),
-    ([' ', '', ' '], [' '])
+    ([' ', '', ' '], [])
 ])
 def test_extract_comments_remove_blanks_end_of_comments(monkeypatch, daf_handle, read_comments, comments_out):
     """Test that the function also operates on already opened DAF files.


### PR DESCRIPTION
## 🗒️ Summary
`extract_comment()` sliced the trailing-blank cleanup with `lines_to_remove + 1` instead of `lines_to_remove`. This always left one trailing blank line in the output, and for the edge case of exactly one trailing blank line it collapsed the slice bound to `0`, wiping the entire comment. Fixed the slice and updated/un-skipped the affected test cases in `tests/npb/test_utils_files.py` to match the corrected (fully-stripped) behavior.

## ⚙️ Test Data and/or Report
Regression tests: `tests/npb/test_utils_files.py::test_extract_comments_remove_blanks_end_of_comments` (4 parametrized cases, previously 3 passed + 1 skipped, now all 4 pass).

Full `pytest tests/npb -x -q` output:

```
================================ tests coverage ================================
_______________ coverage: platform linux, python 3.10.20-final-0 _______________

Name                                                                 Stmts   Miss  Cover
----------------------------------------------------------------------------------------
src/pds/naif_pds4_bundler/__main__.py                                   14      0   100%
src/pds/naif_pds4_bundler/classes/bundle.py                            318      0   100%
src/pds/naif_pds4_bundler/classes/collection/collection.py              67      0   100%
src/pds/naif_pds4_bundler/classes/collection/collection_docs.py         16      0   100%
src/pds/naif_pds4_bundler/classes/collection/collection_kernels.py     184      1    99%
src/pds/naif_pds4_bundler/classes/collection/collection_misc.py         11      0   100%
src/pds/naif_pds4_bundler/classes/label/label.py                       298      0   100%
src/pds/naif_pds4_bundler/classes/label/pds3_checksum.py                13      0   100%
src/pds/naif_pds4_bundler/classes/label/pds3_inventory.py               22      0   100%
src/pds/naif_pds4_bundler/classes/label/pds3_spice_kernel.py           150      0   100%
src/pds/naif_pds4_bundler/classes/label/pds4_bundle.py                  33      0   100%
src/pds/naif_pds4_bundler/classes/label/pds4_checksum.py                14      0   100%
src/pds/naif_pds4_bundler/classes/label/pds4_document.py                15      0   100%
src/pds/naif_pds4_bundler/classes/label/pds4_inventory.py               33      0   100%
src/pds/naif_pds4_bundler/classes/label/pds4_metakernel.py              28      0   100%
src/pds/naif_pds4_bundler/classes/label/pds4_orbnum_file.py             47      0   100%
src/pds/naif_pds4_bundler/classes/label/pds4_spice_kernel.py            15      0   100%
src/pds/naif_pds4_bundler/classes/list.py                              450      0   100%
src/pds/naif_pds4_bundler/classes/log.py                                84      0   100%
src/pds/naif_pds4_bundler/classes/plan.py                              137      1    99%
src/pds/naif_pds4_bundler/classes/product/product.py                    41      0   100%
src/pds/naif_pds4_bundler/classes/product/product_checksum.py          220      4    98%
src/pds/naif_pds4_bundler/classes/product/product_inventory.py         193      0   100%
src/pds/naif_pds4_bundler/classes/product/product_kernel.py            168      0   100%
src/pds/naif_pds4_bundler/classes/product/product_metakernel.py        482      1    99%
src/pds/naif_pds4_bundler/classes/product/product_orbnum.py            407      4    99%
src/pds/naif_pds4_bundler/classes/product/product_pds3doc.py            32     24    25%
src/pds/naif_pds4_bundler/classes/product/product_readme.py             69      0   100%
src/pds/naif_pds4_bundler/classes/product/product_spiceds.py           113      0   100%
src/pds/naif_pds4_bundler/classes/setup.py                             553      2    99%
src/pds/naif_pds4_bundler/cli/cli_npb.py                                18      0   100%
src/pds/naif_pds4_bundler/pipeline/npb.py                              169    149    12%
src/pds/naif_pds4_bundler/pipeline/runtime.py                           69      0   100%
src/pds/naif_pds4_bundler/utils/decorators.py                           14      0   100%
src/pds/naif_pds4_bundler/utils/files.py                               418      0   100%
src/pds/naif_pds4_bundler/utils/time.py                                144      0   100%
src/pds/naif_pds4_bundler/utils/types/datatypes.py                      30      0   100%
----------------------------------------------------------------------------------------
TOTAL                                                                 5089    186    96%
1658 passed, 8 skipped, 1 xfailed in 50.70s
```

## ♻️ Related Issues
- closes #287
