### PR TITLE
Reach 100% branch coverage of `files.mk_to_list`; flag silent-skip bug

### DIFF
--- a/tests/npb/test_utils_files.py
+++ b/tests/npb/test_utils_files.py
@@ -1229,13 +1229,16 @@ def test_mk_to_list(mk, num_kernels, first, last):
 
 def test_mk_to_list_error(monkeypatch, tmp_path, caplog):
     """Test mk_to_list function using pytest. This is to test logging errors"""
-    mk_content = """
-    KPL/MK
-    PATH_SYMBOLS = ( 'KERNELS' )
-    \\KERNELS_TO_LOAD = (
-        # This list is intentionally empty
+    mk_content = (
+        "KPL/MK\n"
+        "\n"
+        "\\begindata\n"
+        "\n"
+        "PATH_VALUES = ( './data' )\n"
+        "PATH_SYMBOLS = ( 'KERNELS' )\n"
+        "KERNELS_TO_LOAD = (\n"
+        ")\n"
     )
-    """
     mk = tmp_path / "empty_kernels.tm"
     mk.write_text(mk_content)
 
@@ -1248,6 +1251,33 @@ def test_mk_to_list_error(monkeypatch, tmp_path, caplog):
         files.mk_to_list(str(mk), setup=False)
 
     assert [f"No kernels present in {mk}. Please review MK generation."] == caplog.messages
+
+# TODO: BUG: This demonstrates an issue with the code. The proposed metakernel is
+#       not valid. If loaded into SPICE,  it would produce a SPICE(FILEREADFAILED)
+#       error, caused by the empty kernel name. This means, that in this case, NPB
+#       shall produce an error and not silently skipping the invalid entry in the
+#       metakernel.
+def test_mk_to_list_skips_empty_kernel_after_trailing_slash(tmp_path):
+    """Kernel paths ending with '/' produce an empty string after split('/') [-1].
+    Those entries must be silently skipped while valid entries are still collected."""
+    mk_content = (
+        "KPL/MK\n"
+        "\n"
+        "\\begindata\n"
+        "\n"
+        "PATH_VALUES = ( './data' )\n"
+        "PATH_SYMBOLS = ( 'KERNELS' )\n"
+        "KERNELS_TO_LOAD = (\n"
+        "  '$KERNELS/'\n"                     # trailing slash → empty kernel name
+        "  '$KERNELS/naif0012.tls'\n"
+        ")\n"
+    )
+    mk = tmp_path / "trailing_slash.tm"
+    mk.write_text(mk_content)
+
+    kernels = files.mk_to_list(str(mk), setup=False)
+    assert kernels == ["naif0012.tls"]
+
 
 # ----------------------------------------------------------------------------
 # files.product_mapping test


### PR DESCRIPTION
## 🗒️ Summary

Closes the last open branch in `files.py` coverage (`437->440`) by adding a test for the `if kernel:` false branch in `mk_to_list`. This branch fires when a `KERNELS_TO_LOAD` entry ends with `'$KERNELS/'` and `split('/')[-1]` yields an empty string.

A `TODO: BUG` comment is added on the new test to flag that SPICE would reject such a metakernel with `SPICE(FILEREADFAILED)`, so NPB should raise an error rather than silently skipping the entry.

Also corrects `test_mk_to_list_error`: the previous fixture used a malformed triple-quoted string lacking `\begindata`, `PATH_VALUES`, and proper MK structure. It is replaced with a well-formed fixture.

## ⚙️ Test Data and/or Report

```
Name                                          Stmts   Miss Branch BrPart  Cover
--------------------------------------------------------------------------------
src/pds/naif_pds4_bundler/utils/files.py        420      0    192      0   100%
--------------------------------------------------------------------------------
222 passed in 4.26s
```