### PR TITLE
Fix dead branches in `Setup` class to reach 100% branch coverage

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/setup.py
+++ b/src/pds/naif_pds4_bundler/classes/setup.py
@@ -645,18 +645,11 @@ class Setup:
             schemas_eval.sort(reverse=True)
             schemas = [schemas[i] for i in schemas_index]
 
-            i = 0
-            while i < len(schemas_eval):
-                if config_schema < schemas_eval[i]:
-                    try:
-                        schema = schemas[i - 1]
-                    except:
-                        # TODO: Code not reachable due to bug.
-                        schema = schemas[0]
-                if config_schema >= schemas_eval[i]:
+            schema = schemas[-1]  # oldest available; fallback if config predates all templates
+            for i, eval_val in enumerate(schemas_eval):
+                if config_schema >= eval_val:
                     schema = schemas[i]
                     break
-                i += 1
 
             templates_directory = f"{self.root_dir}templates/{schema}/"
         #

--- a/src/pds/naif_pds4_bundler/classes/setup.py
+++ b/src/pds/naif_pds4_bundler/classes/setup.py
@@ -320,7 +320,7 @@ class Setup:
                 r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z"
             )
             time_format = "YYYY-MM-DDThh:mm:ss.sssZ"
-        elif self.date_format == "maklabel":
+        else:  # date_format == "maklabel"; the XSD allows no other value
 
             #
             # Warn the user if the End of Line character is not the one

--- a/tests/npb/test_classes_setup.py
+++ b/tests/npb/test_classes_setup.py
@@ -1178,10 +1178,9 @@ class TestSetupCheckConfiguration:
         (im_version(2, 1, 0, 0), 'https://example.com/PDS4_PDS_2100.sch',
          'https://pds.nasa.gov/pds4/pds/v1 https://example.com/PDS4_PDS_2100.xsd',
          im_version(2, 0, 0, 0)),
-        pytest.param(im_version(1, 0, 0, 0), 'https://example.com/PDS4_PDS_1000.sch',
-                     'https://pds.nasa.gov/pds4/pds/v1 https://example.com/PDS4_PDS_1000.xsd',
-                     im_version(1, 5, 0, 0),
-                     marks=pytest.mark.skip(reason='Fails due to bug'))])
+        (im_version(1, 0, 0, 0), 'https://example.com/PDS4_PDS_1000.sch',
+         'https://pds.nasa.gov/pds4/pds/v1 https://example.com/PDS4_PDS_1000.xsd',
+         im_version(1, 5, 0, 0))])
     def test_uses_closest_available_templates_when_exact_schema_is_unavailable(
             self, tmp_path, caplog, information_model, xml_model, schema_location,
             expected_template_version) -> None:


### PR DESCRIPTION
## 🗒️ Summary

Two structural fixes to `Setup` in `setup.py` that eliminated unreachable branches and a logical bug:

1. **`date_format` branch** — The `elif self.date_format == "maklabel"` condition was replaced with a plain `else`. The XSD schema restricts `date_format` to exactly `"infomod2"` or `"maklabel"`, and the class defaults it to `"maklabel"` when absent, so the `elif` condition could never be false. The redundant check created a dead branch in coverage.

2. **Schema-selection loop** — The `while` loop had two bugs: (a) a `try/except` around `schemas[i - 1]` that was dead code because Python's negative indexing silently wraps at `i == 0` rather than raising `IndexError` (acknowledged by a `# TODO` comment in the original code); and (b) when `config_schema` predates all available template directories the loop exhausted without breaking, leaving `schema` set to a wrong intermediate value. Replaced with a `for` loop that pre-sets `schema = schemas[-1]` (the oldest template, which is the correct fallback) before iterating.

## ⚙️ Test Data and/or Report

`test_classes_setup.py` reaches 100% branch coverage on `setup.py` after these changes. The previously skipped test covering the "config predates all templates" edge case was re-enabled to exercise the new fallback path.
