### PR TITLE
Add NPBError exception class

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/exceptions.py
+++ b/src/pds/naif_pds4_bundler/classes/exceptions.py
@@ -2,4 +2,4 @@
 
 
 class NPBError(RuntimeError):
-    """Unrecoverable error during NPB product or label processing."""
+    """Unrecoverable error during NPB execution."""

--- a/src/pds/naif_pds4_bundler/classes/exceptions.py
+++ b/src/pds/naif_pds4_bundler/classes/exceptions.py
@@ -1,0 +1,5 @@
+"""Implementation of the NPBError exception class."""
+
+
+class NPBError(RuntimeError):
+    """Unrecoverable error during NPB product or label processing."""

--- a/tests/npb/test_classes_exceptions.py
+++ b/tests/npb/test_classes_exceptions.py
@@ -1,0 +1,18 @@
+"""Tests for NPBError exception class."""
+import pytest
+
+from pds.naif_pds4_bundler.classes.exceptions import NPBError
+
+
+def test_npberror_is_runtime_error():
+    assert issubclass(NPBError, RuntimeError)
+
+
+def test_npberror_message():
+    exc = NPBError("something went wrong")
+    assert str(exc) == "something went wrong"
+
+
+def test_npberror_can_be_raised_and_caught():
+    with pytest.raises(NPBError, match="something went wrong"):
+        raise NPBError("something went wrong")


### PR DESCRIPTION
## 🗒️ Summary
Adds `NPBError(RuntimeError)` in a new `classes/exceptions.py` module, a domain-layer exception products can raise instead of calling `handle_npb_error()` directly from `pipeline.runtime`. Purely additive — no existing files modified.

## ⚙️ Test Data and/or Report
Regression tests included: `tests/npb/test_classes_exceptions.py` (3 tests,
100% branch coverage of the new module).

    tests/npb/test_classes_exceptions.py::test_npberror_is_runtime_error PASSED
    tests/npb/test_classes_exceptions.py::test_npberror_message PASSED
    tests/npb/test_classes_exceptions.py::test_npberror_can_be_raised_and_caught PASSED
    3 passed in 2.07s

    Name                                              Stmts   Miss Branch BrPart  Cover
    -----------------------------------------------------------------------------------
    src/pds/naif_pds4_bundler/classes/exceptions.py       1      0      0      0   100%
    -----------------------------------------------------------------------------------
    TOTAL                                                 1      0      0      0   100%

    Full merge-gate suite (pytest tests/npb/ -v --cov-branch):
    1662 passed, 8 skipped, 1 xfailed

## ♻️ Related Issues
fixes #290