### PR TITLE
Migrate product files to raise NPBError; wrap constructions in npb.py

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/product/product_checksum.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_checksum.py
@@ -9,7 +9,7 @@ from typing import Optional
 from .product import Product
 from ..label import ChecksumPDS3Label
 from ..label import ChecksumPDS4Label
-from ...pipeline.runtime import handle_npb_error
+from ..exceptions import NPBError
 from ...utils import add_carriage_return
 from ...utils import checksum_from_label
 from ...utils import checksum_from_registry
@@ -204,18 +204,16 @@ class ChecksumProduct(Product):
                     try:
                         (md5_file, filename) = line.split()
                     except BaseException:
-                        handle_npb_error(
-                            f"Checksum file {self.path_current} is corrupted.",
-                            setup=self.setup,
+                        raise NPBError(
+                            f"Checksum file {self.path_current} is corrupted."
                         )
 
                     if len(md5_file) == 32:
                         self.md5_dict[filename] = md5_file
                     else:
-                        handle_npb_error(
+                        raise NPBError(
                             f"Checksum file {self.path_current} "
-                            f"corrupted entry: {line}.",
-                            setup=self.setup,
+                            f"corrupted entry: {line}."
                         )
 
             #
@@ -304,7 +302,7 @@ class ChecksumProduct(Product):
                                 f"the product {product_name} might be a duplicate."
                             )
                             if not self.setup.args.debug:
-                                handle_npb_error(msg)
+                                raise NPBError(msg)
                             else:
                                 logging.debug(msg)
                         self.md5_dict[product_name] = product.checksum

--- a/src/pds/naif_pds4_bundler/classes/product/product_checksum.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_checksum.py
@@ -7,9 +7,9 @@ from pathlib import Path
 from typing import Optional
 
 from .product import Product
+from ..exceptions import NPBError
 from ..label import ChecksumPDS3Label
 from ..label import ChecksumPDS4Label
-from ..exceptions import NPBError
 from ...utils import add_carriage_return
 from ...utils import checksum_from_label
 from ...utils import checksum_from_registry

--- a/src/pds/naif_pds4_bundler/classes/product/product_inventory.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_inventory.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 
 from .product import Product
-from ...pipeline.runtime import handle_npb_error
+from ..exceptions import NPBError
 from ...utils import add_carriage_return
 from ...utils import compare_files
 from ...utils import replace_string_in_file
@@ -285,7 +285,7 @@ class InventoryProduct(Product):
             # Bytes of each column is necessary to write the index label.
             #
             if not line_for_length:
-                handle_npb_error(
+                raise NPBError(
                     "The index file is incomplete since no binary "
                     "kernel is present in the archive."
                 )

--- a/src/pds/naif_pds4_bundler/classes/product/product_kernel.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_kernel.py
@@ -6,7 +6,7 @@ import shutil
 import spiceypy
 
 from .product import Product
-from ...pipeline.runtime import handle_npb_error
+from ..exceptions import NPBError
 from ...utils import ck_coverage
 from ...utils import dsk_coverage
 from ...utils import extension_to_type
@@ -122,7 +122,7 @@ class SpiceKernelProduct(Product):
             # If after the two loops the file is not present raise an error.
             #
             if not origin_path:
-                handle_npb_error(f"{self.name} not present in {directory}.", setup=setup)
+                raise NPBError(f"{self.name} not present in {directory}.")
 
             shutil.copy2(origin_path, product_path + os.sep + self.name)
 
@@ -212,9 +212,8 @@ class SpiceKernelProduct(Product):
                     break
 
         if not description:
-            handle_npb_error(
-                f"{self.name} does not have a DESCRIPTION on {kernel_list_file}.",
-                setup=self.setup,
+            raise NPBError(
+                f"{self.name} does not have a DESCRIPTION on {kernel_list_file}."
             )
 
         return description
@@ -246,9 +245,8 @@ class SpiceKernelProduct(Product):
                     get_token = False
 
         if not maklabel_options:
-            handle_npb_error(
-                f"{self.name} does not have a MAKLABEL_OPTIONS on {kernel_list_file}.",
-                setup=self.setup,
+            raise NPBError(
+                f"{self.name} does not have a MAKLABEL_OPTIONS on {kernel_list_file}."
             )
 
         return maklabel_options

--- a/src/pds/naif_pds4_bundler/classes/product/product_metakernel.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_metakernel.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import spiceypy
 
 from .product import Product
-from ...pipeline.runtime import handle_npb_error
+from ..exceptions import NPBError
 from ...utils import check_line_length
 from ...utils import ck_coverage
 from ...utils import compare_files
@@ -100,9 +100,8 @@ class MetaKernelProduct(Product):
                 pass
 
         if not hasattr(self, "mk_setup"):
-            handle_npb_error(
-                f"Meta-kernel {self.name} has not been matched in configuration.",
-                setup=self.setup,
+            raise NPBError(
+                f"Meta-kernel {self.name} has not been matched in configuration."
             )
 
         if setup.pds_version == "3":
@@ -325,10 +324,9 @@ class MetaKernelProduct(Product):
             # Implement this exceptional check for first releases of an archive.
             #
             if "01" not in self.name:
-                handle_npb_error(
+                raise NPBError(
                     f"{self.name} version does not correspond to VID "
-                    f"1.0. Rename the MK accordingly.",
-                    setup=self.setup,
+                    f"1.0. Rename the MK accordingly."
                 )
 
         self.vid = product_vid
@@ -421,14 +419,13 @@ class MetaKernelProduct(Product):
                                         #
                                         patterns[el]["&value"] = value
                                 else:
-                                    handle_npb_error(
+                                    raise NPBError(
                                         f"Kernel pattern {patt_ker} "
                                         f"not adept to write "
                                         f"description. Remember a "
                                         f"metacharacter "
                                         f"cannot start or finish "
-                                        f"a kernel pattern.",
-                                        setup=self.setup,
+                                        f"a kernel pattern."
                                     )
                             else:
                                 #
@@ -450,11 +447,10 @@ class MetaKernelProduct(Product):
 
                                 # TODO: Review.
                                 if isinstance(value, list):
-                                    handle_npb_error(
+                                    raise NPBError(
                                         f"-- Kernel description "
                                         f"could not be updated with "
-                                        f"pattern: {value}.",
-                                        setup=self.setup,
+                                        f"pattern: {value}."
                                     )
 
                             description = description.replace("$" + el, value)
@@ -464,9 +460,8 @@ class MetaKernelProduct(Product):
             description = description.replace("  ", " ")
 
         if not description:
-            handle_npb_error(
-                f"{self.name} does not have a description on configuration file.",
-                setup=self.setup,
+            raise NPBError(
+                f"{self.name} does not have a description on configuration file."
             )
 
         return description
@@ -477,7 +472,7 @@ class MetaKernelProduct(Product):
         # Obtain meta-kernel grammar from configuration.
         #
         if "grammar" not in self.mk_setup:
-            handle_npb_error(
+            raise NPBError(
                 f"Meta-kernel grammar not defined in configuration for {self.name}"
             )
         kernel_grammar_list = self.mk_setup["grammar"]["pattern"]
@@ -964,11 +959,10 @@ class MetaKernelProduct(Product):
                         elif extension_to_type(kernel) == "ck":
                             (start_time, stop_time) = ck_coverage(path)
                         else:
-                            handle_npb_error(
+                            raise NPBError(
                                 "Kernel used to determine "
                                 "coverage is not a SPK or CK "
-                                "kernel.",
-                                setup=self.setup,
+                                "kernel."
                             )
 
                         start_times.append(spiceypy.utc2et(start_time[:-1]))

--- a/src/pds/naif_pds4_bundler/classes/product/product_orbnum.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_orbnum.py
@@ -7,7 +7,7 @@ import shutil
 from typing import List
 
 from .product import Product
-from ...pipeline.runtime import handle_npb_error
+from ..exceptions import NPBError
 from ...utils.time import parse_date
 from ...utils import add_crs_to_file
 from ...utils import check_eol
@@ -54,10 +54,9 @@ class OrbnumFileProduct(Product):
                 self._pattern = orbnum_type["pattern"]
 
         if not hasattr(self, "_orbnum_type"):
-            handle_npb_error(
+            raise NPBError(
                 "The orbnum file does not match any type "
-                "described in the configuration.",
-                setup=self.setup,
+                "described in the configuration."
             )
 
         if self.setup.pds_version == "4":
@@ -252,15 +251,13 @@ class OrbnumFileProduct(Product):
         # for Descending and Ascending node events (Odyssey).
         #
         if ("Event" not in header[0]) and ("Node" not in header[0]):
-            handle_npb_error(
-                f"The header of the orbnum file {self.name} is not as expected.",
-                setup=self.setup,
+            raise NPBError(
+                f"The header of the orbnum file {self.name} is not as expected."
             )
 
         if "===" not in header[1]:
-            handle_npb_error(
-                f"The header of the orbnum file {self.name} is not as expected.",
-                setup=self.setup,
+            raise NPBError(
+                f"The header of the orbnum file {self.name} is not as expected."
             )
 
         #
@@ -319,7 +316,7 @@ class OrbnumFileProduct(Product):
                         break
 
         if not sample_record:
-            handle_npb_error("The orbnum file has no records.", setup=self.setup)
+            raise NPBError("The orbnum file has no records.")
 
         sample_record = self.utc_blanks_to_dashes(sample_record)
 
@@ -384,9 +381,8 @@ class OrbnumFileProduct(Product):
                     #       orbit_number = int(line.split()[0]). If the line is is blank
                     #       that statement will raise an IndexError.
                     if not line.strip():
-                        handle_npb_error(
-                            f"Orbnum record number {line} is blank.",
-                            setup=self.setup,
+                        raise NPBError(
+                            f"Orbnum record number {line} is blank."
                         )
                     elif (
                             line.strip() and records_length != self.record_fixed_length
@@ -399,7 +395,7 @@ class OrbnumFileProduct(Product):
                         blank_records.append(str(orbit_number))
 
                     # TODO: Fix. This line will always be True, otherwise the code
-                    #       would have raised an IndexError or executed `handle_npb_error`.
+                    #       would have raised an IndexError or executed `NPBError`.
                     if line.strip():
                         records += 1
 
@@ -549,7 +545,7 @@ class OrbnumFileProduct(Product):
                     self._event_detection_key = "D-NODE"
 
         if not hasattr(self, "_event_detection_key"):
-            handle_npb_error("orbnum event detection key is incorrect.", setup=self.setup)
+            raise NPBError("orbnum event detection key is incorrect.")
 
     # TODO: Is this method really needed?
     @staticmethod
@@ -885,7 +881,7 @@ class OrbnumFileProduct(Product):
                 # TODO: Remove `else` block: dead-code. The 'type' key in the hardcoded
                 #       dictionary has only three values.
                 else:
-                    handle_npb_error("Parameter type for ORBNUM file is incorrect.")
+                    raise NPBError("Parameter type for ORBNUM file is incorrect.")
             else:
                 if "ASCII_Real" in params_template[param]["type"]:
                     ascii_format = "F" + length + "." + param_length
@@ -897,7 +893,7 @@ class OrbnumFileProduct(Product):
 
                     # TODO: Remove `else` block: dead-code. The 'type' key in the hardcoded
                     #       dictionary has only three values.
-                    handle_npb_error("Parameter type for ORBNUM file is incorrect.")
+                    raise NPBError("Parameter type for ORBNUM file is incorrect.")
 
             #
             # Parameter number (column number)

--- a/src/pds/naif_pds4_bundler/classes/product/product_readme.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_readme.py
@@ -5,10 +5,10 @@ import shutil
 from types import SimpleNamespace
 
 from .product import Product
+from ..exceptions import NPBError
+from ..label import BundlePDS4Label
 from ...utils import add_carriage_return
 from ...utils import md5
-from ..label import BundlePDS4Label
-from ..exceptions import NPBError
 
 
 class ReadmeProduct(Product):

--- a/src/pds/naif_pds4_bundler/classes/product/product_readme.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_readme.py
@@ -8,7 +8,7 @@ from .product import Product
 from ...utils import add_carriage_return
 from ...utils import md5
 from ..label import BundlePDS4Label
-from ...pipeline.runtime import handle_npb_error
+from ..exceptions import NPBError
 
 
 class ReadmeProduct(Product):
@@ -73,7 +73,7 @@ class ReadmeProduct(Product):
             if os.path.exists(self.setup.readme["input"]):
                 shutil.copy(self.setup.readme["input"], self.path)
             else:
-                handle_npb_error("Readme file provided via configuration does not exist.")
+                raise NPBError("Readme file provided via configuration does not exist.")
         elif not os.path.isfile(self.path):
             with open(self.path, "w+", encoding='utf-8') as f:
                 with open(

--- a/src/pds/naif_pds4_bundler/classes/product/product_spiceds.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_spiceds.py
@@ -8,7 +8,7 @@ import shutil
 from datetime import date
 
 from .product import Product
-from ...pipeline.runtime import handle_npb_error
+from ..exceptions import NPBError
 from ...utils import add_carriage_return
 from ...utils import compare_files
 from ..label import DocumentPDS4Label
@@ -65,17 +65,9 @@ class SpicedsProduct(Product):
             except BaseException:
                 logging.warning("-- No previous version of spiceds_v*.html file found.")
                 if not spiceds:
-                    # TODO: BUG; handle_npb_error is annotated NoReturn but
-                    #      nothing in this code enforces that contract. If it
-                    #      were ever changed to return silently, execution would
-                    #      fall through to self.version = 1 and then
-                    #      shutil.copy2(spiceds='', ...) below, crashing with a
-                    #      confusing FileNotFoundError instead of the intended
-                    #      error message.
-                    handle_npb_error(
+                    raise NPBError(
                         "spiceds not provided and not available "
-                        "from previous releases.",
-                        setup=self.setup,
+                        "from previous releases."
                     )
                 self.version = 1
                 self.latest_spiceds = ""
@@ -83,9 +75,8 @@ class SpicedsProduct(Product):
             self.version = 1
             self.latest_spiceds = ""
             if not spiceds:
-                handle_npb_error(
-                    "spiceds not provided and not available from previous releases.",
-                    setup=self.setup,
+                raise NPBError(
+                    "spiceds not provided and not available from previous releases."
                 )
 
         #

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -396,7 +396,10 @@ def run_pipeline(args: PipelineArgs) -> None:
                         )
                     except NPBError as exc:
                         handle_npb_error(str(exc), setup=setup)
-                    release_checksum.generate(history=release)
+                    try:
+                        release_checksum.generate(history=release)
+                    except NPBError as exc:
+                        handle_npb_error(str(exc), setup=setup)
 
                     #
                     # Initialize a miscellaneous collection for this previous
@@ -474,7 +477,10 @@ def run_pipeline(args: PipelineArgs) -> None:
         miscellaneous_collection.add(checksum)
         miscellaneous_collection.set_collection_vid()
 
-        checksum.set_coverage()
+        try:
+            checksum.set_coverage()
+        except NPBError as exc:
+            handle_npb_error(str(exc), setup=setup)
 
         # The miscellaneous_collection name is "miscellaneous" (PDS4 branch),
         # therefore, we do not log the step, as we do every other time we
@@ -502,7 +508,10 @@ def run_pipeline(args: PipelineArgs) -> None:
         #   checksum and the checksum includes the md5 hash of the
         #   Miscellaneous Collection Inventory.
         #
-        checksum.generate()
+        try:
+            checksum.generate()
+        except NPBError as exc:
+            handle_npb_error(str(exc), setup=setup)
         miscellaneous_collection.add(checksum)
 
     else:  # if setup.pds_version == "3":
@@ -523,7 +532,10 @@ def run_pipeline(args: PipelineArgs) -> None:
             )
         except NPBError as exc:
             handle_npb_error(str(exc), setup=setup)
-        checksum.generate()
+        try:
+            checksum.generate()
+        except NPBError as exc:
+            handle_npb_error(str(exc), setup=setup)
         miscellaneous_collection.add(checksum)
 
     #

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -3,12 +3,13 @@
 from os.path import isdir
 from pathlib import Path
 
-from .runtime import clear_run, finish_execution, log_step
+from .runtime import clear_run, finish_execution, handle_npb_error, log_step
 from .. import __version__
 from ..classes.bundle import Bundle
 from ..classes.collection import DocumentCollection
 from ..classes.collection import MiscellaneousCollection
 from ..classes.collection import SpiceKernelsCollection
+from ..classes.exceptions import NPBError
 from ..classes.list import KernelList
 from ..classes.log import Log
 from ..classes.plan import ReleasePlan
@@ -235,15 +236,21 @@ def run_pipeline(args: PipelineArgs) -> None:
             # because it might require to update the kernel list if the
             # orbnum file name is updated.
             #
-            miscellaneous_collection.add(
-                OrbnumFileProduct(
-                    setup, kernel, miscellaneous_collection, spice_kernels_collection
+            try:
+                miscellaneous_collection.add(
+                    OrbnumFileProduct(
+                        setup, kernel, miscellaneous_collection, spice_kernels_collection
+                    )
                 )
-            )
+            except NPBError as exc:
+                handle_npb_error(str(exc), setup=setup)
         elif ".tm" not in kernel.lower():
-            spice_kernels_collection.add(
-                SpiceKernelProduct(setup, kernel, spice_kernels_collection)
-            )
+            try:
+                spice_kernels_collection.add(
+                    SpiceKernelProduct(setup, kernel, spice_kernels_collection)
+                )
+            except NPBError as exc:
+                handle_npb_error(str(exc), setup=setup)
 
     #
     # * Generate the Meta-kernel(s).
@@ -252,9 +259,12 @@ def run_pipeline(args: PipelineArgs) -> None:
     meta_kernels = spice_kernels_collection.determine_meta_kernels()
     if meta_kernels:
         for mk in sorted(meta_kernels):
-            meta_kernel = MetaKernelProduct(
-                setup, mk, spice_kernels_collection, user_input=meta_kernels[mk]
-            )
+            try:
+                meta_kernel = MetaKernelProduct(
+                    setup, mk, spice_kernels_collection, user_input=meta_kernels[mk]
+                )
+            except NPBError as exc:
+                handle_npb_error(str(exc), setup=setup)
             if setup.pds_version == "4":
                 spice_kernels_collection.add(meta_kernel)
             else:
@@ -312,9 +322,12 @@ def run_pipeline(args: PipelineArgs) -> None:
             spice_kernels_collection.set_collection_vid()
 
         log_step(setup, title=f'Generation of {spice_kernels_collection.name} collection')
-        spice_kernels_collection_inventory = InventoryProduct(
-            setup, spice_kernels_collection
-        )
+        try:
+            spice_kernels_collection_inventory = InventoryProduct(
+                setup, spice_kernels_collection
+            )
+        except NPBError as exc:
+            handle_npb_error(str(exc), setup=setup)
         spice_kernels_collection.add(spice_kernels_collection_inventory)
 
     if setup.pds_version == "4":
@@ -328,7 +341,10 @@ def run_pipeline(args: PipelineArgs) -> None:
         # * Generate of SPICEDS document.
         #
         log_step(setup, title='Processing spiceds file')
-        spiceds = SpicedsProduct(setup, document_collection)
+        try:
+            spiceds = SpicedsProduct(setup, document_collection)
+        except NPBError as exc:
+            handle_npb_error(str(exc), setup=setup)
 
         #
         # * If the SPICEDS document is generated, generate the
@@ -340,7 +356,10 @@ def run_pipeline(args: PipelineArgs) -> None:
             document_collection.set_collection_vid()
 
             log_step(setup, title=f'Generation of {document_collection.name} collection')
-            document_collection_inventory = InventoryProduct(setup, document_collection)
+            try:
+                document_collection_inventory = InventoryProduct(setup, document_collection)
+            except NPBError as exc:
+                handle_npb_error(str(exc), setup=setup)
             document_collection.add(document_collection_inventory)
 
         #
@@ -371,9 +390,12 @@ def run_pipeline(args: PipelineArgs) -> None:
             if not isdir(checksum_dir):
                 for release in bundle.history.items():
                     log_step(setup, title='Generate checksum file')
-                    release_checksum = ChecksumProduct(
-                        setup, miscellaneous_collection, add_previous_checksum=False
-                    )
+                    try:
+                        release_checksum = ChecksumProduct(
+                            setup, miscellaneous_collection, add_previous_checksum=False
+                        )
+                    except NPBError as exc:
+                        handle_npb_error(str(exc), setup=setup)
                     release_checksum.generate(history=release)
 
                     #
@@ -399,9 +421,12 @@ def run_pipeline(args: PipelineArgs) -> None:
                     # The release_miscellaneous_collection name is "miscellaneous"
                     # (PDS4 branch), therefore, we do not log the step, as we do
                     # every other time we generate an InventoryProduct.
-                    release_miscellaneous_collection_inventory = InventoryProduct(
-                        setup, release_miscellaneous_collection
-                    )
+                    try:
+                        release_miscellaneous_collection_inventory = InventoryProduct(
+                            setup, release_miscellaneous_collection
+                        )
+                    except NPBError as exc:
+                        handle_npb_error(str(exc), setup=setup)
 
                     release_miscellaneous_collection.add(
                         release_miscellaneous_collection_inventory
@@ -433,7 +458,10 @@ def run_pipeline(args: PipelineArgs) -> None:
         #      updated.
         #
         log_step(setup, title='Generate checksum file')
-        checksum = ChecksumProduct(setup, miscellaneous_collection)
+        try:
+            checksum = ChecksumProduct(setup, miscellaneous_collection)
+        except NPBError as exc:
+            handle_npb_error(str(exc), setup=setup)
 
         #
         # Before adding the checksum to the current collection
@@ -451,16 +479,22 @@ def run_pipeline(args: PipelineArgs) -> None:
         # The miscellaneous_collection name is "miscellaneous" (PDS4 branch),
         # therefore, we do not log the step, as we do every other time we
         # generate an InventoryProduct.
-        miscellaneous_collection_inventory = InventoryProduct(
-            setup, miscellaneous_collection
-        )
+        try:
+            miscellaneous_collection_inventory = InventoryProduct(
+                setup, miscellaneous_collection
+            )
+        except NPBError as exc:
+            handle_npb_error(str(exc), setup=setup)
         miscellaneous_collection.add(miscellaneous_collection_inventory)
 
         #
         # * Generate the Bundle label and if necessary the readme file.
         #
         log_step(setup, title='Generation of bundle products')
-        bundle.readme = ReadmeProduct(setup, bundle)
+        try:
+            bundle.readme = ReadmeProduct(setup, bundle)
+        except NPBError as exc:
+            handle_npb_error(str(exc), setup=setup)
 
         #
         # * Generate the Checksum product a posteriori in such a way
@@ -483,9 +517,12 @@ def run_pipeline(args: PipelineArgs) -> None:
         bundle.add(miscellaneous_collection)
 
         log_step(setup, title='Generate checksum file')
-        checksum = ChecksumProduct(
-            setup, miscellaneous_collection, add_previous_checksum=False
-        )
+        try:
+            checksum = ChecksumProduct(
+                setup, miscellaneous_collection, add_previous_checksum=False
+            )
+        except NPBError as exc:
+            handle_npb_error(str(exc), setup=setup)
         checksum.generate()
         miscellaneous_collection.add(checksum)
 

--- a/tests/npb/test_classes_product_checksum.py
+++ b/tests/npb/test_classes_product_checksum.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 
 from pds.naif_pds4_bundler.classes.product.product_checksum import ChecksumProduct
+from pds.naif_pds4_bundler.classes.exceptions import NPBError
 
 # ---------------------------------------------------------------------------
 # Helpers / shared fixtures
@@ -47,7 +48,6 @@ MOD = "pds.naif_pds4_bundler.classes.product.product_checksum"
 PATCHES = dict(
     safe_make_directory=f"{MOD}.safe_make_directory",
     glob_glob=f"{MOD}.glob.glob",
-    handle_npb_error=f"{MOD}.handle_npb_error",
     md5=f"{MOD}.md5",
     checksum_from_registry=f"{MOD}.checksum_from_registry",
     checksum_from_label=f"{MOD}.checksum_from_label",
@@ -91,7 +91,6 @@ def _build_pds4(
 
     with patch(PATCHES["safe_make_directory"]) as m_mkdir, \
          patch(PATCHES["glob_glob"]) as m_glob, \
-         patch(PATCHES["handle_npb_error"]) as m_err, \
          patch(PATCHES["md5"], return_value="a" * 32) as m_md5, \
          patch(PATCHES["os_walk"], return_value=[]) as m_walk, \
          patch("builtins.open", mock_open(read_data="")) as m_open:
@@ -100,7 +99,7 @@ def _build_pds4(
 
         obj = ChecksumProduct(setup, collection, add_previous_checksum)
         mocks.update(dict(
-            mkdir=m_mkdir, glob=m_glob, err=m_err, md5=m_md5,
+            mkdir=m_mkdir, glob=m_glob, md5=m_md5,
             walk=m_walk, open=m_open,
         ))
 
@@ -115,7 +114,6 @@ def _build_pds3(add_previous_checksum=False):
 
     with patch(PATCHES["safe_make_directory"]), \
          patch(PATCHES["glob_glob"], return_value=[]), \
-         patch(PATCHES["handle_npb_error"]), \
          patch(PATCHES["md5"], return_value="b" * 32), \
          patch(PATCHES["os_walk"], return_value=[]), \
          patch("builtins.open", mock_open(read_data="")):
@@ -171,7 +169,6 @@ class TestChecksumProductInit:
 
         with patch(PATCHES["safe_make_directory"]) as m_mkdir, \
              patch(PATCHES["glob_glob"], return_value=[]), \
-             patch(PATCHES["handle_npb_error"]), \
              patch(PATCHES["md5"], return_value="a" * 32), \
              patch(PATCHES["os_walk"], return_value=[]), \
              patch("builtins.open", mock_open(read_data="")):
@@ -187,7 +184,6 @@ class TestChecksumProductInit:
 
         with patch(PATCHES["safe_make_directory"]) as m_mkdir, \
              patch(PATCHES["glob_glob"], return_value=[]), \
-             patch(PATCHES["handle_npb_error"]), \
              patch(PATCHES["md5"], return_value="b" * 32), \
              patch(PATCHES["os_walk"], return_value=[]), \
              patch("builtins.open", mock_open(read_data="")):
@@ -234,7 +230,6 @@ class TestReadCurrentProduct:
 
         with patch(PATCHES["safe_make_directory"]), \
              patch(PATCHES["glob_glob"], return_value=[prev]), \
-             patch(PATCHES["handle_npb_error"]), \
              patch(PATCHES["md5"], return_value="c" * 32), \
              patch(PATCHES["os_walk"], return_value=[]), \
              patch("builtins.open", mock_open(read_data=prev_content)):
@@ -251,7 +246,7 @@ class TestReadCurrentProduct:
          'Checksum file /bundle/em16_spice/miscellaneous/checksum/checksum_v001.tab '
          'corrupted entry: 0123456789  some/file.tab\n.')
     ])
-    def test_corrupted_line_calls_handle_npb_error(self, bad_content, error) -> None:
+    def test_corrupted_line_raises_npberror(self, bad_content, error) -> None:
 
         setup = _make_setup(pds_version="4", increment=True)
         collection = _make_collection()
@@ -263,7 +258,7 @@ class TestReadCurrentProduct:
              patch(PATCHES["os_walk"], return_value=[]), \
              patch("builtins.open", mock_open(read_data=bad_content)):
 
-            with pytest.raises(RuntimeError, match=error):
+            with pytest.raises(NPBError, match=error):
                 ChecksumProduct(setup, collection, add_previous_checksum=False)
 
     def test_add_previous_checksum_true_adds_file_and_label_pds4(self):
@@ -275,7 +270,6 @@ class TestReadCurrentProduct:
 
         with patch(PATCHES["safe_make_directory"]), \
              patch(PATCHES["glob_glob"], return_value=[prev]), \
-             patch(PATCHES["handle_npb_error"]), \
              patch(PATCHES["md5"], return_value="d" * 32), \
              patch(PATCHES["os_walk"], return_value=[]), \
              patch("builtins.open", mock_open(read_data=prev_content)):
@@ -302,7 +296,6 @@ class TestReadCurrentProduct:
         # We supply valid content for that file via mock_open.
         with patch(PATCHES["safe_make_directory"]), \
              patch(PATCHES["glob_glob"], return_value=[]), \
-             patch(PATCHES["handle_npb_error"]), \
              patch(PATCHES["md5"], return_value="e" * 32), \
              patch(PATCHES["os_walk"], return_value=[]), \
              patch("builtins.open", mock_open(read_data=prev_content)):
@@ -606,7 +599,7 @@ class TestChecksumProductWriteProduct:
             obj.write_product(history=None, set_coverage=False)
 
     @pytest.mark.skip(reason="Fails due to bug in code. When fixed, the test should be executed.")
-    def test_write_product_duplicate_md5_non_debug_calls_handle_npb_error(self):
+    def test_write_product_duplicate_md5_non_debug_raises_npberror(self):
         obj = self._obj_with_products()
         obj.setup.args.debug = False
         obj.md5_dict["other/different_name.tab"] = "f" * 32
@@ -616,9 +609,9 @@ class TestChecksumProductWriteProduct:
              patch(PATCHES["os_path_isfile"], return_value=False), \
              patch("builtins.open", mock_open()):
 
-            with pytest.raises(RuntimeError, match='Two products have the same MD5 sum, '
-                                                   'the product miscellaneous/test_file.tab '
-                                                   'might be a duplicate.'):
+            with pytest.raises(NPBError, match='Two products have the same MD5 sum, '
+                                                'the product miscellaneous/test_file.tab '
+                                                'might be a duplicate.'):
                 obj.write_product(history=None, set_coverage=False)
 
     def test_write_product_pds4_sets_start_and_stop_times_from_labels(self):

--- a/tests/npb/test_classes_product_inventory.py
+++ b/tests/npb/test_classes_product_inventory.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 
 from pds.naif_pds4_bundler.classes.product.product_inventory import InventoryProduct
+from pds.naif_pds4_bundler.classes.exceptions import NPBError
 
 # ---------------------------------------------------------------------------
 # Helpers / shared fixtures
@@ -416,8 +417,7 @@ class TestInventoryProductWritePds3IndexProduct:
 
         m = mock_open()
         with patch("builtins.open", m), \
-             patch(f"{MODULE}.type_to_extension", return_value=("CK", ".bc")), \
-             patch(f"{MODULE}.handle_npb_error"):
+             patch(f"{MODULE}.type_to_extension", return_value=("CK", ".bc")):
             obj.write_pds3_index_product()
 
         handle = m()
@@ -429,8 +429,7 @@ class TestInventoryProductWritePds3IndexProduct:
         obj = self._make_obj()
 
         m = mock_open()
-        with patch("builtins.open", m), \
-             patch(f"{MODULE}.handle_npb_error"):
+        with patch("builtins.open", m):
             obj.write_pds3_index_product()
 
         assert obj.rows == 1
@@ -450,9 +449,9 @@ class TestInventoryProductWritePds3IndexProduct:
         with patch("builtins.open", m), \
              patch(f"{MODULE}.add_carriage_return", side_effect=lambda l, eol, s: l), \
              patch(f"{MODULE}.type_to_extension", return_value=("CK", ".bc")):
-            with pytest.raises(RuntimeError, match='The index file is incomplete since no binary '
-                                                   'kernel is present in the archive.'):
-                # No rows written; handle_npb_error triggered for empty index
+            with pytest.raises(NPBError, match='The index file is incomplete since no binary '
+                                                'kernel is present in the archive.'):
+                # No rows written; NPBError raised for empty index
                 obj.write_pds3_index_product()
 
     @pytest.mark.parametrize('rows, existing_index', [
@@ -510,8 +509,7 @@ class TestInventoryProductWritePds3IndexProduct:
 
         with patch("builtins.open", side_effect=open_side_effect), \
              patch(f"{MODULE}.add_carriage_return", side_effect=lambda l, eol, s: l), \
-             patch(f"{MODULE}.type_to_extension", return_value=("CK", ".bc")), \
-             patch(f"{MODULE}.handle_npb_error"):
+             patch(f"{MODULE}.type_to_extension", return_value=("CK", ".bc")):
             obj.write_pds3_index_product()
 
         assert obj.rows == rows
@@ -525,8 +523,7 @@ class TestInventoryProductWritePds3IndexProduct:
         m = mock_open()
         with patch("builtins.open", m), \
              patch(f"{MODULE}.add_carriage_return", side_effect=lambda l, eol, s: l), \
-             patch(f"{MODULE}.type_to_extension", return_value=("CK", ".bc")), \
-             patch(f"{MODULE}.handle_npb_error"):
+             patch(f"{MODULE}.type_to_extension", return_value=("CK", ".bc")):
             obj.write_pds3_index_product()
 
         assert len(obj.file_types) == 1

--- a/tests/npb/test_classes_product_kernel.py
+++ b/tests/npb/test_classes_product_kernel.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 
 from pds.naif_pds4_bundler.classes.product.product_kernel import SpiceKernelProduct
+from pds.naif_pds4_bundler.classes.exceptions import NPBError
 
 # ---------------------------------------------------------------------------
 # Helpers / shared fixtures
@@ -273,12 +274,12 @@ class TestSpiceKernelProductInit:
             patch(f"{_MODULE}.extension_to_type", return_value="spk"),
             patch(f"{_MODULE}.safe_make_directory"),
             patch(f"{_MODULE}.product_mapping", return_value="nonexistent.bsp"),
-            patch(f"{_MODULE}.handle_npb_error", side_effect=RuntimeError("not found")) as mock_err,
         ):
-            with pytest.raises(RuntimeError, match="not found"):
+            with pytest.raises(
+                NPBError,
+                match=f"missing.bsp not present in {tmp_env['kernel_dir']}.",
+            ):
                 SpiceKernelProduct(setup, "missing.bsp", collection)
-
-        mock_err.assert_called_once()
 
     def test_init_stores_missions_observers_targets(self, tmp_env):
         product, _, _ = build_product(tmp_env, name="test.bsp")
@@ -367,11 +368,11 @@ class TestSpiceKernelProductReadDescription:
 
         product = self._make_product_stub(setup)
 
-        with patch(f"{_MODULE}.handle_npb_error", side_effect=RuntimeError("no desc")) as mock_err:
-            with pytest.raises(RuntimeError, match="no desc"):
-                product.read_description()
-
-        mock_err.assert_called_once()
+        with pytest.raises(
+            NPBError,
+            match=f"test.bsp does not have a DESCRIPTION on {kl_path}.",
+        ):
+            product.read_description()
 
     def test_description_stripped_of_whitespace(self, tmp_env):
         setup = make_setup(working_directory=tmp_env["work"])
@@ -414,11 +415,11 @@ class TestSpiceKernelProductReadMaklabelOptions:
 
         product = self._make_product_stub(setup)
 
-        with patch(f"{_MODULE}.handle_npb_error", side_effect=RuntimeError("no maklabel")) as mock_err:
-            with pytest.raises(RuntimeError, match="no maklabel"):
-                product.read_maklabel_options()
-
-        mock_err.assert_called_once()
+        with pytest.raises(
+            NPBError,
+            match=f"test.bsp does not have a MAKLABEL_OPTIONS on {kl_path}.",
+        ):
+            product.read_maklabel_options()
 
     def test_get_token_resets_after_finding_options(self, tmp_env):
         """MAKLABEL_OPTIONS found -> get_token set to False; last match returned."""

--- a/tests/npb/test_classes_product_kernel.py
+++ b/tests/npb/test_classes_product_kernel.py
@@ -1,5 +1,6 @@
 """Unit tests for SpiceKernelProduct class."""
 import os
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
@@ -277,7 +278,7 @@ class TestSpiceKernelProductInit:
         ):
             with pytest.raises(
                 NPBError,
-                match=f"missing.bsp not present in {tmp_env['kernel_dir']}.",
+                match=f"missing.bsp not present in {re.escape(tmp_env['kernel_dir'])}.",
             ):
                 SpiceKernelProduct(setup, "missing.bsp", collection)
 
@@ -370,7 +371,7 @@ class TestSpiceKernelProductReadDescription:
 
         with pytest.raises(
             NPBError,
-            match=f"test.bsp does not have a DESCRIPTION on {kl_path}.",
+            match=f"test.bsp does not have a DESCRIPTION on {re.escape(kl_path)}.",
         ):
             product.read_description()
 
@@ -417,7 +418,7 @@ class TestSpiceKernelProductReadMaklabelOptions:
 
         with pytest.raises(
             NPBError,
-            match=f"test.bsp does not have a MAKLABEL_OPTIONS on {kl_path}.",
+            match=f"test.bsp does not have a MAKLABEL_OPTIONS on {re.escape(kl_path)}.",
         ):
             product.read_maklabel_options()
 

--- a/tests/npb/test_classes_product_metakernel.py
+++ b/tests/npb/test_classes_product_metakernel.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 from pds.naif_pds4_bundler.classes.product.product_metakernel import MetaKernelProduct
+from pds.naif_pds4_bundler.classes.exceptions import NPBError
 
 # ---------------------------------------------------------------------------
 # Module path used to target patches
@@ -403,7 +404,7 @@ class TestMetaKernelProductInit:
 
         with (patch(f"{_MODULE}.safe_make_directory"),
               patch(f"{_MODULE}.current_date", return_value="2024-01-01")):
-            with pytest.raises(RuntimeError,
+            with pytest.raises(NPBError,
                                match="Meta-kernel insight_v01.tm has not been matched in configuration."):
                 MetaKernelProduct(setup, "insight_v01.tm", collection)
 
@@ -753,9 +754,9 @@ class TestMetaKernelProductSetProductVid:
         setup = make_setup()
         product = object.__new__(MetaKernelProduct)
         product.setup = setup
-        product.name = "insight_v05.tm"  # no "01" → handle_npb_error called
+        product.name = "insight_v05.tm"  # no "01" → NPBError raised
 
-        with pytest.raises(RuntimeError, match="version does not correspond to VID"):
+        with pytest.raises(NPBError, match="version does not correspond to VID"):
             product.set_product_vid()
 
     def test_all_zero_version_yields_dot_zero(self):
@@ -816,7 +817,7 @@ class TestMetaKernelProductGetDescription:
                 pattern.pattern: {"description": "Not matched."}
             },
         )
-        with pytest.raises(RuntimeError,
+        with pytest.raises(NPBError,
                            match="does not have a description on configuration file"):
             product.get_description()
 
@@ -893,8 +894,8 @@ class TestMetaKernelProductGetDescription:
 
     def test_kernel_pattern_template_missing_variable_raises(self):
         # when the "#text" template does not contain the variable being
-        # substituted, patt_split has length 1 (not 2) and a RuntimeError
-        # is raised.
+        # substituted, patt_split has length 1 (not 2) and an NPBError is
+        # raised.
         pattern = re.compile(r"insight_v\d+\.tm")
         product = self._make_stub(
             name="insight_v05.tm",
@@ -911,13 +912,13 @@ class TestMetaKernelProductGetDescription:
                 }
             },
         )
-        with pytest.raises(RuntimeError, match="not adept to write description"):
+        with pytest.raises(NPBError, match="not adept to write description"):
             product.get_description()
 
     def test_non_kernel_pattern_no_matching_value_raises(self):
         # when the pattern entry is a list (non-kernel lookup) and no @value
-        # matches the kernel name, value stays as the list and a RuntimeError
-        # is raised.
+        # matches the kernel name, value stays as the list and an NPBError is
+        # raised.
         pattern = re.compile(r".*\.tm")
         product = self._make_stub(
             name="no_match_v01.tm",
@@ -933,7 +934,7 @@ class TestMetaKernelProductGetDescription:
                 }
             },
         )
-        with pytest.raises(RuntimeError,
+        with pytest.raises(NPBError,
                            match="Kernel description could not be updated with pattern"):
             product.get_description()
 
@@ -995,7 +996,7 @@ class TestMetaKernelProductWriteProduct:
         product = self._make_stub(tmp_path)
         del product.mk_setup["grammar"]
 
-        with pytest.raises(RuntimeError, match="grammar not defined in configuration"):
+        with pytest.raises(NPBError, match="grammar not defined in configuration"):
             product.write_product()
 
     @pytest.mark.parametrize("padding, mk", [
@@ -1852,8 +1853,7 @@ class TestMetaKernelProductCoverage:
 
     def test_coverage_kernel_not_in_collection_non_spk_ck_raises(
             self, lsk, tmp_path):
-        # when the coverage kernel is neither SPK nor CK, a RuntimeError
-        # is raised.
+        # When the coverage kernel is neither SPK nor CK, an NPBError is raised.
         bundle_dir = tmp_path / "bundle"
         lsk_dir = bundle_dir / "insight_spice" / "spice_kernels" / "lsk"
         lsk_dir.mkdir(parents=True)
@@ -1877,7 +1877,7 @@ class TestMetaKernelProductCoverage:
                 "pattern": [r"naif\d+\.tls"]
             }
         }
-        with pytest.raises(RuntimeError, match="not a SPK or CK kernel"):
+        with pytest.raises(NPBError, match="not a SPK or CK kernel"):
             product.coverage()
 
     def test_collection_non_matching_product_skipped_in_coverage_loop(self, lsk):

--- a/tests/npb/test_classes_product_orbnum.py
+++ b/tests/npb/test_classes_product_orbnum.py
@@ -8,6 +8,7 @@ import pytest
 
 from pds.naif_pds4_bundler.classes.product.product import Product
 from pds.naif_pds4_bundler.classes.product.product_orbnum import OrbnumFileProduct
+from pds.naif_pds4_bundler.classes.exceptions import NPBError
 
 MOD = 'pds.naif_pds4_bundler.classes.product.product_orbnum'
 
@@ -95,8 +96,8 @@ class TestOrbnumFileProductInit:
     def test_init_no_matching_pattern(self, mock_setup, mock_collection, mock_kernels_collection):
         """Test initialization fails if filename does not match pattern."""
         mock_setup.orbnum[0]["pattern"] = r"nomatch\.txt"
-        with pytest.raises(RuntimeError, match="The orbnum file does not match any type "
-                                               "described in the configuration."):
+        with pytest.raises(NPBError, match="The orbnum file does not match any type "
+                                           "described in the configuration."):
             OrbnumFileProduct(mock_setup, "test_file.orb", mock_collection, mock_kernels_collection)
 
     @patch.object(Product, "register")
@@ -311,7 +312,7 @@ class TestOrbnumFileProductReadHeader:
         obj = object.__new__(OrbnumFileProduct)
         obj.path = "/fake/path.orb"
         obj._orbnum_type = {"header_start_line": "2"}
-        
+
         header = obj.read_header()
 
         assert header[0] == "Event UTC PERI\n"
@@ -323,17 +324,17 @@ class TestOrbnumFileProductReadHeader:
         "Event UTC PERI\nNo separator here\n"
     ])
     def test_read_header_missing_separator(self, data):
-        """Test that RuntimeError is raised when the separator line lacks '==='."""
+        """Test that NPBError is raised when the separator line lacks '==='."""
         obj = object.__new__(OrbnumFileProduct)
         obj.path = "/fake/path.orb"
         obj.name = "test_file.orb"
         obj._orbnum_type = {"header_start_line": "1"}
         obj.setup = MagicMock()
 
-        with(
+        with (
             patch("builtins.open", new_callable=mock_open, read_data=data),
-            pytest.raises(RuntimeError, match="The header of the orbnum file test_file.orb "
-                                              "is not as expected.")):
+            pytest.raises(NPBError, match="The header of the orbnum file test_file.orb "
+                                          "is not as expected.")):
             obj.read_header()
 
 
@@ -373,7 +374,7 @@ class TestOrbnumFileProductGetSampleRecord:
         obj._orbnum_type = {"header_start_line": "1"}
         obj.setup = MagicMock()
 
-        with pytest.raises(RuntimeError, match="The orbnum file has no records."):
+        with pytest.raises(NPBError, match="The orbnum file has no records."):
             obj.get_sample_record()
 
 
@@ -394,7 +395,7 @@ class TestOrbnumFileProductReadRecords:
         obj.path = "test.orb"
         obj._orbnum_type = {"header_start_line": "1"}
         obj.record_fixed_length = 7
-        
+
         records = obj.read_records()
         assert records == 2
         assert obj.blank_records == []
@@ -541,7 +542,7 @@ class TestOrbnumFileProductSetEventDetectionKey:
         obj = object.__new__(OrbnumFileProduct)
         obj.setup = MagicMock()
         header = ["Invalid Header Line"]
-        with pytest.raises(RuntimeError, match="orbnum event detection key is incorrect."):
+        with pytest.raises(NPBError, match="orbnum event detection key is incorrect."):
             obj.set_event_detection_key(header)
 
 
@@ -555,7 +556,7 @@ class TestOrbnumFileProductGetParams:
 
 class TestOrbnumFileProductSetParams:
     """Test set_params (also implicitly tests event_mapping and opposite_event_mapping)."""
-    
+
     def test_set_params(self):
         obj = object.__new__(OrbnumFileProduct)
         obj._params = ["No.", "Event UTC", "SolLon"]
@@ -565,14 +566,14 @@ class TestOrbnumFileProductSetParams:
         obj.setup = MagicMock(target="MARS", information_model_float=1007000000.0)
 
         header = ["ignore", "===== ==================== ======="]
-        
+
         obj.set_params(header)
-        
+
         assert "No." in obj.params
         assert obj.params["Event UTC"]["name"] == "Event UTC PERI"
         assert "pericenter" in obj.params["Event UTC"]["description"] # from event_mapping
         assert obj.params["SolLon"]["format"] == "%7.3f"
-        
+
     def test_set_params_legacy_im(self):
         obj = object.__new__(OrbnumFileProduct)
         obj._params = ["No.", "SolLon"]
@@ -582,7 +583,7 @@ class TestOrbnumFileProductSetParams:
         obj.setup = MagicMock(target="MARS", information_model_float=1006000000.0)
 
         header = ["ignore", "===== ======="]
-        
+
         obj.set_params(header)
         assert obj.params["No."]["format"] == "I5"
         assert obj.params["SolLon"]["format"] == "F7.3"
@@ -738,7 +739,7 @@ class TestOrbnumFileProductCoverage:
         obj._orbnum_type = {"coverage": {"kernel": {"#text": "/path/test.bsp", "@cutoff": cutoff}}}
         obj.setup = MagicMock(spice_name="test_spice")
         mock_spk_coverage.return_value = ("2020-01-01T00:00:00Z", stop_time)
-        
+
         # Mock os.listdir to pretend kernel is found in the path
         with patch(f"{MOD}.os.listdir", return_value=["test.bsp"]):
             obj.coverage()
@@ -752,7 +753,7 @@ class TestOrbnumFileProductCoverage:
         obj._orbnum_type = {"coverage": {"lookup_table": {"file": [
             {"@name": "test.orb", "start": "start_time", "finish": "end_time"}
         ]}}}
-        
+
         obj.coverage()
         assert obj.start_time == "start_time"
         assert obj.stop_time == "end_time"
@@ -765,7 +766,7 @@ class TestOrbnumFileProductCoverage:
         obj._orbnum_type = {}
         obj._sample_record = "1 2020-01-01T00:00:00 data"
         obj.utc_blanks_to_dashes = MagicMock(return_value="1 2020-01-01T00:00:00 data 2020-01-02T00:00:00")
-        
+
         mock_parse_date.return_value = datetime.datetime(2020, 1, 1)
 
         with patch("builtins.open", mock_open(read_data=b"dummy\n1 2020-01-01T00:00:00 data 2020-01-02T00:00:00\n")) as m_open:

--- a/tests/npb/test_classes_product_readme.py
+++ b/tests/npb/test_classes_product_readme.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 
 from pds.naif_pds4_bundler.classes.product.product_readme import ReadmeProduct
+from pds.naif_pds4_bundler.classes.exceptions import NPBError
 
 # ---------------------------------------------------------------------------
 # Patch target: every name imported into product_readme is patched here so the
@@ -216,7 +217,7 @@ class TestReadmeProductWriteProduct:
 
     def test_write_product_copies_input_when_provided_and_exists(self, tmp_path):
         # When setup.readme['input'] points to an existing file it is copied to
-        # self.path via shutil.copy; handle_npb_error is not called.
+        # self.path via shutil.copy.
         input_file = tmp_path / 'provided_readme.txt'
         input_file.write_text('provided', encoding='utf-8')
 
@@ -224,32 +225,30 @@ class TestReadmeProductWriteProduct:
         # self.path does not exist yet so the copy branch is entered.
         obj = self._make_obj(setup, str(tmp_path / 'staging' / 'readme.txt'))
 
-        with patch(f'{MOD}.shutil.copy') as m_copy, \
-                patch(f'{MOD}.handle_npb_error') as m_err:
+        with patch(f'{MOD}.shutil.copy') as m_copy:
             obj._write_product()
 
         m_copy.assert_called_once_with(str(input_file), obj.path)
-        m_err.assert_not_called()
 
     # ------------------------------------------------------------------
     # Branch: readme provided via configuration but the file is missing
     # ------------------------------------------------------------------
 
     def test_write_product_errors_when_input_file_missing(self, tmp_path):
-        # When setup.readme['input'] points to a non-existent file,
-        # handle_npb_error is called with the appropriate message and shutil.copy
-        # is never invoked.
+        # When setup.readme['input'] points to a non-existent file,  NPBError is
+        # raised with the appropriate message and shutil.copy is never invoked.
         missing = str(tmp_path / 'does_not_exist.txt')
         setup = make_setup(tmp_path, readme={'input': missing})
         obj = self._make_obj(setup, str(tmp_path / 'staging' / 'readme.txt'))
 
-        with patch(f'{MOD}.shutil.copy') as m_copy, \
-                patch(f'{MOD}.handle_npb_error') as m_err:
-            obj._write_product()
+        with patch(f'{MOD}.shutil.copy') as m_copy:
+            with pytest.raises(
+                NPBError,
+                match='Readme file provided via configuration does not exist.',
+            ):
+                obj._write_product()
 
         m_copy.assert_not_called()
-        m_err.assert_called_once_with(
-            'Readme file provided via configuration does not exist.')
 
     # ------------------------------------------------------------------
     # Branch: template generation (no 'input' key in setup.readme)

--- a/tests/npb/test_classes_product_spiceds.py
+++ b/tests/npb/test_classes_product_spiceds.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pds.naif_pds4_bundler.classes.product.product_spiceds import SpicedsProduct
+from pds.naif_pds4_bundler.classes.exceptions import NPBError
 
 # Module path used as the anchor for every patch target.
 _MODULE = 'pds.naif_pds4_bundler.classes.product.product_spiceds'
@@ -222,53 +223,43 @@ class TestSpicedsProductInit:
     def test_init_increment_no_previous_with_spiceds_provided(self):
         # Increment but glob finds nothing, yet a spiceds is provided. The
         # empty-list [-1] raises IndexError -> the except branch sets version 1
-        # and empty latest_spiceds; handle_npb_error must NOT fire because a
-        # spiceds was supplied.
+        # and empty latest_spiceds; NPBError must NOT fire because a spiceds was
+        # supplied.
         setup = make_setup(increment=True, spiceds='/input/spiceds.html')
         collection = make_collection()
 
         patches = base_init_patches()
         with patch(f'{_MODULE}.glob.glob', return_value=[]), \
-                patch(f'{_MODULE}.handle_npb_error') as npb_error, \
                 patches[0], patches[1], patches[2], \
                 patches[3], patches[4], patches[5]:
             product = SpicedsProduct(setup, collection)
 
-        npb_error.assert_not_called()
         assert product.version == 1
         assert product.latest_spiceds == ''
         assert product.name == 'spiceds_v001.html'
 
     def test_init_increment_no_previous_no_spiceds_calls_handle_error(self):
-        # Increment, no previous version AND no 'spiceds' -> handle_npb_error.
-
-        # TODO: BUG, handle_npb_error is annotated NoReturn, so the constructor
-        #       assumes it never returns. However, the code does not enforce
-        #       this structurally: if handle_npb_error were to return, execution
-        #       would fall through to shutil.copy2(spiceds='', ...) and raise
-        #       FileNotFoundError instead of the intended npb error message.
+        # Increment, no previous version AND no 'spiceds' -> NPBError raised.
         setup = make_setup(increment=True, spiceds='')
         collection = make_collection()
 
-        with patch(f'{_MODULE}.glob.glob', return_value=[]), \
-                patch(f'{_MODULE}.handle_npb_error',
-                      side_effect=SystemExit) as npb_error:
-            with pytest.raises(SystemExit):
+        with patch(f'{_MODULE}.glob.glob', return_value=[]):
+            with pytest.raises(
+                NPBError,
+                match='spiceds not provided and not available from previous releases.',
+            ):
                 SpicedsProduct(setup, collection)
 
-        npb_error.assert_called_once()
-
     def test_init_no_increment_no_spiceds_calls_handle_error(self):
-        # No increment and no spiceds -> handle_npb_error on the else branch.
+        # No increment and no spiceds -> NPBError raised on the else branch.
         setup = make_setup(increment=False, spiceds='')
         collection = make_collection()
 
-        with patch(f'{_MODULE}.handle_npb_error',
-                   side_effect=SystemExit) as npb_error:
-            with pytest.raises(SystemExit):
-                SpicedsProduct(setup, collection)
-
-        npb_error.assert_called_once()
+        with pytest.raises(
+            NPBError,
+            match='spiceds not provided and not available from previous releases.',
+        ):
+            SpicedsProduct(setup, collection)
 
     def test_init_missing_spiceds_attribute_treated_as_empty(self):
         # If accessing setup.spiceds raises, the constructor's try/except
@@ -279,12 +270,11 @@ class TestSpicedsProductInit:
         del setup.spiceds
         collection = make_collection()
 
-        with patch(f'{_MODULE}.handle_npb_error',
-                   side_effect=SystemExit) as npb_error:
-            with pytest.raises(SystemExit):
-                SpicedsProduct(setup, collection)
-
-        npb_error.assert_called_once()
+        with pytest.raises(
+            NPBError,
+            match='spiceds not provided and not available from previous releases.',
+        ):
+            SpicedsProduct(setup, collection)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/npb/test_pipeline_npb.py
+++ b/tests/npb/test_pipeline_npb.py
@@ -1126,9 +1126,10 @@ class TestNPBErrorHandling:
     def test_npb_error_is_routed_to_handle_npb_error(self, mocks, overrides, target_attr, message):
         self._apply_overrides(mocks, overrides)
         getattr(mocks, target_attr).side_effect = NPBError(message)
+        args = _args()
 
         with pytest.raises(RuntimeError, match=message):
-            run_pipeline(_args())
+            run_pipeline(args)
 
         setup = mocks.Setup.return_value
         setup.write_file_list.assert_called_once()

--- a/tests/npb/test_pipeline_npb.py
+++ b/tests/npb/test_pipeline_npb.py
@@ -24,6 +24,7 @@ Phase → Test class mapping
  10  PDS3 path                           TestPhase10PDS3Path
  11  Staging recap + copy                TestPhase11StagingRecapAndCopy
  12  Final validation                    TestPhase12FinalValidation
+ 13  NPBError -> handle_npb_error routing TestNPBErrorHandling
 """
 from contextlib import ExitStack
 from pathlib import Path
@@ -33,6 +34,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pds.naif_pds4_bundler.pipeline.npb import run_pipeline
+from pds.naif_pds4_bundler.classes.exceptions import NPBError
 from pds.naif_pds4_bundler.utils.types.datatypes import PipelineArgs
 
 # Imported to create specified mocks that pass isinstance checks in Phase 12.
@@ -75,6 +77,7 @@ _PATCH_TARGETS = [
     'ReadmeProduct',
     'clear_run',
     'finish_execution',
+    'handle_npb_error',
     'log_step',
     'isdir',
 ]
@@ -1050,3 +1053,179 @@ class TestPhase12FinalValidation:
         run_pipeline(_args())
         _, log_arg = mocks.finish_execution.call_args[0]
         assert log_arg is mocks.Log.return_value
+
+
+# ---------------------------------------------------------------------------
+# Phase 13 - NPBError -> handle_npb_error routing
+# ---------------------------------------------------------------------------
+
+class TestNPBErrorHandling:
+    # Phase 13 - NPBError routing
+    # Every direct product-construction call in run_pipeline (SpiceKernelProduct,
+    # OrbnumFileProduct, MetaKernelProduct, InventoryProduct, SpicedsProduct,
+    # ChecksumProduct, and ReadmeProduct) is wrapped in a try/except that catches
+    # NPBError and forwards its message to handle_npb_error along with the shared
+    # setup object. handle_npb_error itself is NoReturn in production: it performs
+    # cleanup (file list, checksum registry, template removal, kernel pool clear)
+    # and then always raises. Each test below forces exactly one construction
+    # call to raise NPBError and asserts that handle_npb_error is invoked with
+    # the exception's message and setup, confirming the routing for that
+    # specific call site rather than relying on a neighboring site to fail first.
+
+    @pytest.fixture(autouse=True)
+    def _handle_npb_error_raises(self, mocks):
+        # Mirror the real NoReturn contract so control does not fall through to
+        # code that assumes the construction succeeded.
+        mocks.handle_npb_error.side_effect = RuntimeError
+
+    def test_orbnum_file_product_error_is_routed(self, mocks):
+        # .orb/.nrb kernels are dispatched to OrbnumFileProduct in the per-kernel loop.
+        mocks.ReleasePlan.return_value.kernel_list = ['maven_2024.orb']
+        mocks.OrbnumFileProduct.side_effect = NPBError('boom orbnum')
+
+        with pytest.raises(RuntimeError):
+            run_pipeline(_args())
+
+        mocks.handle_npb_error.assert_called_once_with(
+            'boom orbnum', setup=mocks.Setup.return_value
+        )
+
+    def test_spice_kernel_product_error_is_routed(self, mocks):
+        # Non-.tm kernels are dispatched to SpiceKernelProduct in the per-kernel loop.
+        mocks.ReleasePlan.return_value.kernel_list = ['maven_2024.bc']
+        mocks.SpiceKernelProduct.side_effect = NPBError('boom kernel')
+
+        with pytest.raises(RuntimeError):
+            run_pipeline(_args())
+
+        mocks.handle_npb_error.assert_called_once_with(
+            'boom kernel', setup=mocks.Setup.return_value
+        )
+
+    def test_meta_kernel_product_error_is_routed(self, mocks):
+        # A determined meta-kernel is wrapped in a MetaKernelProduct.
+        mocks.SpiceKernelsCollection.return_value.determine_meta_kernels.return_value = {
+            'maven_v01.tm': None
+        }
+        mocks.MetaKernelProduct.side_effect = NPBError('boom mk')
+
+        with pytest.raises(RuntimeError):
+            run_pipeline(_args())
+
+        mocks.handle_npb_error.assert_called_once_with(
+            'boom mk', setup=mocks.Setup.return_value
+        )
+
+    def test_spice_kernels_collection_inventory_error_is_routed(self, mocks):
+        # An updated SPICE kernels collection gets its own InventoryProduct.
+        mocks.SpiceKernelsCollection.return_value.updated = True
+        mocks.InventoryProduct.side_effect = NPBError('boom skc inventory')
+
+        with pytest.raises(RuntimeError):
+            run_pipeline(_args())
+
+        mocks.handle_npb_error.assert_called_once_with(
+            'boom skc inventory', setup=mocks.Setup.return_value
+        )
+
+    def test_spiceds_product_error_is_routed(self, mocks):
+        # SpicedsProduct is constructed unconditionally on the PDS4 path.
+        mocks.SpicedsProduct.side_effect = NPBError('boom spiceds')
+
+        with pytest.raises(RuntimeError):
+            run_pipeline(_args())
+
+        mocks.handle_npb_error.assert_called_once_with(
+            'boom spiceds', setup=mocks.Setup.return_value
+        )
+
+    def test_document_collection_inventory_error_is_routed(self, mocks):
+        # A generated SPICEDS document triggers a document collection InventoryProduct.
+        mocks.SpicedsProduct.return_value.generated = True
+        mocks.InventoryProduct.side_effect = NPBError('boom doc inventory')
+
+        with pytest.raises(RuntimeError):
+            run_pipeline(_args())
+
+        mocks.handle_npb_error.assert_called_once_with(
+            'boom doc inventory', setup=mocks.Setup.return_value
+        )
+
+    def test_release_checksum_backfill_error_is_routed(self, mocks):
+        # The per-release backfill loop constructs one ChecksumProduct per
+        # historical release when the checksum directory does not yet exist.
+        setup = mocks.Setup.return_value
+        setup.increment = True
+        mocks.isdir.return_value = False
+        mocks.Bundle.return_value.history = {'release_01': ('data', 'label')}
+        mocks.ChecksumProduct.side_effect = NPBError('boom checksum backfill')
+
+        with pytest.raises(RuntimeError):
+            run_pipeline(_args())
+
+        mocks.handle_npb_error.assert_called_once_with(
+            'boom checksum backfill', setup=setup
+        )
+
+    def test_release_miscellaneous_inventory_error_is_routed(self, mocks):
+        # Within the backfill loop, each release also gets its own miscellaneous
+        # collection InventoryProduct.
+        setup = mocks.Setup.return_value
+        setup.increment = True
+        mocks.isdir.return_value = False
+        mocks.Bundle.return_value.history = {'release_01': ('data', 'label')}
+        mocks.InventoryProduct.side_effect = NPBError('boom release misc inventory')
+
+        with pytest.raises(RuntimeError):
+            run_pipeline(_args())
+
+        mocks.handle_npb_error.assert_called_once_with(
+            'boom release misc inventory', setup=setup
+        )
+
+    def test_miscellaneous_checksum_error_is_routed(self, mocks):
+        # The current-release checksum for the miscellaneous collection is
+        # constructed unconditionally on the PDS4 path.
+        mocks.ChecksumProduct.side_effect = NPBError('boom checksum misc')
+
+        with pytest.raises(RuntimeError):
+            run_pipeline(_args())
+
+        mocks.handle_npb_error.assert_called_once_with(
+            'boom checksum misc', setup=mocks.Setup.return_value
+        )
+
+    def test_miscellaneous_collection_inventory_error_is_routed(self, mocks):
+        # The miscellaneous collection's own InventoryProduct is constructed
+        # unconditionally on the PDS4 path.
+        mocks.InventoryProduct.side_effect = NPBError('boom misc inventory')
+
+        with pytest.raises(RuntimeError):
+            run_pipeline(_args())
+
+        mocks.handle_npb_error.assert_called_once_with(
+            'boom misc inventory', setup=mocks.Setup.return_value
+        )
+
+    def test_readme_product_error_is_routed(self, mocks):
+        # ReadmeProduct is constructed unconditionally on the PDS4 path.
+        mocks.ReadmeProduct.side_effect = NPBError('boom readme')
+
+        with pytest.raises(RuntimeError):
+            run_pipeline(_args())
+
+        mocks.handle_npb_error.assert_called_once_with(
+            'boom readme', setup=mocks.Setup.return_value
+        )
+
+    def test_pds3_checksum_error_is_routed(self, mocks):
+        # The PDS3 path constructs its own ChecksumProduct without history.
+        mocks.Setup.return_value.pds_version = '3'
+        mocks.ChecksumProduct.side_effect = NPBError('boom checksum pds3')
+
+        with pytest.raises(RuntimeError):
+            run_pipeline(_args())
+
+        mocks.handle_npb_error.assert_called_once_with(
+            'boom checksum pds3', setup=mocks.Setup.return_value
+        )

--- a/tests/npb/test_pipeline_npb.py
+++ b/tests/npb/test_pipeline_npb.py
@@ -77,7 +77,6 @@ _PATCH_TARGETS = [
     'ReadmeProduct',
     'clear_run',
     'finish_execution',
-    'handle_npb_error',
     'log_step',
     'isdir',
 ]
@@ -1060,172 +1059,77 @@ class TestPhase12FinalValidation:
 # ---------------------------------------------------------------------------
 
 class TestNPBErrorHandling:
-    # Phase 13 - NPBError routing
-    # Every direct product-construction call in run_pipeline (SpiceKernelProduct,
-    # OrbnumFileProduct, MetaKernelProduct, InventoryProduct, SpicedsProduct,
-    # ChecksumProduct, and ReadmeProduct) is wrapped in a try/except that catches
-    # NPBError and forwards its message to handle_npb_error along with the shared
-    # setup object. handle_npb_error itself is NoReturn in production: it performs
-    # cleanup (file list, checksum registry, template removal, kernel pool clear)
-    # and then always raises. Each test below forces exactly one construction
-    # call to raise NPBError and asserts that handle_npb_error is invoked with
-    # the exception's message and setup, confirming the routing for that
-    # specific call site rather than relying on a neighboring site to fail first.
+    # Every direct product-construction call in run_pipeline is wrapped in a
+    # try/except that catches NPBError and forwards it to the *real*
+    # handle_npb_error (not mocked here), which performs cleanup -- writes the
+    # file list and checksum registry, removes template files, clears the SPICE
+    # kernel pool -- and then always raises RuntimeError with the same message.
+    # Each case forces one construction call to raise NPBError and asserts both
+    # that cleanup ran and that the RuntimeError carries the original message.
 
-    @pytest.fixture(autouse=True)
-    def _handle_npb_error_raises(self, mocks):
-        # Mirror the real NoReturn contract so control does not fall through to
-        # code that assumes the construction succeeded.
-        mocks.handle_npb_error.side_effect = RuntimeError
+    @staticmethod
+    def _apply_overrides(mocks, overrides):
+        for path, value in overrides.items():
+            *attrs, last = path.split('.')
+            target = mocks
+            for attr in attrs:
+                target = getattr(target, attr)
+            setattr(target, last, value)
 
-    def test_orbnum_file_product_error_is_routed(self, mocks):
-        # .orb/.nrb kernels are dispatched to OrbnumFileProduct in the per-kernel loop.
-        mocks.ReleasePlan.return_value.kernel_list = ['maven_2024.orb']
-        mocks.OrbnumFileProduct.side_effect = NPBError('boom orbnum')
+    # Each case: (dotted attribute overrides on `mocks`, mock attribute to fail, expected message).
+    @pytest.mark.parametrize('overrides, target_attr, message', [
+        pytest.param(
+            {'ReleasePlan.return_value.kernel_list': ['maven_2024.orb']},
+            'OrbnumFileProduct', 'boom orbnum', id='orbnum_file_product',
+        ),
+        pytest.param(
+            {'ReleasePlan.return_value.kernel_list': ['maven_2024.bc']},
+            'SpiceKernelProduct', 'boom kernel', id='spice_kernel_product',
+        ),
+        pytest.param(
+            {'SpiceKernelsCollection.return_value.determine_meta_kernels.return_value': {'maven_v01.tm': None}},
+            'MetaKernelProduct', 'boom mk', id='meta_kernel_product',
+        ),
+        pytest.param(
+            {'SpiceKernelsCollection.return_value.updated': True},
+            'InventoryProduct', 'boom skc inventory', id='skc_inventory',
+        ),
+        pytest.param({}, 'SpicedsProduct', 'boom spiceds', id='spiceds_product'),
+        pytest.param(
+            {'SpicedsProduct.return_value.generated': True},
+            'InventoryProduct', 'boom doc inventory', id='doc_inventory',
+        ),
+        pytest.param(
+            {
+                'Setup.return_value.increment': True,
+                'isdir.return_value': False,
+                'Bundle.return_value.history': {'release_01': ('data', 'label')},
+            },
+            'ChecksumProduct', 'boom checksum backfill', id='release_checksum_backfill',
+        ),
+        pytest.param(
+            {
+                'Setup.return_value.increment': True,
+                'isdir.return_value': False,
+                'Bundle.return_value.history': {'release_01': ('data', 'label')},
+            },
+            'InventoryProduct', 'boom release misc inventory', id='release_misc_inventory',
+        ),
+        pytest.param({}, 'ChecksumProduct', 'boom checksum misc', id='misc_checksum'),
+        pytest.param({}, 'InventoryProduct', 'boom misc inventory', id='misc_inventory'),
+        pytest.param({}, 'ReadmeProduct', 'boom readme', id='readme_product'),
+        pytest.param(
+            {'Setup.return_value.pds_version': '3'},
+            'ChecksumProduct', 'boom checksum pds3', id='pds3_checksum',
+        ),
+    ])
+    def test_npb_error_is_routed_to_handle_npb_error(self, mocks, overrides, target_attr, message):
+        self._apply_overrides(mocks, overrides)
+        getattr(mocks, target_attr).side_effect = NPBError(message)
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match=message):
             run_pipeline(_args())
 
-        mocks.handle_npb_error.assert_called_once_with(
-            'boom orbnum', setup=mocks.Setup.return_value
-        )
-
-    def test_spice_kernel_product_error_is_routed(self, mocks):
-        # Non-.tm kernels are dispatched to SpiceKernelProduct in the per-kernel loop.
-        mocks.ReleasePlan.return_value.kernel_list = ['maven_2024.bc']
-        mocks.SpiceKernelProduct.side_effect = NPBError('boom kernel')
-
-        with pytest.raises(RuntimeError):
-            run_pipeline(_args())
-
-        mocks.handle_npb_error.assert_called_once_with(
-            'boom kernel', setup=mocks.Setup.return_value
-        )
-
-    def test_meta_kernel_product_error_is_routed(self, mocks):
-        # A determined meta-kernel is wrapped in a MetaKernelProduct.
-        mocks.SpiceKernelsCollection.return_value.determine_meta_kernels.return_value = {
-            'maven_v01.tm': None
-        }
-        mocks.MetaKernelProduct.side_effect = NPBError('boom mk')
-
-        with pytest.raises(RuntimeError):
-            run_pipeline(_args())
-
-        mocks.handle_npb_error.assert_called_once_with(
-            'boom mk', setup=mocks.Setup.return_value
-        )
-
-    def test_spice_kernels_collection_inventory_error_is_routed(self, mocks):
-        # An updated SPICE kernels collection gets its own InventoryProduct.
-        mocks.SpiceKernelsCollection.return_value.updated = True
-        mocks.InventoryProduct.side_effect = NPBError('boom skc inventory')
-
-        with pytest.raises(RuntimeError):
-            run_pipeline(_args())
-
-        mocks.handle_npb_error.assert_called_once_with(
-            'boom skc inventory', setup=mocks.Setup.return_value
-        )
-
-    def test_spiceds_product_error_is_routed(self, mocks):
-        # SpicedsProduct is constructed unconditionally on the PDS4 path.
-        mocks.SpicedsProduct.side_effect = NPBError('boom spiceds')
-
-        with pytest.raises(RuntimeError):
-            run_pipeline(_args())
-
-        mocks.handle_npb_error.assert_called_once_with(
-            'boom spiceds', setup=mocks.Setup.return_value
-        )
-
-    def test_document_collection_inventory_error_is_routed(self, mocks):
-        # A generated SPICEDS document triggers a document collection InventoryProduct.
-        mocks.SpicedsProduct.return_value.generated = True
-        mocks.InventoryProduct.side_effect = NPBError('boom doc inventory')
-
-        with pytest.raises(RuntimeError):
-            run_pipeline(_args())
-
-        mocks.handle_npb_error.assert_called_once_with(
-            'boom doc inventory', setup=mocks.Setup.return_value
-        )
-
-    def test_release_checksum_backfill_error_is_routed(self, mocks):
-        # The per-release backfill loop constructs one ChecksumProduct per
-        # historical release when the checksum directory does not yet exist.
         setup = mocks.Setup.return_value
-        setup.increment = True
-        mocks.isdir.return_value = False
-        mocks.Bundle.return_value.history = {'release_01': ('data', 'label')}
-        mocks.ChecksumProduct.side_effect = NPBError('boom checksum backfill')
-
-        with pytest.raises(RuntimeError):
-            run_pipeline(_args())
-
-        mocks.handle_npb_error.assert_called_once_with(
-            'boom checksum backfill', setup=setup
-        )
-
-    def test_release_miscellaneous_inventory_error_is_routed(self, mocks):
-        # Within the backfill loop, each release also gets its own miscellaneous
-        # collection InventoryProduct.
-        setup = mocks.Setup.return_value
-        setup.increment = True
-        mocks.isdir.return_value = False
-        mocks.Bundle.return_value.history = {'release_01': ('data', 'label')}
-        mocks.InventoryProduct.side_effect = NPBError('boom release misc inventory')
-
-        with pytest.raises(RuntimeError):
-            run_pipeline(_args())
-
-        mocks.handle_npb_error.assert_called_once_with(
-            'boom release misc inventory', setup=setup
-        )
-
-    def test_miscellaneous_checksum_error_is_routed(self, mocks):
-        # The current-release checksum for the miscellaneous collection is
-        # constructed unconditionally on the PDS4 path.
-        mocks.ChecksumProduct.side_effect = NPBError('boom checksum misc')
-
-        with pytest.raises(RuntimeError):
-            run_pipeline(_args())
-
-        mocks.handle_npb_error.assert_called_once_with(
-            'boom checksum misc', setup=mocks.Setup.return_value
-        )
-
-    def test_miscellaneous_collection_inventory_error_is_routed(self, mocks):
-        # The miscellaneous collection's own InventoryProduct is constructed
-        # unconditionally on the PDS4 path.
-        mocks.InventoryProduct.side_effect = NPBError('boom misc inventory')
-
-        with pytest.raises(RuntimeError):
-            run_pipeline(_args())
-
-        mocks.handle_npb_error.assert_called_once_with(
-            'boom misc inventory', setup=mocks.Setup.return_value
-        )
-
-    def test_readme_product_error_is_routed(self, mocks):
-        # ReadmeProduct is constructed unconditionally on the PDS4 path.
-        mocks.ReadmeProduct.side_effect = NPBError('boom readme')
-
-        with pytest.raises(RuntimeError):
-            run_pipeline(_args())
-
-        mocks.handle_npb_error.assert_called_once_with(
-            'boom readme', setup=mocks.Setup.return_value
-        )
-
-    def test_pds3_checksum_error_is_routed(self, mocks):
-        # The PDS3 path constructs its own ChecksumProduct without history.
-        mocks.Setup.return_value.pds_version = '3'
-        mocks.ChecksumProduct.side_effect = NPBError('boom checksum pds3')
-
-        with pytest.raises(RuntimeError):
-            run_pipeline(_args())
-
-        mocks.handle_npb_error.assert_called_once_with(
-            'boom checksum pds3', setup=mocks.Setup.return_value
-        )
+        setup.write_file_list.assert_called_once()
+        setup.write_checksum_registry.assert_called_once()

--- a/tests/npb/test_pipeline_npb.py
+++ b/tests/npb/test_pipeline_npb.py
@@ -1076,7 +1076,21 @@ class TestNPBErrorHandling:
                 target = getattr(target, attr)
             setattr(target, last, value)
 
-    # Each case: (dotted attribute overrides on `mocks`, mock attribute to fail, expected message).
+    @staticmethod
+    def _resolve(mocks, dotted_path):
+        # Walks a dotted path off `mocks` (e.g. "ChecksumProduct" for a
+        # construction-site failure, or "ChecksumProduct.return_value.generate"
+        # for a failure in a call on the constructed instance) and returns the
+        # mock at the end of it, so the caller can set .side_effect on it.
+        target = mocks
+        for attr in dotted_path.split('.'):
+            target = getattr(target, attr)
+        return target
+
+    # Each case: (dotted attribute overrides on `mocks`, dotted mock attribute
+    # to fail (resolved via `_resolve`, e.g. a bare class name for a
+    # construction-site failure, or "ChecksumProduct.return_value.generate"
+    # for a failure in a call on the constructed instance), expected message).
     @pytest.mark.parametrize('overrides, target_attr, message', [
         pytest.param(
             {'ReleasePlan.return_value.kernel_list': ['maven_2024.orb']},
@@ -1122,10 +1136,37 @@ class TestNPBErrorHandling:
             {'Setup.return_value.pds_version': '3'},
             'ChecksumProduct', 'boom checksum pds3', id='pds3_checksum',
         ),
+        # The four sites below are not construction calls but post-construction
+        # calls on an already-built ChecksumProduct (.generate()/.set_coverage()),
+        # which previously sat outside any try/except NPBError. Failing them
+        # exercises the same routing via the dotted
+        # "ChecksumProduct.return_value.<method>" path.
+        pytest.param(
+            {
+                'Setup.return_value.increment': True,
+                'isdir.return_value': False,
+                'Bundle.return_value.history': {'release_01': ('data', 'label')},
+            },
+            'ChecksumProduct.return_value.generate', 'boom release checksum generate',
+            id='release_checksum_generate',
+        ),
+        pytest.param(
+            {}, 'ChecksumProduct.return_value.set_coverage', 'boom checksum set_coverage',
+            id='misc_checksum_set_coverage',
+        ),
+        pytest.param(
+            {}, 'ChecksumProduct.return_value.generate', 'boom checksum generate',
+            id='misc_checksum_generate',
+        ),
+        pytest.param(
+            {'Setup.return_value.pds_version': '3'},
+            'ChecksumProduct.return_value.generate', 'boom checksum pds3 generate',
+            id='pds3_checksum_generate',
+        ),
     ])
     def test_npb_error_is_routed_to_handle_npb_error(self, mocks, overrides, target_attr, message):
         self._apply_overrides(mocks, overrides)
-        getattr(mocks, target_attr).side_effect = NPBError(message)
+        self._resolve(mocks, target_attr).side_effect = NPBError(message)
         args = _args()
 
         with pytest.raises(RuntimeError, match=message):


### PR DESCRIPTION
## 🗒️ Summary
Replaces every `handle_npb_error` call inside the seven product-file methods with `raise NPBError(...)`, and adds try/except wrappers around all 12 product construction sites in `npb.py` to catch `NPBError` and route it to
`handle_npb_error` for cleanup.

## ⚙️  Test Data and/or Report
Regression tests included: the 7 migrated product-file test modules, plus the pre-existing `test_pipeline_npb.py` orchestration suite (409 tests total, covering both the product-level `raise NPBError` changes and the `npb.py` try/except wrappers).

  <details>
  <summary>pytest -v output (409 tests)</summary>

      tests/npb/test_classes_product_kernel.py::TestSpiceKernelProductInit::test_pds4_binary_kernel_sets_binary_file_format PASSED
      ... (39 tests) ...
      tests/npb/test_classes_product_inventory.py::TestInventoryProductInitPDS4::test_pds4_attribute_settings[...] PASSED
      ... (36 tests) ...
      tests/npb/test_classes_product_readme.py::TestReadmeProductInit::test_init_generates_product_when_no_existing_readme PASSED
      ... (17 tests, 1 xfailed) ...
      tests/npb/test_classes_product_spiceds.py::TestSpicedsProductInit::test_init_no_increment_with_spiceds_provided PASSED
      ... (18 tests) ...
      tests/npb/test_classes_product_checksum.py::TestChecksumProductInit::test_init_pds4_no_increment_sets_version_1 PASSED
      ... (37 tests, 1 skipped) ...
      tests/npb/test_classes_product_metakernel.py::TestMetaKernelProductInit::test_collection_path_and_kernelpath_by_pds_version[...] PASSED
      ... (115 tests) ...
      tests/npb/test_classes_product_orbnum.py::TestOrbnumFileProductInit::test_init_no_matching_pattern PASSED
      ... (53 tests) ...
      tests/npb/test_pipeline_npb.py::TestPhase1Initialization::test_setup_constructed_with_args_and_version PASSED
      ... (94 tests across 12 phase classes) ...

      ================== 407 passed, 1 skipped, 1 xfailed in 10.19s ==================

  </details>

      Name                                                                 Stmts   Miss Branch BrPart  Cover
     ------------------------------------------------------------------------------------------------------
      src/pds/naif_pds4_bundler/classes/product/product_checksum.py          220      4    102      1    98%
      src/pds/naif_pds4_bundler/classes/product/product_inventory.py         193      0     80      0   100%
      src/pds/naif_pds4_bundler/classes/product/product_kernel.py            168      0     72      0   100%
      src/pds/naif_pds4_bundler/classes/product/product_metakernel.py        482      1    232      2    99%
      src/pds/naif_pds4_bundler/classes/product/product_orbnum.py            407      4    182      5    98%
      src/pds/naif_pds4_bundler/classes/product/product_readme.py             69      0     24      0   100%
      src/pds/naif_pds4_bundler/classes/product/product_spiceds.py           113      0     28      0   100%
      src/pds/naif_pds4_bundler/pipeline/npb.py                              205     24     62      0    91%
      ------------------------------------------------------------------------------------------------------

      Full merge-gate suite (pytest tests/npb/ -v --cov-branch -n0, single-process for a deterministic count): 1756 passed, 8 skipped, 1 xfailed 

Manual verification:
* `grep -rn "handle_npb_error\|from.*pipeline.runtime" src/pds/naif_pds4_bundler/classes/product/ | grep -v __pycache__` → no output
* All 12 `Product(` construction sites in `npb.py` confirmed wrapped in `try/except NPBError`

## ♻️ Related Issues
- fixes #292