### PR TITLE
Fix(B-11): fix filename truncation at first dot (7 sites)

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/label/pds4_checksum.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_checksum.py
@@ -25,7 +25,6 @@ class ChecksumPDS4Label(PDSLabel):
         self.FILE_FORMAT = "Character"
         self.START_TIME = self.product.start_time
         self.STOP_TIME = self.product.stop_time
-        # TODO: There may be a bug if the 'name' contains more than one dot.
-        self.name = product.name.split(".")[0] + ".xml"
+        self.name = Path(product.name).stem + ".xml"
 
         self.write_label()

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_checksum.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_checksum.py
@@ -25,6 +25,6 @@ class ChecksumPDS4Label(PDSLabel):
         self.FILE_FORMAT = "Character"
         self.START_TIME = self.product.start_time
         self.STOP_TIME = self.product.stop_time
-        self.name = Path(product.name).stem + ".xml"
+        self.name = Path(product.name).with_suffix(".xml").name
 
         self.write_label()

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_document.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_document.py
@@ -29,6 +29,6 @@ class DocumentPDS4Label(PDSLabel):
         self.STOP_TIME = setup.mission_finish
         self.FILE_NAME = inventory.name
 
-        self.name = Path(collection.name).stem + ".xml"
+        self.name = Path(collection.name).with_suffix(".xml").name
 
         self.write_label()

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_document.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_document.py
@@ -29,8 +29,6 @@ class DocumentPDS4Label(PDSLabel):
         self.STOP_TIME = setup.mission_finish
         self.FILE_NAME = inventory.name
 
-        # TODO: BUG, a valid file name containing more than one dot is
-        #       truncated at the first dot.
-        self.name = collection.name.split(".")[0] + ".xml"
+        self.name = Path(collection.name).stem + ".xml"
 
         self.write_label()

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_inventory.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_inventory.py
@@ -74,10 +74,7 @@ class InventoryPDS4Label(PDSLabel):
         with open(self.product.path, 'r', encoding='utf-8') as f:
             self.N_RECORDS = str(len(f.readlines()))
 
-        # TODO: BUG; collection.name.split(".")[0] truncates at the FIRST dot,
-        #       so any collection name containing more than one dot produces an
-        #       incorrect XML label name.
-        self.name = collection.name.split(".")[0] + ".xml"
+        self.name = Path(collection.name).stem + ".xml"
         self.write_label()
 
     def get_mission_reference_type(self):

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_inventory.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_inventory.py
@@ -74,7 +74,7 @@ class InventoryPDS4Label(PDSLabel):
         with open(self.product.path, 'r', encoding='utf-8') as f:
             self.N_RECORDS = str(len(f.readlines()))
 
-        self.name = Path(collection.name).stem + ".xml"
+        self.name = Path(collection.name).with_suffix(".xml").name
         self.write_label()
 
     def get_mission_reference_type(self):

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_metakernel.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_metakernel.py
@@ -36,7 +36,7 @@ class MetaKernelPDS4Label(PDSLabel):
 
         self.KERNEL_INTERNAL_REFERENCES = self.get_kernel_internal_references()
 
-        self.name = Path(product.name).stem + ".xml"
+        self.name = Path(product.name).with_suffix(".xml").name
 
         self.write_label()
 

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_metakernel.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_metakernel.py
@@ -36,11 +36,7 @@ class MetaKernelPDS4Label(PDSLabel):
 
         self.KERNEL_INTERNAL_REFERENCES = self.get_kernel_internal_references()
 
-        # TODO: BUG, split(".")[0] truncates the name at the FIRST dot, so any
-        #       product whose name contains more than one dot produces a
-        #       truncated XML label name.
-        #       e.g. maven_v01.0.tm -> maven_v01.xml instead of maven_v01.0.xml
-        self.name = product.name.split(".")[0] + ".xml"
+        self.name = Path(product.name).stem + ".xml"
 
         self.write_label()
 

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_orbnum_file.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_orbnum_file.py
@@ -60,10 +60,7 @@ class OrbnumFilePDS4Label(PDSLabel):
         if self.TABLE_CHARACTER_DESCRIPTION:
             self.TABLE_CHARACTER_DESCRIPTION = self.get_table_character_description()
 
-        # TODO: BUG, split(".")[0] truncates at the FIRST dot, not at the
-        #       file extension. A name with more than one dot loses everything
-        #       after the first.
-        self.name = product.name.split(".")[0] + ".xml"
+        self.name = Path(product.name).stem + ".xml"
 
         self.write_label()
 

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_orbnum_file.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_orbnum_file.py
@@ -60,7 +60,7 @@ class OrbnumFilePDS4Label(PDSLabel):
         if self.TABLE_CHARACTER_DESCRIPTION:
             self.TABLE_CHARACTER_DESCRIPTION = self.get_table_character_description()
 
-        self.name = Path(product.name).stem + ".xml"
+        self.name = Path(product.name).with_suffix(".xml").name
 
         self.write_label()
 

--- a/src/pds/naif_pds4_bundler/utils/files.py
+++ b/src/pds/naif_pds4_bundler/utils/files.py
@@ -265,7 +265,7 @@ def add_crs_to_file(file, eol, setup=False):
     :raise: If CR cannot be added to the file
     """
     try:
-        file_crs = file.split(".")[0] + "crs_tmp"
+        file_crs = Path(file).parent / (Path(file).stem + "crs_tmp")
         with open(file, "r", encoding='utf-8') as r:
             with open(file_crs, "w+", encoding='utf-8') as f:
                 for line in r:
@@ -767,7 +767,7 @@ def checksum_from_label(path):
     :rtype: str
     """
     checksum = ""
-    product_label = path.split(".")[0] + ".xml"
+    product_label = Path(path).with_suffix(".xml")
     if os.path.exists(product_label):
         with open(product_label, "r", encoding='utf-8') as lbl:
             for line in lbl:

--- a/tests/npb/test_classes_label_pds4_checksum.py
+++ b/tests/npb/test_classes_label_pds4_checksum.py
@@ -147,8 +147,8 @@ class TestChecksumPDS4Label:
     @pytest.mark.parametrize('product_name, expected_file_name, expected_label_name', [
         ('checksum.tab', 'checksum.tab', 'checksum.xml'),
         ('checksum', 'checksum', 'checksum.xml'),
-        ('checksum.v01.tab', 'checksum.v01.tab', 'checksum.xml')])
-    def test_label_name_is_derived_from_text_before_first_dot(
+        ('checksum.v01.tab', 'checksum.v01.tab', 'checksum.v01.xml')])
+    def test_label_name_is_derived_from_stem(
             self, tmp_path: Path, helpers: SimpleNamespace,
             product_name: str, expected_file_name: str,
             expected_label_name: str) -> None:

--- a/tests/npb/test_classes_label_pds4_document.py
+++ b/tests/npb/test_classes_label_pds4_document.py
@@ -72,11 +72,8 @@ class TestDocumentPDS4LabelInit:
         # once.
         write_label_mock.assert_called_once_with(document_label)
 
-    def test_init_currently_truncates_collection_name_at_first_dot(
+    def test_init_derives_collection_name_from_stem(
             self, mocker, tmp_path: Path) -> None:
-        # This test document a bug. A valid file name containing more than one
-        # dot is truncated at the first dot.
-
         # Create an object with a valid file name with more than one dot.
         setup, collection, inventory = self.make_document_label_inputs(
             tmp_path, collection_name='collection.document_inventory_v001.csv')
@@ -89,8 +86,8 @@ class TestDocumentPDS4LabelInit:
 
         document_label = DocumentPDS4Label(setup, collection, inventory)
 
-        # Represents the truncated file name because the bug.
-        assert document_label.name == 'collection.xml'
+        # Only the last suffix is replaced; earlier dots in the name are preserved.
+        assert document_label.name == 'collection.document_inventory_v001.xml'
 
 
 class TestDocumentPDS4LabelIntegration:

--- a/tests/npb/test_classes_label_pds4_inventory.py
+++ b/tests/npb/test_classes_label_pds4_inventory.py
@@ -421,16 +421,14 @@ class TestInventoryPDS4Label:
                 InventoryPDS4Label(setup, collection, inventory)
 
     # ------------------------------------------------------------------
-    # XML label name derivation (truncation bug)
+    # XML label name derivation
     # ------------------------------------------------------------------
 
     @pytest.mark.parametrize('collection_name, expected_label_name', [
         ('spice_kernels', 'spice_kernels.xml'),
         ('document', 'document.xml'),
-        # TODO: BUG; collection.name.split(".")[0] truncates at the FIRST dot,
-        #       so a name with more than one dot loses everything after it.
-        ('collection.document_inventory_v001.csv', 'collection.xml')])
-    def test_label_name_is_derived_from_text_before_first_dot(
+        ('collection.document_inventory_v001.csv', 'collection.document_inventory_v001.xml')])
+    def test_label_name_is_derived_from_stem(
             self, tmp_path: Path, helpers: SimpleNamespace,
             collection_name: str, expected_label_name: str) -> None:
         # Document how collection names are converted into XML label names.

--- a/tests/npb/test_classes_label_pds4_metakernel.py
+++ b/tests/npb/test_classes_label_pds4_metakernel.py
@@ -292,15 +292,12 @@ class TestMetaKernelPDS4Label:
     @pytest.mark.parametrize('product_name, expected_label_name', [
         ('maven_v01.tm', 'maven_v01.xml'),
         ('maven', 'maven.xml'),
-        # TODO: BUG; product.name.split(".")[0] truncates at the FIRST dot, so
-        #       a legitimate multi-dot name loses everything after it.
-        ('maven_v01.0.tm', 'maven_v01.xml')])
-    def test_label_name_is_derived_from_text_before_first_dot(
+        ('maven_v01.0.tm', 'maven_v01.0.xml')])
+    def test_label_name_is_derived_from_stem(
             self, tmp_path: Path, helpers: SimpleNamespace,
             product_name: str, expected_label_name: str) -> None:
         # Document how product names are converted into XML label names. The
-        # last case proves the truncation bug shared with the other PDS4
-        # labels.
+        # last case has more than one dot; only the last suffix is replaced.
 
         # Mock the setup so that the label can be built.
         setup = helpers.make_setup()

--- a/tests/npb/test_classes_label_pds4_orbnum_file.py
+++ b/tests/npb/test_classes_label_pds4_orbnum_file.py
@@ -357,15 +357,12 @@ class TestOrbnumFilePDS4Label:
     @pytest.mark.parametrize('product_name, expected_label_name', [
         ('maven_orb_v01.orb', 'maven_orb_v01.xml'),
         ('maven_orb', 'maven_orb.xml'),
-        # TODO: BUG; product.name.split(".")[0] truncates at the FIRST dot, so
-        #       a legitimate multi-dot name loses everything after it.
-        ('maven_orb.v01.orb', 'maven_orb.xml')])
-    def test_label_name_is_derived_from_text_before_first_dot(
+        ('maven_orb.v01.orb', 'maven_orb.v01.xml')])
+    def test_label_name_is_derived_from_stem(
             self, tmp_path: Path, helpers: SimpleNamespace,
             product_name: str, expected_label_name: str) -> None:
         # Document how product names are converted into XML label names. The
-        # last case proves the truncation bug shared with the other PDS4
-        # labels.
+        # last case has more than one dot; only the last suffix is replaced.
 
         # Mock the setup so that the label can be built.
         setup = helpers.make_setup()

--- a/tests/npb/test_utils_files.py
+++ b/tests/npb/test_utils_files.py
@@ -459,6 +459,25 @@ def test_checksum_from_label_without_checksum(tmp_path, caplog):
     assert result == ''
     assert logs == []
 
+def test_checksum_from_label_multi_dot_name(tmp_path, caplog):
+    """Multi-dot kernel names must resolve to their correctly-suffixed label,
+    not one truncated at the first dot."""
+    kernel = tmp_path / "kernel.v1.2.bc"
+    kernel.write_text("dummy")
+    label = tmp_path / "kernel.v1.2.xml"
+    label.write_text(
+        "<product><md5_checksum>ABC123</md5_checksum></product>"
+    )
+
+    with caplog.at_level(logging.INFO):
+        result = files.checksum_from_label(str(kernel))
+
+    logs = [(r[1], r[2]) for r in caplog.record_tuples]
+    assert result == "ABC123"
+    assert logs == [
+        (logging.WARNING, "-- Checksum obtained from existing label: kernel.v1.2.xml")
+    ]
+
 # ----------------------------------------------------------------------------
 # files.checksum_from_registry test
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## 🗒️ Summary
`.split(".")[0]` truncated names at the first dot instead of the last, across 7 sites in `utils/files.py` and five PDS4 label classes. Replaced with `Path.stem` / `Path.with_suffix()` so only the last suffix is affected — fixes truncation for multi-dot names, dotted directory components, and dotfiles.

Fixing this exposed five existing tests that had been explicitly written to document the truncation as expected behavior (e.g. `checksum.v01.tab` → `checksum.xml`) rather than flag it as a bug. Corrected their expectations and renamed them accordingly.

## ⚙️ Test Data and/or Report
Regression tests added/corrected:
- `tests/npb/test_utils_files.py::test_checksum_from_label_multi_dot_name` (new)
- `tests/npb/test_classes_label_pds4_checksum.py::test_label_name_is_derived_from_stem` (corrected)
- `tests/npb/test_classes_label_pds4_document.py::test_init_derives_collection_name_from_stem` (corrected)
- `tests/npb/test_classes_label_pds4_metakernel.py::test_label_name_is_derived_from_stem` (corrected)
- `tests/npb/test_classes_label_pds4_orbnum_file.py::test_label_name_is_derived_from_stem` (corrected)
- `tests/npb/test_classes_label_pds4_inventory.py::test_label_name_is_derived_from_stem` (corrected)

```
$ pytest tests/npb -x -q --cov-branch

Name                                                       Stmts  Miss  Branch  BrPart  Cover
------------------------------------------------------------------------------------------------
src/pds/naif_pds4_bundler/utils/files.py                     421     0     192       1    99%
src/pds/naif_pds4_bundler/classes/label/pds4_checksum.py      14     0       0       0   100%
src/pds/naif_pds4_bundler/classes/label/pds4_document.py      15     0       0       0   100%
src/pds/naif_pds4_bundler/classes/label/pds4_metakernel.py    28     0       2       0   100%
src/pds/naif_pds4_bundler/classes/label/pds4_orbnum_file.py   47     0      10       0   100%
src/pds/naif_pds4_bundler/classes/label/pds4_inventory.py     33     0       8       0   100%
------------------------------------------------------------------------------------------------
TOTAL (full suite)                                           5092    37   2298      18    99%
------------------------------------------------------------------------------------------------
1757 passed, 8 skipped, 1 xfailed in 64.60s
```

Note: `files.py`'s 1 partial branch (`427->430`) is a pre-existing branch in an unrelated metakernel-parsing loop — not introduced by this fix, and not covered by these tests since it's out of scope. All 5 label-class files are at 100%.

## ♻️ Related Issues
- Closes #294