### PR TITLE
Refactor(L-01): split PDSLabel into version-agnostic base + PDS3Label/PDS4Label

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -119,13 +119,10 @@ class PDSLabel:
         """Write the Label."""
         label_dictionary = vars(self)
 
-        label_extension = self._label_extension
-        eol = self._eol
-
-        if label_extension not in self.product.path:
+        if self._label_extension not in self.product.path:
             label_name = (
                 self.product.path.split(f".{self.product.extension}")[0]
-                + label_extension
+                + self._label_extension
             )
         else:
             #
@@ -154,7 +151,7 @@ class PDSLabel:
                     #
                     if label_name.split(os.sep)[-1] == "checksum.lbl":
                         line += " " * (self.product.record_bytes - len(line) - 2)
-                    line = add_carriage_return(line, eol, self.setup)
+                    line = add_carriage_return(line, self._eol, self.setup)
 
                     f.write(line)
 

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -15,6 +15,8 @@ class PDSLabel:
     :param product: Product to be labeled
     """
 
+    _label_extension: str
+
     def __init__(self, setup, product) -> None:
         """Constructor."""
         self.name = ''

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -92,19 +92,6 @@ class PDSLabel:
             self.targets = product.targets
 
     @property
-    def _mission_reference_type(self):
-        """Get the mission reference type.
-
-        Version-agnostic labels have no notion of a mission reference type;
-        only PDS4 labels do. Subclasses that need one must override this.
-
-        :raises NotImplementedError: always, on the base class
-        """
-        raise NotImplementedError(
-            f"{type(self).__name__} does not define a mission reference type."
-        )
-
-    @property
     def _target_reference_type(self):
         """Get the target reference type.
 

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -91,19 +91,6 @@ class PDSLabel:
             self.observers = product.observers
             self.targets = product.targets
 
-    @property
-    def _target_reference_type(self):
-        """Get the target reference type.
-
-        Version-agnostic labels have no notion of a target reference type;
-        only PDS4 labels do. Subclasses that need one must override this.
-
-        :raises NotImplementedError: always, on the base class
-        """
-        raise NotImplementedError(
-            f"{type(self).__name__} does not define a target reference type."
-        )
-
     def write_label(self):
         """Write the Label."""
         label_dictionary = vars(self)

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -91,7 +91,8 @@ class PDSLabel:
             self.observers = product.observers
             self.targets = product.targets
 
-    def get_mission_reference_type(self):
+    @property
+    def _mission_reference_type(self):
         """Get the mission reference type.
 
         Version-agnostic labels have no notion of a mission reference type;
@@ -103,7 +104,8 @@ class PDSLabel:
             f"{type(self).__name__} does not define a mission reference type."
         )
 
-    def get_target_reference_type(self):
+    @property
+    def _target_reference_type(self):
         """Get the target reference type.
 
         Version-agnostic labels have no notion of a target reference type;

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -16,6 +16,8 @@ class PDSLabel:
     """
 
     _label_extension: str
+    _eol: str
+    _template: str
 
     def __init__(self, setup, product) -> None:
         """Constructor."""
@@ -115,7 +117,7 @@ class PDSLabel:
         # Using newline guarantees that what we write into the file is what
         # we intend to write, independently of the platform.
         with open(label_name, "w+", encoding='utf-8', newline='') as f:
-            with open(self.template, "r", encoding='utf-8') as t:
+            with open(self._template, "r", encoding='utf-8') as t:
                 for line in t:
                     line = line.rstrip()
                     for key, value in label_dictionary.items():

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -5,7 +5,6 @@ import logging
 import os
 from pathlib import Path
 
-from ...pipeline.runtime import handle_npb_error
 from ...utils import add_carriage_return, compare_files
 
 
@@ -18,14 +17,6 @@ class PDSLabel:
 
     def __init__(self, setup, product) -> None:
         """Constructor."""
-        if setup.pds_version == "4":
-            try:
-                context_products = product.collection.bundle.context_products
-                if not context_products:
-                    raise Exception("No context products from bundle in collection")
-            except BaseException:
-                context_products = product.bundle.context_products
-
         self.name = ''
         self.product = product
         self.setup = setup
@@ -35,64 +26,6 @@ class PDSLabel:
         #
         self.root_dir = setup.root_dir
         self.mission_acronym = setup.mission_acronym
-
-        if setup.pds_version == "4":
-            self.XML_MODEL = setup.xml_model
-            self.SCHEMA_LOCATION = setup.schema_location
-            self.INFORMATION_MODEL_VERSION = setup.information_model
-
-            #
-            # Needs to be built for several Missions.
-            #
-            if hasattr(setup, "secondary_missions"):
-                if len(setup.secondary_missions) == 1:
-                    missions_text = (
-                        f"{setup.mission_name} and {setup.secondary_missions[0]}"
-                    )
-                else:
-                    missions_text = f"{setup.mission_name}, "
-                    for i, sm_name in enumerate(setup.secondary_missions):
-                        if i == len(setup.secondary_missions) - 1:
-                            missions_text += f"and {sm_name}"
-                        else:
-                            missions_text += f"{sm_name}, "
-
-                self.PDS4_MISSION_NAME = f"{missions_text}"
-            else:
-                self.PDS4_MISSION_NAME = f"{setup.mission_name}"
-
-            #
-            # Needs to be built for several observers.
-            #
-            if hasattr(setup, "secondary_observers"):
-                if len(setup.secondary_observers) == 1:
-                    observers_text = (
-                        f"{setup.observer} and {setup.secondary_observers[0]}"
-                    )
-                else:
-                    observers_text = f"{setup.observer}, "
-                    for i, so_name in enumerate(setup.secondary_observers):
-                        if i == len(setup.secondary_observers) - 1:
-                            observers_text += f"and {so_name}"
-                        else:
-                            observers_text += f"{so_name}, "
-
-                self.PDS4_OBSERVER_NAME = f"{observers_text} spacecraft and their"
-            else:
-                self.PDS4_OBSERVER_NAME = f"{setup.observer} spacecraft and its"
-
-            self.END_OF_LINE_PDS4 = "Carriage-Return Line-Feed"
-            if setup.end_of_line == "CRLF":
-                self.END_OF_LINE = "Carriage-Return Line-Feed"
-            elif setup.end_of_line == "LF":
-                self.END_OF_LINE = "Line-Feed"
-            else:
-                handle_npb_error(
-                    "End of Line provided via configuration is not CRLF nor LF.",
-                    setup=self.setup,
-                )
-
-            self.BUNDLE_DESCRIPTION_LID = f"{setup.logical_identifier}:document:spiceds"
 
         if hasattr(self.setup, "creation_date_time"):
             creation_dt = self.setup.creation_date_time
@@ -158,231 +91,36 @@ class PDSLabel:
             self.observers = product.observers
             self.targets = product.targets
 
-        if setup.pds_version == "4":
-            self.MISSIONS = self.get_missions()
-            self.OBSERVERS = self.get_observers()
-            self.TARGETS = self.get_targets()
-
-    def get_missions(self) -> str:
-        """Get the label mission from the context products.
-
-        :return: List of missions to be included in the label
-        """
-        miss = self.missions
-
-        if not isinstance(miss, list):
-            miss = [miss]
-
-        mis_list_for_label = ""
-
-        try:
-            context_products = self.product.collection.bundle.context_products
-        except BaseException:
-            context_products = self.product.bundle.context_products
-
-        eol = self.setup.eol_pds4
-        tab = self.setup.xml_tab
-        for mis in miss:
-            if mis:
-                mis_name = mis
-                mission_lid, mission_type = None, None
-                for product in context_products:
-                    if product["name"][0] == mis_name and (
-                        product["type"][0] == "Mission"
-                        or product["type"][0] == "Other Investigation"
-                    ):
-                        mission_lid = product["lidvid"].split("::")[0]
-                        mission_type = product["type"][0]
-
-                if not mission_lid:
-                    handle_npb_error(
-                        f"LID has not been obtained for mission {mis}.",
-                        setup=self.setup,
-                    )
-
-                mis_list_for_label += (
-                    f"{' ' * 2 * tab}<Investigation_Area>{eol}"
-                    + f"{' ' * 3 * tab}<name>{mis_name}</name>{eol}"
-                    + f"{' ' * 3 * tab}<type>{mission_type}</type>{eol}"
-                    + f"{' ' * 3 * tab}<Internal_Reference>{eol}"
-                    + f"{' ' * 4 * tab}<lid_reference>{mission_lid}"
-                    f"</lid_reference>{eol}" + f"{' ' * 4 * tab}<reference_type>"
-                    f"{self.get_mission_reference_type()}"
-                    f"</reference_type>{eol}"
-                    + f"{' ' * 3 * tab}</Internal_Reference>{eol}"
-                    + f"{' ' * 2 * tab}</Investigation_Area>{eol}"
-                )
-        if not mis_list_for_label:
-            handle_npb_error(
-                f"{self.product.name} missions not defined.", setup=self.setup
-            )
-        mis_list_for_label = mis_list_for_label.rstrip() + eol
-
-        return mis_list_for_label
-
     def get_mission_reference_type(self):
         """Get the mission reference type.
 
-        :return: Mission_Reference_Type value for PDS4 label
-        :rtype: str
+        Version-agnostic labels have no notion of a mission reference type;
+        only PDS4 labels do. Subclasses that need one must override this.
+
+        :raises NotImplementedError: always, on the base class
         """
-        if self.__class__.__name__ == "ChecksumPDS4Label":
-            ref_type = "ancillary_to_investigation"
-        elif self.__class__.__name__ == "BundlePDS4Label":
-            ref_type = "bundle_to_investigation"
-        elif self.__class__.__name__ == "DocumentPDS4Label":
-            ref_type = "document_to_investigation"
-        elif self.__class__.__name__ == "InventoryPDS4Label":
-            ref_type = "collection_to_investigation"
-        elif self.__class__.__name__ == "OrbnumFilePDS4Label":
-            if self.setup.information_model_float >= 1014000000.0:
-                ref_type = "ancillary_to_investigation"
-            else:
-                ref_type = "data_to_investigation"
-        else:
-            ref_type = "data_to_investigation"
-
-        return ref_type
-
-    def get_observers(self) -> str:
-        """Get the label observers from the context products.
-
-        :return: List of Observers to be included in the label
-        """
-        obs = self.observers
-        if not isinstance(obs, list):
-            obs = [obs]
-
-        obs_list_for_label = ""
-
-        try:
-            context_products = self.product.collection.bundle.context_products
-        except BaseException:
-            context_products = self.product.bundle.context_products
-
-        eol = self.setup.eol_pds4
-        tab = self.setup.xml_tab
-
-        for ob in obs:
-            if ob:
-                ob_lid, ob_type = None, None
-                ob_name = ob.split(",")[0]
-                for product in context_products:
-                    if product["name"][0] == ob_name and (
-                        product["type"][0] == "Spacecraft"
-                        or product["type"][0] == "Rover"
-                        or product["type"][0] == "Lander"
-                        or product["type"][0] == "Host"
-                    ):
-                        ob_lid = product["lidvid"].split("::")[0]
-                        ob_type = product["type"][0]
-
-                if not ob_lid:
-                    handle_npb_error(
-                        f"LID has not been obtained for observer {ob}.",
-                        setup=self.setup,
-                    )
-
-                obs_list_for_label += (
-                    f"{' ' * 3 * tab}<Observing_System_Component>{eol}"
-                    + f"{' ' * (3+1) * tab}<name>{ob_name}</name>{eol}"
-                    + f"{' ' * (3+1) * tab}<type>{ob_type}</type>{eol}"
-                    + f"{' ' * (3+1) * tab}<Internal_Reference>{eol}"
-                    + f"{' ' * (3 + 2) * tab}<lid_reference>{ob_lid}"
-                    f"</lid_reference>{eol}"
-                    + f"{' ' * (3 + 2) * tab}<reference_type>is_instrument_host"
-                    f"</reference_type>{eol}"
-                    + f"{' ' * (3+1) * tab}</Internal_Reference>{eol}"
-                    + f"{' ' * 3 * tab}</Observing_System_Component>{eol}"
-                )
-
-        if not obs_list_for_label:
-            handle_npb_error(
-                f"{self.product.name} observers not defined.", setup=self.setup
-            )
-        obs_list_for_label = obs_list_for_label.rstrip() + eol
-
-        return obs_list_for_label
-
-    def get_targets(self) -> str:
-        """Get the label targets from the context products.
-
-        :return: List of Targets to be included in the label
-        """
-        tars = self.targets
-        if not isinstance(tars, list):
-            tars = [tars]
-
-        tar_list_for_label = ""
-
-        try:
-            context_products = self.product.collection.bundle.context_products
-        except BaseException:
-            context_products = self.product.bundle.context_products
-
-        eol = self.setup.eol_pds4
-        tab = self.setup.xml_tab
-
-        for tar in tars:
-            if tar:
-                target_name = tar
-                target_lid, target_type = None, None
-                for product in context_products:
-                    if product["name"][0].upper() == target_name.upper():
-                        target_lid = product["lidvid"].split("::")[0]
-                        target_type = product["type"][0].capitalize()
-
-                tar_list_for_label += (
-                    f"{' ' * 2 * tab}<Target_Identification>{eol}"
-                    + f"{' ' * 3 * tab}<name>{target_name}</name>{eol}"
-                    + f"{' ' * 3 * tab}<type>{target_type}</type>{eol}"
-                    + f"{' ' * 3 * tab}<Internal_Reference>{eol}"
-                    + f"{' ' * 4 * tab}<lid_reference>{target_lid}"
-                    f"</lid_reference>{eol}" + f"{' ' * 4 * tab}<reference_type>"
-                    f"{self.get_target_reference_type()}"
-                    f"</reference_type>{eol}"
-                    + f"{' ' * 3 * tab}</Internal_Reference>{eol}"
-                    + f"{' ' * 2 * tab}</Target_Identification>{eol}"
-                )
-
-        if not tar_list_for_label:
-            handle_npb_error(f"{self.product.name} targets not defined.", setup=self.setup)
-        tar_list_for_label = tar_list_for_label.rstrip() + eol
-
-        return tar_list_for_label
+        raise NotImplementedError(
+            f"{type(self).__name__} does not define a mission reference type."
+        )
 
     def get_target_reference_type(self):
         """Get the target reference type.
 
-        :return: Target_Reference_Type value for PDS4 label
-        :rtype: str
-        """
-        if self.__class__.__name__ == "ChecksumPDS4Label":
-            ref_type = "ancillary_to_target"
-        elif self.__class__.__name__ == "BundlePDS4Label":
-            ref_type = "bundle_to_target"
-        elif self.__class__.__name__ == "InventoryPDS4Label":
-            ref_type = "collection_to_target"
-        elif self.__class__.__name__ == "OrbnumFilePDS4Label":
-            if self.setup.information_model_float >= 1014000000.0:
-                ref_type = "ancillary_to_target"
-            else:
-                ref_type = "data_to_target"
-        else:
-            ref_type = "data_to_target"
+        Version-agnostic labels have no notion of a target reference type;
+        only PDS4 labels do. Subclasses that need one must override this.
 
-        return ref_type
+        :raises NotImplementedError: always, on the base class
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not define a target reference type."
+        )
 
     def write_label(self):
         """Write the Label."""
         label_dictionary = vars(self)
 
-        if self.setup.pds_version == "4":
-            label_extension = ".xml"
-            eol = self.setup.eol_pds4
-        else:
-            label_extension = ".lbl"
-            eol = self.setup.eol_pds3
+        label_extension = self._label_extension
+        eol = self._eol
 
         if label_extension not in self.product.path:
             label_name = (

--- a/src/pds/naif_pds4_bundler/classes/label/pds3_checksum.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds3_checksum.py
@@ -2,10 +2,10 @@
 """
 from pathlib import Path
 
-from .label import PDSLabel
+from .pds3_label import PDS3Label
 
 
-class ChecksumPDS3Label(PDSLabel):
+class ChecksumPDS3Label(PDS3Label):
     """PDS Label child class to a PDS3 Checksum Label.
 
     :param setup:   NPB  execution Setup object

--- a/src/pds/naif_pds4_bundler/classes/label/pds3_checksum.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds3_checksum.py
@@ -16,8 +16,8 @@ class ChecksumPDS3Label(PDS3Label):
         """Constructor."""
         super().__init__(setup, product)
 
-        self.template = str(Path(setup.templates_directory)
-                            / "template_product_checksum_table.lbl")
+        self._template = str(Path(setup.templates_directory)
+                             / "template_product_checksum_table.lbl")
 
         self.VOLUME_ID = self.setup.volume_id.upper()
         self.PRODUCT_CREATION_TIME = product.creation_time

--- a/src/pds/naif_pds4_bundler/classes/label/pds3_inventory.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds3_inventory.py
@@ -1,9 +1,9 @@
 """Implementation of the PDS3 version of a label for Index files.
 """
-from .label import PDSLabel
+from .pds3_label import PDS3Label
 
 
-class InventoryPDS3Label(PDSLabel):
+class InventoryPDS3Label(PDS3Label):
     """PDS Label child class to generate a PDS3 Index Label.
 
     :param setup:      NPB execution Setup object

--- a/src/pds/naif_pds4_bundler/classes/label/pds3_inventory.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds3_inventory.py
@@ -19,7 +19,7 @@ class InventoryPDS3Label(PDS3Label):
 
         # TODO: Check why this template path is not following the approach of all
         #       other labels.
-        self.template = f'{self.root_dir}/templates/pds3/template_collection_{collection.type}.lbl'
+        self._template = f'{self.root_dir}/templates/pds3/template_collection_{collection.type}.lbl'
 
         self.VOLUME_ID = self.setup.volume_id
         self.ROW_BYTES = str(self.product.row_bytes)

--- a/src/pds/naif_pds4_bundler/classes/label/pds3_label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds3_label.py
@@ -1,0 +1,23 @@
+"""PDS3 version-specific base class for PDS labels."""
+
+from .label import PDSLabel
+
+
+class PDS3Label(PDSLabel):
+    """Version-specific base class for PDS3 labels.
+
+    Leaf PDS3 label classes still assign their own PDS3-specific fields
+    in their own ``__init__``; this class exists so that ``write_label()``
+    can ask any label for its extension and end-of-line convention without
+    checking ``setup.pds_version``.
+    """
+
+    @property
+    def _label_extension(self) -> str:
+        """File extension used for PDS3 labels."""
+        return ".lbl"
+
+    @property
+    def _eol(self) -> str:
+        """End-of-line convention used for PDS3 labels."""
+        return self.setup.eol_pds3

--- a/src/pds/naif_pds4_bundler/classes/label/pds3_label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds3_label.py
@@ -12,10 +12,8 @@ class PDS3Label(PDSLabel):
     checking ``setup.pds_version``.
     """
 
-    @property
-    def _label_extension(self) -> str:
-        """File extension used for PDS3 labels."""
-        return ".lbl"
+    # File extension used for PDS3 labels.
+    _label_extension = ".lbl"
 
     @property
     def _eol(self) -> str:

--- a/src/pds/naif_pds4_bundler/classes/label/pds3_spice_kernel.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds3_spice_kernel.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import spiceypy
 
-from .label import PDSLabel
+from .pds3_label import PDS3Label
 from ...pipeline.runtime import handle_npb_error
 from ...utils import (
     ck_coverage,
@@ -16,7 +16,7 @@ from ...utils import (
 )
 
 
-class SpiceKernelPDS3Label(PDSLabel):
+class SpiceKernelPDS3Label(PDS3Label):
     """Class to generate a PDS3 SPICE Kernel Label.
     """
 

--- a/src/pds/naif_pds4_bundler/classes/label/pds3_spice_kernel.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds3_spice_kernel.py
@@ -24,8 +24,8 @@ class SpiceKernelPDS3Label(PDS3Label):
         """Constructor."""
         super().__init__(mission, product)
 
-        self.template = str(Path(self.setup.templates_directory)
-                            / "template_product_spice_kernel.lbl")
+        self._template = str(Path(self.setup.templates_directory)
+                             / "template_product_spice_kernel.lbl")
 
         self.FILE_NAME = f'"{product.name}"'
         self.INTERCHANGE_FORMAT = product.file_format

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_bundle.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_bundle.py
@@ -2,10 +2,10 @@
 """
 from pathlib import Path
 
-from .label import PDSLabel
+from .pds4_label import PDS4Label
 
 
-class BundlePDS4Label(PDSLabel):
+class BundlePDS4Label(PDS4Label):
     """Class to generate a PDS4 Bundle Label.
 
     :param setup:  NPB execution Setup object

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_bundle.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_bundle.py
@@ -19,8 +19,8 @@ class BundlePDS4Label(PDS4Label):
         """Constructor."""
         super().__init__(setup, readme)
 
-        self.template = str(Path(setup.templates_directory)
-                            / "template_bundle.xml")
+        self._template = str(Path(setup.templates_directory)
+                             / "template_bundle.xml")
 
         self.BUNDLE_LID = self.product.bundle.lid
         self.BUNDLE_VID = self.product.bundle.vid

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_bundle.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_bundle.py
@@ -12,6 +12,9 @@ class BundlePDS4Label(PDS4Label):
     :param readme: Readme product
     """
 
+    _mission_reference_type = "bundle_to_investigation"
+    _target_reference_type = "bundle_to_target"
+
     def __init__(self, setup, readme) -> None:
         """Constructor."""
         super().__init__(setup, readme)
@@ -74,19 +77,3 @@ class BundlePDS4Label(PDS4Label):
             )
 
         self.write_label()
-
-    def get_mission_reference_type(self):
-        """Get mission reference type.
-
-        :return: Literally ``bundle_to_investigation``
-        :rtype: str
-        """
-        return "bundle_to_investigation"
-
-    def get_target_reference_type(self):
-        """Get target reference type.
-
-        :return: Literally ``bundle_to_target``
-        :rtype: str
-        """
-        return "bundle_to_target"

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_checksum.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_checksum.py
@@ -2,10 +2,10 @@
 """
 from pathlib import Path
 
-from .label import PDSLabel
+from .pds4_label import PDS4Label
 
 
-class ChecksumPDS4Label(PDSLabel):
+class ChecksumPDS4Label(PDS4Label):
     """Class to generate a PDS4 Checksum Label.
 
     :param setup: NPB execution Setup object
@@ -28,3 +28,19 @@ class ChecksumPDS4Label(PDSLabel):
         self.name = Path(product.name).with_suffix(".xml").name
 
         self.write_label()
+
+    def get_mission_reference_type(self):
+        """Get mission reference type.
+
+        :return: Literally ``ancillary_to_investigation``
+        :rtype: str
+        """
+        return "ancillary_to_investigation"
+
+    def get_target_reference_type(self):
+        """Get target reference type.
+
+        :return: Literally ``ancillary_to_target``
+        :rtype: str
+        """
+        return "ancillary_to_target"

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_checksum.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_checksum.py
@@ -19,8 +19,8 @@ class ChecksumPDS4Label(PDS4Label):
         """Constructor."""
         super().__init__(setup, product)
 
-        self.template = str(Path(setup.templates_directory)
-                            / "template_product_checksum_table.xml")
+        self._template = str(Path(setup.templates_directory)
+                             / "template_product_checksum_table.xml")
 
         self.FILE_NAME = product.name
         self.PRODUCT_LID = self.product.lid

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_checksum.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_checksum.py
@@ -12,6 +12,9 @@ class ChecksumPDS4Label(PDS4Label):
     :param product: Checksum product to label
     """
 
+    _mission_reference_type = "ancillary_to_investigation"
+    _target_reference_type = "ancillary_to_target"
+
     def __init__(self, setup, product) -> None:
         """Constructor."""
         super().__init__(setup, product)
@@ -28,19 +31,3 @@ class ChecksumPDS4Label(PDS4Label):
         self.name = Path(product.name).with_suffix(".xml").name
 
         self.write_label()
-
-    def get_mission_reference_type(self):
-        """Get mission reference type.
-
-        :return: Literally ``ancillary_to_investigation``
-        :rtype: str
-        """
-        return "ancillary_to_investigation"
-
-    def get_target_reference_type(self):
-        """Get target reference type.
-
-        :return: Literally ``ancillary_to_target``
-        :rtype: str
-        """
-        return "ancillary_to_target"

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_document.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_document.py
@@ -13,6 +13,8 @@ class DocumentPDS4Label(PDS4Label):
     :param inventory:  Inventory Product of the Collection
     """
 
+    _mission_reference_type = "document_to_investigation"
+
     def __init__(self, setup, collection, inventory) -> None:
         """Constructor."""
         super().__init__(setup, inventory)
@@ -32,11 +34,3 @@ class DocumentPDS4Label(PDS4Label):
         self.name = Path(collection.name).with_suffix(".xml").name
 
         self.write_label()
-
-    def get_mission_reference_type(self):
-        """Get mission reference type.
-
-        :return: Literally ``document_to_investigation``
-        :rtype: str
-        """
-        return "document_to_investigation"

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_document.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_document.py
@@ -2,10 +2,10 @@
 """
 from pathlib import Path
 
-from .label import PDSLabel
+from .pds4_label import PDS4Label
 
 
-class DocumentPDS4Label(PDSLabel):
+class DocumentPDS4Label(PDS4Label):
     """Class to generate a PDS4 Document Label.
 
     :param setup:      NPB execution Setup object
@@ -32,3 +32,11 @@ class DocumentPDS4Label(PDSLabel):
         self.name = Path(collection.name).with_suffix(".xml").name
 
         self.write_label()
+
+    def get_mission_reference_type(self):
+        """Get mission reference type.
+
+        :return: Literally ``document_to_investigation``
+        :rtype: str
+        """
+        return "document_to_investigation"

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_document.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_document.py
@@ -22,8 +22,8 @@ class DocumentPDS4Label(PDS4Label):
         self.setup = setup
         self.collection = collection
 
-        self.template = str(Path(setup.templates_directory)
-                            / "template_product_html_document.xml")
+        self._template = str(Path(setup.templates_directory)
+                             / "template_product_html_document.xml")
 
         self.PRODUCT_LID = inventory.lid
         self.PRODUCT_VID = inventory.vid

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_inventory.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_inventory.py
@@ -23,8 +23,8 @@ class InventoryPDS4Label(PDS4Label):
 
         self.collection = collection
 
-        self.template = str(Path(setup.templates_directory)
-                            / f"template_collection_{collection.type}.xml")
+        self._template = str(Path(setup.templates_directory)
+                             / f"template_collection_{collection.type}.xml")
 
         self.COLLECTION_LID = self.collection.lid
         self.COLLECTION_VID = self.collection.vid

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_inventory.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_inventory.py
@@ -14,6 +14,9 @@ class InventoryPDS4Label(PDS4Label):
     :param inventory:  Inventory Product of the Collection
     """
 
+    _mission_reference_type = "collection_to_investigation"
+    _target_reference_type = "collection_to_target"
+
     def __init__(self, setup, collection, inventory) -> None:
         """Constructor."""
         super().__init__(setup, inventory)
@@ -76,19 +79,3 @@ class InventoryPDS4Label(PDS4Label):
 
         self.name = Path(collection.name).with_suffix(".xml").name
         self.write_label()
-
-    def get_mission_reference_type(self):
-        """Get mission reference type.
-
-        :return: Literally ``collection_to_investigation``
-        :rtype: str
-        """
-        return "collection_to_investigation"
-
-    def get_target_reference_type(self):
-        """Get target reference type.
-
-        :return: Literally ``collection_to_target``
-        :rtype: str
-        """
-        return "collection_to_target"

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_inventory.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_inventory.py
@@ -3,10 +3,10 @@ files.
 """
 from pathlib import Path
 
-from .label import PDSLabel
+from .pds4_label import PDS4Label
 
 
-class InventoryPDS4Label(PDSLabel):
+class InventoryPDS4Label(PDS4Label):
     """Class to generate a PDS4 Collection Inventory Label.
 
     :param setup:      NPB execution Setup object

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_label.py
@@ -11,6 +11,14 @@ class PDS4Label(PDSLabel):
     ``if setup.pds_version == "4":`` checks in ``PDSLabel``.
     """
 
+    # File extension used for PDS4 labels.
+    _label_extension = ".xml"
+
+    # Default Mission/Target_Reference_Type for any PDS4 label that does
+    # not override them.
+    _mission_reference_type = "data_to_investigation"
+    _target_reference_type = "data_to_target"
+
     def __init__(self, setup, product) -> None:
         """Constructor."""
         super().__init__(setup, product)
@@ -84,32 +92,9 @@ class PDS4Label(PDSLabel):
         self.TARGETS = self.get_targets()
 
     @property
-    def _label_extension(self) -> str:
-        """File extension used for PDS4 labels."""
-        return ".xml"
-
-    @property
     def _eol(self) -> str:
         """End-of-line convention used for PDS4 labels."""
         return self.setup.eol_pds4
-
-    def get_mission_reference_type(self):
-        """Get the mission reference type.
-
-        :return: Mission_Reference_Type value for PDS4 label; the default
-                 for any PDS4 label that does not override this.
-        :rtype: str
-        """
-        return "data_to_investigation"
-
-    def get_target_reference_type(self):
-        """Get the target reference type.
-
-        :return: Target_Reference_Type value for PDS4 label; the default
-                 for any PDS4 label that does not override this.
-        :rtype: str
-        """
-        return "data_to_target"
 
     def get_missions(self) -> str:
         """Get the label mission from the context products.
@@ -155,7 +140,7 @@ class PDS4Label(PDSLabel):
                     + f"{' ' * 3 * tab}<Internal_Reference>{eol}"
                     + f"{' ' * 4 * tab}<lid_reference>{mission_lid}"
                     f"</lid_reference>{eol}" + f"{' ' * 4 * tab}<reference_type>"
-                    f"{self.get_mission_reference_type()}"
+                    f"{self._mission_reference_type}"
                     f"</reference_type>{eol}"
                     + f"{' ' * 3 * tab}</Internal_Reference>{eol}"
                     + f"{' ' * 2 * tab}</Investigation_Area>{eol}"
@@ -263,7 +248,7 @@ class PDS4Label(PDSLabel):
                     + f"{' ' * 3 * tab}<Internal_Reference>{eol}"
                     + f"{' ' * 4 * tab}<lid_reference>{target_lid}"
                     f"</lid_reference>{eol}" + f"{' ' * 4 * tab}<reference_type>"
-                    f"{self.get_target_reference_type()}"
+                    f"{self._target_reference_type}"
                     f"</reference_type>{eol}"
                     + f"{' ' * 3 * tab}</Internal_Reference>{eol}"
                     + f"{' ' * 2 * tab}</Target_Identification>{eol}"

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_label.py
@@ -92,3 +92,185 @@ class PDS4Label(PDSLabel):
     def _eol(self) -> str:
         """End-of-line convention used for PDS4 labels."""
         return self.setup.eol_pds4
+
+    def get_mission_reference_type(self):
+        """Get the mission reference type.
+
+        :return: Mission_Reference_Type value for PDS4 label; the default
+                 for any PDS4 label that does not override this.
+        :rtype: str
+        """
+        return "data_to_investigation"
+
+    def get_target_reference_type(self):
+        """Get the target reference type.
+
+        :return: Target_Reference_Type value for PDS4 label; the default
+                 for any PDS4 label that does not override this.
+        :rtype: str
+        """
+        return "data_to_target"
+
+    def get_missions(self) -> str:
+        """Get the label mission from the context products.
+
+        :return: List of missions to be included in the label
+        """
+        miss = self.missions
+
+        if not isinstance(miss, list):
+            miss = [miss]
+
+        mis_list_for_label = ""
+
+        try:
+            context_products = self.product.collection.bundle.context_products
+        except BaseException:
+            context_products = self.product.bundle.context_products
+
+        eol = self.setup.eol_pds4
+        tab = self.setup.xml_tab
+        for mis in miss:
+            if mis:
+                mis_name = mis
+                mission_lid, mission_type = None, None
+                for product in context_products:
+                    if product["name"][0] == mis_name and (
+                        product["type"][0] == "Mission"
+                        or product["type"][0] == "Other Investigation"
+                    ):
+                        mission_lid = product["lidvid"].split("::")[0]
+                        mission_type = product["type"][0]
+
+                if not mission_lid:
+                    handle_npb_error(
+                        f"LID has not been obtained for mission {mis}.",
+                        setup=self.setup,
+                    )
+
+                mis_list_for_label += (
+                    f"{' ' * 2 * tab}<Investigation_Area>{eol}"
+                    + f"{' ' * 3 * tab}<name>{mis_name}</name>{eol}"
+                    + f"{' ' * 3 * tab}<type>{mission_type}</type>{eol}"
+                    + f"{' ' * 3 * tab}<Internal_Reference>{eol}"
+                    + f"{' ' * 4 * tab}<lid_reference>{mission_lid}"
+                    f"</lid_reference>{eol}" + f"{' ' * 4 * tab}<reference_type>"
+                    f"{self.get_mission_reference_type()}"
+                    f"</reference_type>{eol}"
+                    + f"{' ' * 3 * tab}</Internal_Reference>{eol}"
+                    + f"{' ' * 2 * tab}</Investigation_Area>{eol}"
+                )
+        if not mis_list_for_label:
+            handle_npb_error(
+                f"{self.product.name} missions not defined.", setup=self.setup
+            )
+        mis_list_for_label = mis_list_for_label.rstrip() + eol
+
+        return mis_list_for_label
+
+    def get_observers(self) -> str:
+        """Get the label observers from the context products.
+
+        :return: List of Observers to be included in the label
+        """
+        obs = self.observers
+        if not isinstance(obs, list):
+            obs = [obs]
+
+        obs_list_for_label = ""
+
+        try:
+            context_products = self.product.collection.bundle.context_products
+        except BaseException:
+            context_products = self.product.bundle.context_products
+
+        eol = self.setup.eol_pds4
+        tab = self.setup.xml_tab
+
+        for ob in obs:
+            if ob:
+                ob_lid, ob_type = None, None
+                ob_name = ob.split(",")[0]
+                for product in context_products:
+                    if product["name"][0] == ob_name and (
+                        product["type"][0] == "Spacecraft"
+                        or product["type"][0] == "Rover"
+                        or product["type"][0] == "Lander"
+                        or product["type"][0] == "Host"
+                    ):
+                        ob_lid = product["lidvid"].split("::")[0]
+                        ob_type = product["type"][0]
+
+                if not ob_lid:
+                    handle_npb_error(
+                        f"LID has not been obtained for observer {ob}.",
+                        setup=self.setup,
+                    )
+
+                obs_list_for_label += (
+                    f"{' ' * 3 * tab}<Observing_System_Component>{eol}"
+                    + f"{' ' * (3+1) * tab}<name>{ob_name}</name>{eol}"
+                    + f"{' ' * (3+1) * tab}<type>{ob_type}</type>{eol}"
+                    + f"{' ' * (3+1) * tab}<Internal_Reference>{eol}"
+                    + f"{' ' * (3 + 2) * tab}<lid_reference>{ob_lid}"
+                    f"</lid_reference>{eol}"
+                    + f"{' ' * (3 + 2) * tab}<reference_type>is_instrument_host"
+                    f"</reference_type>{eol}"
+                    + f"{' ' * (3+1) * tab}</Internal_Reference>{eol}"
+                    + f"{' ' * 3 * tab}</Observing_System_Component>{eol}"
+                )
+
+        if not obs_list_for_label:
+            handle_npb_error(
+                f"{self.product.name} observers not defined.", setup=self.setup
+            )
+        obs_list_for_label = obs_list_for_label.rstrip() + eol
+
+        return obs_list_for_label
+
+    def get_targets(self) -> str:
+        """Get the label targets from the context products.
+
+        :return: List of Targets to be included in the label
+        """
+        tars = self.targets
+        if not isinstance(tars, list):
+            tars = [tars]
+
+        tar_list_for_label = ""
+
+        try:
+            context_products = self.product.collection.bundle.context_products
+        except BaseException:
+            context_products = self.product.bundle.context_products
+
+        eol = self.setup.eol_pds4
+        tab = self.setup.xml_tab
+
+        for tar in tars:
+            if tar:
+                target_name = tar
+                target_lid, target_type = None, None
+                for product in context_products:
+                    if product["name"][0].upper() == target_name.upper():
+                        target_lid = product["lidvid"].split("::")[0]
+                        target_type = product["type"][0].capitalize()
+
+                tar_list_for_label += (
+                    f"{' ' * 2 * tab}<Target_Identification>{eol}"
+                    + f"{' ' * 3 * tab}<name>{target_name}</name>{eol}"
+                    + f"{' ' * 3 * tab}<type>{target_type}</type>{eol}"
+                    + f"{' ' * 3 * tab}<Internal_Reference>{eol}"
+                    + f"{' ' * 4 * tab}<lid_reference>{target_lid}"
+                    f"</lid_reference>{eol}" + f"{' ' * 4 * tab}<reference_type>"
+                    f"{self.get_target_reference_type()}"
+                    f"</reference_type>{eol}"
+                    + f"{' ' * 3 * tab}</Internal_Reference>{eol}"
+                    + f"{' ' * 2 * tab}</Target_Identification>{eol}"
+                )
+
+        if not tar_list_for_label:
+            handle_npb_error(f"{self.product.name} targets not defined.", setup=self.setup)
+        tar_list_for_label = tar_list_for_label.rstrip() + eol
+
+        return tar_list_for_label

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_label.py
@@ -1,0 +1,94 @@
+"""PDS4 version-specific base class for PDS labels."""
+
+from .label import PDSLabel
+from ...pipeline.runtime import handle_npb_error
+
+
+class PDS4Label(PDSLabel):
+    """Version-specific base class for PDS4 labels.
+
+    Adds the PDS4-only fields that used to be gated behind
+    ``if setup.pds_version == "4":`` checks in ``PDSLabel``.
+    """
+
+    def __init__(self, setup, product) -> None:
+        """Constructor."""
+        super().__init__(setup, product)
+
+        try:
+            context_products = product.collection.bundle.context_products
+            if not context_products:
+                raise Exception("No context products from bundle in collection")
+        except BaseException:
+            context_products = product.bundle.context_products
+
+        self.XML_MODEL = setup.xml_model
+        self.SCHEMA_LOCATION = setup.schema_location
+        self.INFORMATION_MODEL_VERSION = setup.information_model
+
+        #
+        # Needs to be built for several Missions.
+        #
+        if hasattr(setup, "secondary_missions"):
+            if len(setup.secondary_missions) == 1:
+                missions_text = (
+                    f"{setup.mission_name} and {setup.secondary_missions[0]}"
+                )
+            else:
+                missions_text = f"{setup.mission_name}, "
+                for i, sm_name in enumerate(setup.secondary_missions):
+                    if i == len(setup.secondary_missions) - 1:
+                        missions_text += f"and {sm_name}"
+                    else:
+                        missions_text += f"{sm_name}, "
+
+            self.PDS4_MISSION_NAME = f"{missions_text}"
+        else:
+            self.PDS4_MISSION_NAME = f"{setup.mission_name}"
+
+        #
+        # Needs to be built for several observers.
+        #
+        if hasattr(setup, "secondary_observers"):
+            if len(setup.secondary_observers) == 1:
+                observers_text = (
+                    f"{setup.observer} and {setup.secondary_observers[0]}"
+                )
+            else:
+                observers_text = f"{setup.observer}, "
+                for i, so_name in enumerate(setup.secondary_observers):
+                    if i == len(setup.secondary_observers) - 1:
+                        observers_text += f"and {so_name}"
+                    else:
+                        observers_text += f"{so_name}, "
+
+            self.PDS4_OBSERVER_NAME = f"{observers_text} spacecraft and their"
+        else:
+            self.PDS4_OBSERVER_NAME = f"{setup.observer} spacecraft and its"
+
+        self.END_OF_LINE_PDS4 = "Carriage-Return Line-Feed"
+        if setup.end_of_line == "CRLF":
+            self.END_OF_LINE = "Carriage-Return Line-Feed"
+        elif setup.end_of_line == "LF":
+            self.END_OF_LINE = "Line-Feed"
+        else:
+            handle_npb_error(
+                "End of Line provided via configuration is not CRLF nor LF.",
+                setup=self.setup,
+            )
+
+        self.BUNDLE_DESCRIPTION_LID = f"{setup.logical_identifier}:document:spiceds"
+
+        self.MISSIONS = self.get_missions()
+        self.OBSERVERS = self.get_observers()
+        self.TARGETS = self.get_targets()
+
+    @property
+    def _label_extension(self) -> str:
+        """File extension used for PDS4 labels."""
+        return ".xml"
+
+    @property
+    def _eol(self) -> str:
+        """End-of-line convention used for PDS4 labels."""
+        return self.setup.eol_pds4

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_metakernel.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_metakernel.py
@@ -2,11 +2,11 @@
 """
 from pathlib import Path
 
-from .label import PDSLabel
+from .pds4_label import PDS4Label
 from ...utils import extension_to_type
 
 
-class MetaKernelPDS4Label(PDSLabel):
+class MetaKernelPDS4Label(PDS4Label):
     """Class to generate a PDS4 SPICE Kernel MK Label.
 
     :param setup:   NPB execution Setup object

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_metakernel.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_metakernel.py
@@ -17,8 +17,8 @@ class MetaKernelPDS4Label(PDS4Label):
         """Constructor."""
         super().__init__(setup, product)
 
-        self.template = str(Path(setup.templates_directory)
-                            / "template_product_spice_kernel_mk.xml")
+        self._template = str(Path(setup.templates_directory)
+                             / "template_product_spice_kernel_mk.xml")
 
         #
         # Fields from Kernels

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_orbnum_file.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_orbnum_file.py
@@ -3,10 +3,10 @@ files.
 """
 from pathlib import Path
 
-from .label import PDSLabel
+from .pds4_label import PDS4Label
 
 
-class OrbnumFilePDS4Label(PDSLabel):
+class OrbnumFilePDS4Label(PDS4Label):
     """Class to generate a PDS4 Orbit Number File Label.
 
     :param setup:   NPB execution Setup object
@@ -63,6 +63,28 @@ class OrbnumFilePDS4Label(PDSLabel):
         self.name = Path(product.name).with_suffix(".xml").name
 
         self.write_label()
+
+    def get_mission_reference_type(self):
+        """Get mission reference type.
+
+        :return: ``ancillary_to_investigation`` for information models at or
+                 above 1014000000.0, ``data_to_investigation`` otherwise
+        :rtype: str
+        """
+        if self.setup.information_model_float >= 1014000000.0:
+            return "ancillary_to_investigation"
+        return "data_to_investigation"
+
+    def get_target_reference_type(self):
+        """Get target reference type.
+
+        :return: ``ancillary_to_target`` for information models at or above
+                 1014000000.0, ``data_to_target`` otherwise
+        :rtype: str
+        """
+        if self.setup.information_model_float >= 1014000000.0:
+            return "ancillary_to_target"
+        return "data_to_target"
 
     def get_table_character_fields(self):
         """Get the Table Character fields.

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_orbnum_file.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_orbnum_file.py
@@ -17,8 +17,8 @@ class OrbnumFilePDS4Label(PDS4Label):
         """Constructor."""
         super().__init__(setup, product)
 
-        self.template = str(Path(setup.templates_directory)
-                            / "template_product_orbnum_table.xml")
+        self._template = str(Path(setup.templates_directory)
+                             / "template_product_orbnum_table.xml")
 
         #
         # Fields from orbnum object.

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_orbnum_file.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_orbnum_file.py
@@ -64,7 +64,8 @@ class OrbnumFilePDS4Label(PDS4Label):
 
         self.write_label()
 
-    def get_mission_reference_type(self):
+    @property
+    def _mission_reference_type(self):
         """Get mission reference type.
 
         :return: ``ancillary_to_investigation`` for information models at or
@@ -75,7 +76,8 @@ class OrbnumFilePDS4Label(PDS4Label):
             return "ancillary_to_investigation"
         return "data_to_investigation"
 
-    def get_target_reference_type(self):
+    @property
+    def _target_reference_type(self):
         """Get target reference type.
 
         :return: ``ancillary_to_target`` for information models at or above

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_spice_kernel.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_spice_kernel.py
@@ -2,10 +2,10 @@
 """
 from pathlib import Path
 
-from .label import PDSLabel
+from .pds4_label import PDS4Label
 
 
-class SpiceKernelPDS4Label(PDSLabel):
+class SpiceKernelPDS4Label(PDS4Label):
     """Class to generate a non-MK PDS4 SPICE Kernel Label.
 
     :param setup:   NPB execution Setup object

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_spice_kernel.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_spice_kernel.py
@@ -16,8 +16,8 @@ class SpiceKernelPDS4Label(PDS4Label):
         """Constructor."""
         super().__init__(setup, product)
 
-        self.template = str(Path(setup.templates_directory)
-                            / "template_product_spice_kernel.xml")
+        self._template = str(Path(setup.templates_directory)
+                             / "template_product_spice_kernel.xml")
 
         #
         # Fields from Kernels

--- a/tests/npb/conftest.py
+++ b/tests/npb/conftest.py
@@ -155,3 +155,112 @@ def base_helpers(tmp_path: Path) -> SimpleNamespace:
         return product
 
     return SimpleNamespace(make_setup=_make_setup, make_product=_make_product)
+
+
+# ---------------------------------------------------------------------------
+# Shared PDSLabel/PDS4Label mock factories
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def label_test_helpers() -> SimpleNamespace:
+    """Provide the MagicMock-based factories shared by test_classes_label.py
+    (PDSLabel, version-agnostic) and test_classes_label_pds4.py (PDS4Label).
+
+    Both files need identical setup/product/context-product mocks, so the
+    factories live here once instead of being duplicated across the two
+    files (duplication that SonarCloud flagged on PR #308).
+
+    :return: container exposing make_context_products, make_bundle,
+             make_collection, make_product and make_setup_pds4
+    """
+
+    def _make_context_products():
+        """Return a minimal list of context product dicts used across tests."""
+        return [
+            {
+                "name": ["TestMission"],
+                "type": ["Mission"],
+                "lidvid": "urn:nasa:pds:testmission::1.0",
+            },
+            {
+                "name": ["TestObserver"],
+                "type": ["Spacecraft"],
+                "lidvid": "urn:nasa:pds:testobserver::1.0",
+            },
+            {
+                "name": ["TestTarget"],
+                "type": ["planet"],
+                "lidvid": "urn:nasa:pds:testtarget::1.0",
+            },
+        ]
+
+    def _make_bundle(context_products=None):
+        bundle = MagicMock()
+        bundle.context_products = context_products or _make_context_products()
+        return bundle
+
+    def _make_collection(bundle=None):
+        collection = MagicMock()
+        collection.bundle = bundle or _make_bundle()
+        collection.name = "spice_kernels"
+        return collection
+
+    def _make_product(collection=None, bundle=None):
+        """Return a mock product that supplies all attributes PDS4Label touches."""
+        product = MagicMock()
+        product.collection = collection or _make_collection()
+        product.bundle = bundle or _make_bundle()
+        product.creation_time = "2024-01-01T00:00:00"
+        product.creation_date = "2024-01-01"
+        product.size = 1024
+        product.checksum = "abc123"
+        product.missions = ["TestMission"]
+        product.observers = ["TestObserver"]
+        product.targets = ["TestTarget"]
+        product.name = "test_kernel.bc"
+        product.extension = "bc"
+        product.path = "/staging/test_kernel.bc"
+        product.record_bytes = 80
+        return product
+
+    def _make_setup_pds4(**kwargs):
+        """Return a mock setup object configured for PDS4."""
+        setup = MagicMock()
+        setup.pds_version = "4"
+        setup.root_dir = "/root"
+        setup.mission_acronym = "test"
+        setup.xml_model = "model"
+        setup.schema_location = "schema"
+        setup.information_model = ".".join(["1", "14", "0", "0"])
+        setup.information_model_float = 1014000000.0
+        setup.mission_name = "TestMission"
+        setup.observer = "TestObserver"
+        setup.target = "TestTarget"
+        setup.end_of_line = "CRLF"
+        setup.logical_identifier = "urn:nasa:pds:testmission"
+        setup.eol_pds4 = "\r\n"
+        setup.xml_tab = 2
+        setup.staging_directory = "/staging"
+        setup.working_directory = "/work"
+        setup.bundle_directory = "/bundle"
+        setup.diff = False
+        setup.args.silent = False
+        setup.args.verbose = False
+
+        # Ensure secondary_* attributes are NOT present by default
+        del setup.secondary_missions
+        del setup.secondary_observers
+        del setup.secondary_targets
+        del setup.creation_date_time
+
+        for k, v in kwargs.items():
+            setattr(setup, k, v)
+        return setup
+
+    return SimpleNamespace(
+        make_context_products=_make_context_products,
+        make_bundle=_make_bundle,
+        make_collection=_make_collection,
+        make_product=_make_product,
+        make_setup_pds4=_make_setup_pds4,
+    )

--- a/tests/npb/test_classes_label.py
+++ b/tests/npb/test_classes_label.py
@@ -212,7 +212,7 @@ class TestPDSLabelWriteLabel:
             label.setup = setup
             label.product = product
             label.name = ""
-            label.template = "/tmpl/template.xml"
+            label._template = "/tmpl/template.xml"
             label._label_extension = ".xml" if pds_version == "4" else ".lbl"
             label._eol = "\r\n"
 
@@ -220,7 +220,7 @@ class TestPDSLabelWriteLabel:
                 label.__class__ = type("ChecksumLabelClass", (PDSLabel,), {})
                 label.name = f"/staging{os.sep}checksum.lbl"
                 product.path = label.name
-                label.template = "/tmpl/template.lbl"
+                label._template = "/tmpl/template.lbl"
                 product.extension = "lbl"
                 product.record_bytes = 80
 

--- a/tests/npb/test_classes_label.py
+++ b/tests/npb/test_classes_label.py
@@ -163,23 +163,6 @@ class TestPDSLabelInit:
 
 
 # ===========================================================================
-# PDSLabel._target_reference_type
-# ===========================================================================
-
-class TestPDSLabelReferenceTypeNotImplemented:
-    """Covers the base class contract: PDSLabel itself defines no reference
-    type and must not silently return a default. PDS4Label's own default
-    and every leaf override are covered in their respective test files
-    (test_classes_label_pds4.py and each PDS4 leaf's test module).
-    """
-
-    def test_target_reference_type_raises(self):
-        label = object.__new__(PDSLabel)
-        with pytest.raises(NotImplementedError):
-            label._target_reference_type
-
-
-# ===========================================================================
 # PDSLabel.write_label
 # ===========================================================================
 

--- a/tests/npb/test_classes_label.py
+++ b/tests/npb/test_classes_label.py
@@ -163,7 +163,7 @@ class TestPDSLabelInit:
 
 
 # ===========================================================================
-# PDSLabel._mission_reference_type / _target_reference_type
+# PDSLabel._target_reference_type
 # ===========================================================================
 
 class TestPDSLabelReferenceTypeNotImplemented:
@@ -172,11 +172,6 @@ class TestPDSLabelReferenceTypeNotImplemented:
     and every leaf override are covered in their respective test files
     (test_classes_label_pds4.py and each PDS4 leaf's test module).
     """
-
-    def test_mission_reference_type_raises(self):
-        label = object.__new__(PDSLabel)
-        with pytest.raises(NotImplementedError):
-            label._mission_reference_type
 
     def test_target_reference_type_raises(self):
         label = object.__new__(PDSLabel)

--- a/tests/npb/test_classes_label.py
+++ b/tests/npb/test_classes_label.py
@@ -5,7 +5,7 @@ Tests for PDSLabel class.
 import os
 from pathlib import Path
 from typing import cast, Type
-from unittest.mock import MagicMock, call, mock_open
+from unittest.mock import call, mock_open
 
 import pytest
 
@@ -22,97 +22,13 @@ _PATCH_GLOB = "pds.naif_pds4_bundler.classes.label.label.glob.glob"
 # ---------------------------------------------------------------------------
 # Shared builder helpers
 # ---------------------------------------------------------------------------
+# make_context_products/make_bundle/make_collection/make_product/
+# make_setup_pds4 live in conftest.py's label_test_helpers fixture, shared
+# with test_classes_label_pds4.py. Only the PDS3-flavored setup builder is
+# specific to this file.
 
-def _make_context_products():
-    """Return a minimal list of context product dicts used across tests."""
-    return [
-        {
-            "name": ["TestMission"],
-            "type": ["Mission"],
-            "lidvid": "urn:nasa:pds:testmission::1.0",
-        },
-        {
-            "name": ["TestObserver"],
-            "type": ["Spacecraft"],
-            "lidvid": "urn:nasa:pds:testobserver::1.0",
-        },
-        {
-            "name": ["TestTarget"],
-            "type": ["planet"],
-            "lidvid": "urn:nasa:pds:testtarget::1.0",
-        },
-    ]
-
-
-def _make_bundle(context_products=None):
-    bundle = MagicMock()
-    bundle.context_products = context_products or _make_context_products()
-    return bundle
-
-
-def _make_collection(bundle=None):
-    collection = MagicMock()
-    collection.bundle = bundle or _make_bundle()
-    collection.name = "spice_kernels"
-    return collection
-
-
-def _make_product(collection=None, bundle=None):
-    """Return a mock product that supplies all attributes PDSLabel touches."""
-    product = MagicMock()
-    product.collection = collection or _make_collection()
-    product.bundle = bundle or _make_bundle()
-    product.creation_time = "2024-01-01T00:00:00"
-    product.creation_date = "2024-01-01"
-    product.size = 1024
-    product.checksum = "abc123"
-    product.missions = ["TestMission"]
-    product.observers = ["TestObserver"]
-    product.targets = ["TestTarget"]
-    product.name = "test_kernel.bc"
-    product.extension = "bc"
-    product.path = "/staging/test_kernel.bc"
-    product.record_bytes = 80
-    return product
-
-
-def _make_setup_pds4(**kwargs):
-    """Return a mock setup object configured for PDS4."""
-    setup = MagicMock()
-    setup.pds_version = "4"
-    setup.root_dir = "/root"
-    setup.mission_acronym = "test"
-    setup.xml_model = "model"
-    setup.schema_location = "schema"
-    setup.information_model = ".".join(["1", "14", "0", "0"])
-    setup.information_model_float = 1014000000.0
-    setup.mission_name = "TestMission"
-    setup.observer = "TestObserver"
-    setup.target = "TestTarget"
-    setup.end_of_line = "CRLF"
-    setup.logical_identifier = "urn:nasa:pds:testmission"
-    setup.eol_pds4 = "\r\n"
-    setup.xml_tab = 2
-    setup.staging_directory = "/staging"
-    setup.working_directory = "/work"
-    setup.bundle_directory = "/bundle"
-    setup.diff = False
-    setup.args.silent = False
-    setup.args.verbose = False
-
-    # Ensure secondary_* attributes are NOT present by default
-    del setup.secondary_missions
-    del setup.secondary_observers
-    del setup.secondary_targets
-    del setup.creation_date_time
-
-    for k, v in kwargs.items():
-        setattr(setup, k, v)
-    return setup
-
-
-def _make_setup_pds3(**kwargs):
-    setup = _make_setup_pds4(**kwargs)
+def _make_setup_pds3(label_test_helpers, **kwargs):
+    setup = label_test_helpers.make_setup_pds4(**kwargs)
     setup.pds_version = "3"
     return setup
 
@@ -122,18 +38,18 @@ def _make_setup_pds3(**kwargs):
 # ---------------------------------------------------------------------------
 
 @pytest.fixture
-def setup_pds4():
-    return _make_setup_pds4()
+def setup_pds4(label_test_helpers):
+    return label_test_helpers.make_setup_pds4()
 
 
 @pytest.fixture
-def setup_pds3():
-    return _make_setup_pds3()
+def setup_pds3(label_test_helpers):
+    return _make_setup_pds3(label_test_helpers)
 
 
 @pytest.fixture
-def product():
-    return _make_product()
+def product(label_test_helpers):
+    return label_test_helpers.make_product()
 
 
 # ===========================================================================
@@ -278,7 +194,7 @@ class TestPDSLabelWriteLabel:
     """Covers PDSLabel.write_label – all branches."""
 
     @pytest.fixture
-    def label_for(self):
+    def label_for(self, label_test_helpers):
         """Factory fixture: builds a bare label ready for write_label."""
         def _build(
             pds_version="4",
@@ -288,13 +204,14 @@ class TestPDSLabelWriteLabel:
             diff=False,
             is_pds3_kernel=False,
         ):
-            setup = _make_setup_pds4() if pds_version == "4" else _make_setup_pds3()
+            setup = (label_test_helpers.make_setup_pds4() if pds_version == "4"
+                    else _make_setup_pds3(label_test_helpers))
             setup.diff = diff
             setup.pds_version = pds_version
             setup.eol_pds4 = "\r\n"
             setup.eol_pds3 = "\r\n"
 
-            product = _make_product()
+            product = label_test_helpers.make_product()
 
             if label_name_has_ext:
                 ext = ".xml" if pds_version == "4" else ".lbl"
@@ -414,13 +331,13 @@ class TestPDSLabelCompare:
     """Covers PDSLabel.compare – all three fallback levels and success path."""
 
     @pytest.fixture
-    def label_for(self):
+    def label_for(self, label_test_helpers):
         """Factory fixture: builds a bare label ready for compare."""
 
         def _build(collection_name="spice_kernels", label_name_part="kernel"):
-            setup = _make_setup_pds4()
+            setup = label_test_helpers.make_setup_pds4()
             setup.diff = "html"
-            product = _make_product()
+            product = label_test_helpers.make_product()
             product.collection.name = collection_name
             product.name = "kernel.bc"
             product.extension = "bc"

--- a/tests/npb/test_classes_label.py
+++ b/tests/npb/test_classes_label.py
@@ -165,7 +165,7 @@ class TestPDSLabelInit:
 
 
 # ===========================================================================
-# PDSLabel.get_mission_reference_type / get_target_reference_type
+# PDSLabel._mission_reference_type / _target_reference_type
 # ===========================================================================
 
 class TestPDSLabelReferenceTypeNotImplemented:
@@ -175,15 +175,15 @@ class TestPDSLabelReferenceTypeNotImplemented:
     (test_classes_label_pds4.py and each PDS4 leaf's test module).
     """
 
-    def test_get_mission_reference_type_raises(self):
+    def test_mission_reference_type_raises(self):
         label = object.__new__(PDSLabel)
         with pytest.raises(NotImplementedError):
-            label.get_mission_reference_type()
+            label._mission_reference_type
 
-    def test_get_target_reference_type_raises(self):
+    def test_target_reference_type_raises(self):
         label = object.__new__(PDSLabel)
         with pytest.raises(NotImplementedError):
-            label.get_target_reference_type()
+            label._target_reference_type
 
 
 # ===========================================================================

--- a/tests/npb/test_classes_label.py
+++ b/tests/npb/test_classes_label.py
@@ -10,9 +10,10 @@ from unittest.mock import MagicMock, call, mock_open
 import pytest
 
 from pds.naif_pds4_bundler.classes.label.label import PDSLabel
+from pds.naif_pds4_bundler.classes.label.pds3_label import PDS3Label
+from pds.naif_pds4_bundler.classes.label.pds4_label import PDS4Label
 
 # Patch targets — resolved to where the names are looked up inside label.py
-_PATCH_HANDLE_ERROR = "pds.naif_pds4_bundler.classes.label.label.handle_npb_error"
 _PATCH_ADD_CR = "pds.naif_pds4_bundler.classes.label.label.add_carriage_return"
 _PATCH_COMPARE = "pds.naif_pds4_bundler.classes.label.label.compare_files"
 _PATCH_GLOB = "pds.naif_pds4_bundler.classes.label.label.glob.glob"
@@ -140,86 +141,13 @@ def product():
 # ===========================================================================
 
 class TestPDSLabelInit:
-    """Covers PDSLabel.__init__ – all branches."""
+    """Covers PDSLabel.__init__ – version-agnostic branches only.
 
-    @staticmethod
-    @pytest.fixture
-    def mock_class_methods(mocker):
-        # Mocks all three methods at once
-        mocker.patch('pds.naif_pds4_bundler.classes.label.label.PDSLabel.get_missions',
-                     return_value='MockedMission')
-        mocker.patch('pds.naif_pds4_bundler.classes.label.label.PDSLabel.get_observers',
-                     return_value='MockedObserver')
-        mocker.patch('pds.naif_pds4_bundler.classes.label.label.PDSLabel.get_targets',
-                     return_value='MockedTarget')
-
-    def test_pds4_context_from_collection_bundle(self, setup_pds4, product):
-        """pds_version == "4", context products from collection.bundle"""
-        label = PDSLabel(setup_pds4, product)
-        assert label.setup is setup_pds4
-        assert label.product is product
-        assert label.name == ""
-
-    def test_pds4_context_falls_back_to_product_bundle(self, mock_class_methods, setup_pds4, product):
-        """ pds_version == "4", context products from product.bundle
-           (collection.bundle.context_products is falsy => raises Exception)
-        """
-        product.collection.bundle.context_products = []
-        label = PDSLabel(setup_pds4, product)
-        assert label is not None
-
-    def test_pds4_context_attribute_error_falls_back(self, setup_pds4, product):
-        """collection.bundle raises AttributeError entirely"""
-        product.collection = MagicMock(spec=[])
-        label = PDSLabel(setup_pds4, product)
-        assert label is not None
-
-    def test_pds3_skips_pds4_block(self, setup_pds3, product):
-        """pds_version == "3" (skips PDS4 XML block entirely)"""
-        label = PDSLabel(setup_pds3, product)
-        assert not hasattr(label, "XML_MODEL")
-
-    def test_pds4_single_mission_name(self, mock_class_methods, setup_pds4, product):
-        label = PDSLabel(setup_pds4, product)
-        assert label.PDS4_MISSION_NAME == "TestMission"
-
-    @pytest.mark.parametrize("secondary_missions, expected_name",[
-        (["OtherMission"], "TestMission and OtherMission"),
-        (["MissionB", "MissionC"], "TestMission, MissionB, and MissionC"),
-    ])
-    def test_pds4_multiple_mission_name(self, mock_class_methods, setup_pds4, product, secondary_missions, expected_name):
-        setup_pds4.secondary_missions = secondary_missions
-        label = PDSLabel(setup_pds4, product)
-        assert label.PDS4_MISSION_NAME == expected_name
-
-    def test_pds4_single_observer_name(self, mock_class_methods, setup_pds4, product):
-        label = PDSLabel(setup_pds4, product)
-        assert label.PDS4_OBSERVER_NAME == "TestObserver spacecraft and its"
-
-    @pytest.mark.parametrize("secondary_observer, expected_name",[
-        (["OtherObserver"], "TestObserver and OtherObserver spacecraft and their"),
-        (["ObsB", "ObsC"], "TestObserver, ObsB, and ObsC spacecraft and their"),
-    ])
-    def test_pds4_multiple_observer_name(self, mock_class_methods, setup_pds4, product, secondary_observer, expected_name):
-        setup_pds4.secondary_observers = secondary_observer
-        label = PDSLabel(setup_pds4, product)
-        assert label.PDS4_OBSERVER_NAME == expected_name
-
-    @pytest.mark.parametrize("eol, expected_eol_name",[
-        ('LF', 'Line-Feed'),
-        ('CRLF', 'Carriage-Return Line-Feed')
-    ])
-    def test_pds4_end_of_line(self, product, eol, expected_eol_name):
-        setup = _make_setup_pds4(end_of_line=eol)
-        label = PDSLabel(setup, product)
-        assert label.END_OF_LINE == expected_eol_name
-
-    def test_pds4_end_of_line_invalid(self, product):
-        """end_of_line is invalid (neither CRLF nor LF)"""
-        setup = _make_setup_pds4(end_of_line="CR")
-        with pytest.raises(RuntimeError, match=r'End of Line provided via configuration '
-                                               r'is not CRLF nor LF\.'):
-            PDSLabel(setup, product)
+    The pds_version-gated behavior this class used to cover (XML_MODEL,
+    PDS4_MISSION_NAME/PDS4_OBSERVER_NAME, END_OF_LINE, MISSIONS/OBSERVERS/
+    TARGETS, and the context_products lookup) now lives on PDS4Label; see
+    test_classes_label_pds4.py::TestPDS4LabelInit.
+    """
 
     def test_uses_setup_creation_date_time(self, setup_pds4, product):
         """setup has creation_date_time"""
@@ -261,22 +189,11 @@ class TestPDSLabelInit:
         assert label.observers == product.observers
         assert label.targets == product.targets
 
-    # TODO: The following two test cases demonstrate an issue:
-    #       If they are not a list, the code to set up PDS4_MISSION_NAME
-    #       and PDS4_OBSERVER_NAME, results in a list of letters.
-    def test_pds4_secondary_missions_non_list_wrapped(self, mock_class_methods, setup_pds4, product):
-        setup_pds4.secondary_missions = "SingleMission"
-        label = PDSLabel(setup_pds4, product)
-        assert label.missions == ['TestMission', 'SingleMission']
-        # TODO: This is a bug!!!!
-        assert 'TestMission, S, i, n, g, l, e, M, i, s, s, i, o, and n' == label.PDS4_MISSION_NAME
-
-    def test_pds4_secondary_observers_non_list_wrapped(self, mock_class_methods, setup_pds4, product):
-        setup_pds4.secondary_observers = 'SingleObserver'
-        label = PDSLabel(setup_pds4, product)
-        assert label.observers == ['TestObserver', 'SingleObserver']
-        # TODO: This is a bug!!!
-        assert 'TestObserver, S, i, n, g, l, e, O, b, s, e, r, v, e, and r spacecraft and their' == label.PDS4_OBSERVER_NAME
+    # NOTE: PDS4_MISSION_NAME/PDS4_OBSERVER_NAME (and the non-list-wrapping
+    #       bug affecting them) are PDS4-only; see
+    #       test_classes_label_pds4.py::TestPDS4LabelInit for those two cases.
+    #       The list-wrapping of self.missions/self.observers itself is
+    #       version-agnostic and stays covered below and via the pds3 cases.
 
     def test_pds4_secondary_targets_non_list_wrapped(self, setup_pds4, product):
         setup_pds4.secondary_targets = 'SingleTarget'
@@ -300,12 +217,12 @@ class TestPDSLabelInit:
         label = PDSLabel(setup_pds3, product)
         assert label.targets == ['TestTarget', 'SingleTarget']
 
-    def test_pds4_secondary_missions_list(self, mock_class_methods, setup_pds4, product):
+    def test_pds4_secondary_missions_list(self, setup_pds4, product):
         setup_pds4.secondary_missions = ["MissionB", "MissionC"]
         label = PDSLabel(setup_pds4, product)
         assert label.missions == ['TestMission', "MissionB", "MissionC"]
 
-    def test_pds4_secondary_observers_list(self, mock_class_methods, setup_pds4, product):
+    def test_pds4_secondary_observers_list(self, setup_pds4, product):
         setup_pds4.secondary_observers = ["ObsB", "ObsC"]
         label = PDSLabel(setup_pds4, product)
         assert label.observers == ['TestObserver', "ObsB", "ObsC"]
@@ -330,305 +247,27 @@ class TestPDSLabelInit:
         label = PDSLabel(setup_pds3, product)
         assert label.targets == ['TestTarget', "TargetB", "TargetC"]
 
-    def test_pds4_sets_missions_targets_observers(self, mock_class_methods, setup_pds4, product):
-        setup_pds4.secondary_missions = ["MissionB", "MissionC"]
-        setup_pds4.secondary_observers = ["ObsB", "ObsC"]
-        setup_pds4.secondary_targets = ["TargetB", "TargetC"]
-
-        # Since the mock is called, the values of the MISSIONS,
-        # OBSERVERS and TARGETS should be the ones provided as return_value
-        # in the mock.
-        label = PDSLabel(setup_pds4, product)
-        assert label.MISSIONS == 'MockedMission'
-        assert label.OBSERVERS == 'MockedObserver'
-        assert label.TARGETS == 'MockedTarget'
-
 
 # ===========================================================================
-# PDSLabel.get_missions
+# PDSLabel.get_mission_reference_type / get_target_reference_type
 # ===========================================================================
 
-class TestPDSLabelGetMissions:
-    """Covers PDSLabel.get_missions – all branches."""
+class TestPDSLabelReferenceTypeNotImplemented:
+    """Covers the base class contract: PDSLabel itself defines no reference
+    type and must not silently return a default. PDS4Label's own default
+    and every leaf override are covered in their respective test files
+    (test_classes_label_pds4.py and each PDS4 leaf's test module).
+    """
 
-    @pytest.fixture
-    def label_for(self):
-        """Factory fixture: returns a callable that builds a bare label."""
-        def _build(missions, context_products=None, fallback_to_bundle=False):
-            setup = _make_setup_pds4()
-            product = _make_product()
-            ctx = context_products or _make_context_products()
-            if fallback_to_bundle:
-                product.collection = MagicMock(spec=[])  # no .bundle
-                product.bundle.context_products = ctx
-            else:
-                product.collection.bundle.context_products = ctx
-            label = PDSLabel.__new__(PDSLabel)
-            label.setup = setup
-            label.product = product
-            label.missions = missions if isinstance(missions, list) else [missions]
-            return label
-        return _build
+    def test_get_mission_reference_type_raises(self):
+        label = object.__new__(PDSLabel)
+        with pytest.raises(NotImplementedError):
+            label.get_mission_reference_type()
 
-    @pytest.mark.parametrize('missions, expected', [
-        (['TestMission'], '    <Investigation_Area>\r\n'
-                          '      <name>TestMission</name>\r\n'
-                          '      <type>Mission</type>\r\n'
-                          '      <Internal_Reference>\r\n'
-                          '        <lid_reference>urn:nasa:pds:testmission</lid_reference>\r\n'
-                          '        <reference_type>data_to_investigation</reference_type>\r\n'
-                          '      </Internal_Reference>\r\n'
-                          '    </Investigation_Area>\r\n'),
-        ('TestMission', '    <Investigation_Area>\r\n'
-                        '      <name>TestMission</name>\r\n'
-                        '      <type>Mission</type>\r\n'
-                        '      <Internal_Reference>\r\n'
-                        '        <lid_reference>urn:nasa:pds:testmission</lid_reference>\r\n'
-                        '        <reference_type>data_to_investigation</reference_type>\r\n'
-                        '      </Internal_Reference>\r\n'
-                        '    </Investigation_Area>\r\n')
-    ])
-    def test_mission(self, label_for, missions, expected):
-        label = label_for(missions)
-        label.missions = missions
-        result = label.get_missions()
-        assert result == expected
-
-    def test_context_falls_back_to_product_bundle(self, label_for):
-        result = label_for(["TestMission"], fallback_to_bundle=True).get_missions()
-        assert "TestMission" in result
-
-    def test_empty_mission_name_skipped_calls_error(self, label_for, mocker):
-        """A falsy mission entry (empty string) must be skipped."""
-        mock_err = mocker.patch(_PATCH_HANDLE_ERROR)
-        label_for([""]).get_missions()
-        mock_err.assert_called()
-
-    def test_other_investigation_type_accepted(self, label_for):
-        ctx = [
-            {
-                "name": ["TestMission"],
-                "type": ["Other Investigation"],
-                "lidvid": "urn:nasa:pds:testmission::1.0",
-            }
-        ]
-        result = label_for(["TestMission"], context_products=ctx).get_missions()
-        assert result == ('    <Investigation_Area>\r\n'
-                          '      <name>TestMission</name>\r\n'
-                          '      <type>Other Investigation</type>\r\n'
-                          '      <Internal_Reference>\r\n'
-                          '        <lid_reference>urn:nasa:pds:testmission</lid_reference>\r\n'
-                          '        <reference_type>data_to_investigation</reference_type>\r\n'
-                          '      </Internal_Reference>\r\n'
-                          '    </Investigation_Area>\r\n')
-
-    def test_no_lid_found_calls_handle_npb_error(self, label_for, mocker):
-        """No context product matches → mission_lid never set → handle_npb_error."""
-        ctx = [
-            {
-                "name": ["Different"],
-                "type": ["Mission"],
-                "lidvid": "urn:nasa:pds:different::1.0",
-            }
-        ]
-        mock_err = mocker.patch(_PATCH_HANDLE_ERROR)
-        label_for(["TestMission"], context_products=ctx).get_missions()
-        mock_err.assert_called()
-
-
-# ===========================================================================
-# PDSLabel.get_mission_reference_type
-# ===========================================================================
-
-class TestPDSLabelGetMissionReferenceType:
-    """Covers PDSLabel.get_mission_reference_type – every branch."""
-
-    @pytest.fixture
-    def label_of_class(self):
-        """Factory fixture: builds a bare label instance of the given class name."""
-        def _build(class_name, info_model_float=1014000000.0):
-            cls = cast(Type[PDSLabel], type(class_name, (PDSLabel,), {}))
-            obj = object.__new__(cls)
-            obj.setup = MagicMock()
-            obj.setup.information_model_float = info_model_float
-            return obj
-        return _build
-
-    @pytest.mark.parametrize('pds_label, model, ref_type', [
-        ('ChecksumPDS4Label', None, 'ancillary_to_investigation'),
-        ('BundlePDS4Label', None, 'bundle_to_investigation'),
-        ('DocumentPDS4Label', None, 'document_to_investigation'),
-        ('InventoryPDS4Label', None, 'collection_to_investigation'),
-        ('OrbnumFilePDS4Label', 1014000000.0, 'ancillary_to_investigation'),
-        ('OrbnumFilePDS4Label', 1013000000.0, 'data_to_investigation'),
-        ('SpiceKernelPDS4Label', None, 'data_to_investigation'),
-        ('MetaKernelPDS4Label', None, 'data_to_investigation'),
-        ('SpiceKernelPDS3Label', None, 'data_to_investigation')
-    ])
-    def test_checksum_label(self, label_of_class, pds_label, model, ref_type):
-        assert label_of_class(pds_label, model).get_mission_reference_type() == ref_type
-
-
-# ===========================================================================
-# PDSLabel.get_observers
-# ===========================================================================
-
-class TestPDSLabelGetObservers:
-    """Covers PDSLabel.get_observers – all branches."""
-
-    @pytest.fixture
-    def label_for(self):
-        """Factory fixture: builds a bare label with given observers."""
-        def _build(observers, context_products=None, fallback_to_bundle=False):
-            setup = _make_setup_pds4()
-            product = _make_product()
-            ctx = context_products or _make_context_products()
-            if fallback_to_bundle:
-                product.collection = MagicMock(spec=[])
-                product.bundle.context_products = ctx
-            else:
-                product.collection.bundle.context_products = ctx
-            label = PDSLabel.__new__(PDSLabel)
-            label.setup = setup
-            label.product = product
-            label.observers = observers if isinstance(observers, list) else [observers]
-            return label
-        return _build
-
-    def test_single_observer_spacecraft(self, label_for):
-        result = label_for(["TestObserver"]).get_observers()
-        assert "TestObserver" in result
-        assert "Observing_System_Component" in result
-
-    def test_observers_not_a_list_wrapped(self, label_for):
-        label = label_for("TestObserver")
-        label.observers = "TestObserver"  # scalar
-        assert "TestObserver" in label.get_observers()
-
-    def test_context_fallback_to_product_bundle(self, label_for):
-        result = label_for(["TestObserver"], fallback_to_bundle=True).get_observers()
-        assert "TestObserver" in result
-
-    def test_rover_type_accepted(self, label_for):
-        ctx = [{"name": ["TestObserver"], "type": ["Rover"], "lidvid": "urn:x::1.0"}]
-        assert "Rover" in label_for(["TestObserver"], ctx).get_observers()
-
-    def test_lander_type_accepted(self, label_for):
-        ctx = [{"name": ["TestObserver"], "type": ["Lander"], "lidvid": "urn:x::1.0"}]
-        assert "Lander" in label_for(["TestObserver"], ctx).get_observers()
-
-    def test_host_type_accepted(self, label_for):
-        ctx = [{"name": ["TestObserver"], "type": ["Host"], "lidvid": "urn:x::1.0"}]
-        assert "Host" in label_for(["TestObserver"], ctx).get_observers()
-
-    def test_comma_in_observer_name_strips_suffix(self, label_for):
-        """Observer names like 'Name, suffix' → only 'Name' used for look-up."""
-        ctx = [{"name": ["TestObserver"], "type": ["Spacecraft"], "lidvid": "urn:x::1.0"}]
-        assert "TestObserver" in label_for(["TestObserver, extra"], ctx).get_observers()
-
-    def test_empty_observer_skipped_calls_error(self, label_for, mocker):
-        mock_err = mocker.patch(_PATCH_HANDLE_ERROR)
-        label_for([""]).get_observers()
-        mock_err.assert_called()
-
-    def test_no_lid_calls_handle_npb_error(self, label_for, mocker):
-        ctx = [{"name": ["NoMatch"], "type": ["Spacecraft"], "lidvid": "urn:x::1.0"}]
-        mock_err = mocker.patch(_PATCH_HANDLE_ERROR)
-        label_for(["TestObserver"], ctx).get_observers()
-        mock_err.assert_called()
-
-    def test_trailing_eol_appended(self, label_for):
-        assert label_for(["TestObserver"]).get_observers().endswith("\r\n")
-
-
-# ===========================================================================
-# PDSLabel.get_targets
-# ===========================================================================
-
-class TestPDSLabelGetTargets:
-    """Covers PDSLabel.get_targets – all branches."""
-
-    @pytest.fixture
-    def label_for(self):
-        """Factory fixture: builds a bare label with given targets."""
-        def _build(targets, context_products=None, fallback_to_bundle=False):
-            setup = _make_setup_pds4()
-            product = _make_product()
-            ctx = context_products or _make_context_products()
-            if fallback_to_bundle:
-                product.collection = MagicMock(spec=[])
-                product.bundle.context_products = ctx
-            else:
-                product.collection.bundle.context_products = ctx
-            label = PDSLabel.__new__(PDSLabel)
-            label.setup = setup
-            label.product = product
-            label.targets = targets if isinstance(targets, list) else [targets]
-            return label
-        return _build
-
-    def test_single_target(self, label_for):
-        result = label_for(["TestTarget"]).get_targets()
-        assert "TestTarget" in result
-        assert "Target_Identification" in result
-
-    def test_targets_not_a_list_wrapped(self, label_for):
-        label = label_for("TestTarget")
-        label.targets = "TestTarget"  # scalar
-        assert "TestTarget" in label.get_targets()
-
-    def test_context_fallback_to_product_bundle(self, label_for):
-        result = label_for(["TestTarget"], fallback_to_bundle=True).get_targets()
-        assert "TestTarget" in result
-
-    def test_case_insensitive_name_match(self, label_for):
-        ctx = [{"name": ["TESTTARGET"], "type": ["planet"], "lidvid": "urn:x::1.0"}]
-        assert "testtarget" in label_for(["testtarget"], ctx).get_targets()
-
-    def test_empty_target_skipped_calls_error(self, label_for, mocker):
-        mock_err = mocker.patch(_PATCH_HANDLE_ERROR)
-        label_for([""]).get_targets()
-        mock_err.assert_called()
-
-    def test_trailing_eol_appended(self, label_for):
-        assert label_for(["TestTarget"]).get_targets().endswith("\r\n")
-
-
-# ===========================================================================
-# PDSLabel.get_target_reference_type
-# ===========================================================================
-
-class TestPDSLabelGetTargetReferenceType:
-    """Covers PDSLabel.get_target_reference_type – every branch."""
-
-    @pytest.fixture
-    def label_of_class(self):
-        """Factory fixture: builds a bare label instance of the given class name."""
-        def _build(class_name, info_model_float=1014000000.0):
-            cls = cast(Type[PDSLabel], type(class_name, (PDSLabel,), {}))
-            obj = object.__new__(cls)
-            obj.setup = MagicMock()
-            obj.setup.information_model_float = info_model_float
-            return obj
-        return _build
-
-    def test_checksum_label(self, label_of_class):
-        assert label_of_class("ChecksumPDS4Label").get_target_reference_type() == "ancillary_to_target"
-
-    def test_bundle_label(self, label_of_class):
-        assert label_of_class("BundlePDS4Label").get_target_reference_type() == "bundle_to_target"
-
-    def test_inventory_label(self, label_of_class):
-        assert label_of_class("InventoryPDS4Label").get_target_reference_type() == "collection_to_target"
-
-    def test_orbnum_label_new_model(self, label_of_class):
-        assert label_of_class("OrbnumFilePDS4Label", 1014000000.0).get_target_reference_type() == "ancillary_to_target"
-
-    def test_orbnum_label_old_model(self, label_of_class):
-        assert label_of_class("OrbnumFilePDS4Label", 1013000000.0).get_target_reference_type() == "data_to_target"
-
-    def test_default_label(self, label_of_class):
-        assert label_of_class("SomeOtherLabel").get_target_reference_type() == "data_to_target"
+    def test_get_target_reference_type_raises(self):
+        label = object.__new__(PDSLabel)
+        with pytest.raises(NotImplementedError):
+            label.get_target_reference_type()
 
 
 # ===========================================================================
@@ -667,8 +306,14 @@ class TestPDSLabelWriteLabel:
                 product.path = "/staging/test_kernel.bc"
                 product.extension = "bc"
 
+            # _label_extension/_eol come from whichever of PDS3Label/PDS4Label
+            # is mixed in here, driven by pds_version — exactly like the real
+            # hierarchy, where a label's class (not its name) decides its
+            # extension. cls_name only matters for write_label's unrelated
+            # "suppress trailing log line for SpiceKernelPDS3Label" check.
+            base_cls = PDS4Label if pds_version == "4" else PDS3Label
             cls_name = "SpiceKernelPDS3Label" if is_pds3_kernel else "PDSLabel"
-            cls = cast(Type[PDSLabel], type(cls_name, (PDSLabel,), {}))
+            cls = cast(Type[PDSLabel], type(cls_name, (base_cls,), {}))
             label = object.__new__(cls)
             label.setup = setup
             label.product = product
@@ -676,7 +321,7 @@ class TestPDSLabelWriteLabel:
             label.template = "/tmpl/template.xml"
 
             if is_checksum:
-                label.__class__ = type("ChecksumLabelClass", (PDSLabel,), {})
+                label.__class__ = type("ChecksumLabelClass", (base_cls,), {})
                 label.name = f"/staging{os.sep}checksum.lbl"
                 product.path = label.name
                 label.template = "/tmpl/template.lbl"

--- a/tests/npb/test_classes_label.py
+++ b/tests/npb/test_classes_label.py
@@ -10,8 +10,6 @@ from unittest.mock import call, mock_open
 import pytest
 
 from pds.naif_pds4_bundler.classes.label.label import PDSLabel
-from pds.naif_pds4_bundler.classes.label.pds3_label import PDS3Label
-from pds.naif_pds4_bundler.classes.label.pds4_label import PDS4Label
 
 # Patch targets — resolved to where the names are looked up inside label.py
 _PATCH_ADD_CR = "pds.naif_pds4_bundler.classes.label.label.add_carriage_return"
@@ -195,7 +193,14 @@ class TestPDSLabelWriteLabel:
 
     @pytest.fixture
     def label_for(self, label_test_helpers):
-        """Factory fixture: builds a bare label ready for write_label."""
+        """Factory fixture: builds a bare label ready for write_label.
+
+        Built directly off PDSLabel, with _label_extension/_eol assigned as
+        plain instance attributes — decoupled from PDS3Label/PDS4Label. The
+        coupling between those subclasses' real properties and write_label
+        is covered separately by the integration tests in
+        test_classes_label_pds3.py/test_classes_label_pds4.py.
+        """
         def _build(
             pds_version="4",
             label_name_has_ext=False,
@@ -208,8 +213,6 @@ class TestPDSLabelWriteLabel:
                     else _make_setup_pds3(label_test_helpers))
             setup.diff = diff
             setup.pds_version = pds_version
-            setup.eol_pds4 = "\r\n"
-            setup.eol_pds3 = "\r\n"
 
             product = label_test_helpers.make_product()
 
@@ -223,22 +226,20 @@ class TestPDSLabelWriteLabel:
                 product.path = "/staging/test_kernel.bc"
                 product.extension = "bc"
 
-            # _label_extension/_eol come from whichever of PDS3Label/PDS4Label
-            # is mixed in here, driven by pds_version — exactly like the real
-            # hierarchy, where a label's class (not its name) decides its
-            # extension. cls_name only matters for write_label's unrelated
-            # "suppress trailing log line for SpiceKernelPDS3Label" check.
-            base_cls = PDS4Label if pds_version == "4" else PDS3Label
+            # cls_name only matters for write_label's unrelated "suppress
+            # trailing log line for SpiceKernelPDS3Label" check.
             cls_name = "SpiceKernelPDS3Label" if is_pds3_kernel else "PDSLabel"
-            cls = cast(Type[PDSLabel], type(cls_name, (base_cls,), {}))
+            cls = cast(Type[PDSLabel], type(cls_name, (PDSLabel,), {}))
             label = object.__new__(cls)
             label.setup = setup
             label.product = product
             label.name = ""
             label.template = "/tmpl/template.xml"
+            label._label_extension = ".xml" if pds_version == "4" else ".lbl"
+            label._eol = "\r\n"
 
             if is_checksum:
-                label.__class__ = type("ChecksumLabelClass", (base_cls,), {})
+                label.__class__ = type("ChecksumLabelClass", (PDSLabel,), {})
                 label.name = f"/staging{os.sep}checksum.lbl"
                 product.path = label.name
                 label.template = "/tmpl/template.lbl"

--- a/tests/npb/test_classes_label_pds3.py
+++ b/tests/npb/test_classes_label_pds3.py
@@ -94,8 +94,8 @@ class TestPDS3LabelWriteLabelIntegration:
         product.extension = "bc"
 
         label = PDS3Label(setup, product)
-        label.template = str(tmp_path / "template.lbl")
-        Path(label.template).write_text("Static content line\n")
+        label._template = str(tmp_path / "template.lbl")
+        Path(label._template).write_text("Static content line\n")
 
         label.write_label()
 

--- a/tests/npb/test_classes_label_pds3.py
+++ b/tests/npb/test_classes_label_pds3.py
@@ -1,0 +1,74 @@
+"""
+Tests for PDS3Label class.
+
+PDS3Label currently adds no __init__ logic of its own — PDS3-specific
+field assignment still lives in each PDS3 leaf class. Its only real
+behavior is the _label_extension/_eol pair consumed by PDSLabel.write_label,
+and by construction it must not pick up any PDS4-only attribute.
+"""
+
+from unittest.mock import MagicMock
+
+from pds.naif_pds4_bundler.classes.label.pds3_label import PDS3Label
+
+
+def _make_setup_pds3(**kwargs):
+    setup = MagicMock()
+    setup.pds_version = "3"
+    setup.root_dir = "/root"
+    setup.mission_acronym = "test"
+    setup.eol_pds3 = "\r\n"
+    del setup.creation_date_time
+
+    for k, v in kwargs.items():
+        setattr(setup, k, v)
+    return setup
+
+
+def _make_product():
+    product = MagicMock()
+    product.creation_time = "2024-01-01T00:00:00"
+    product.creation_date = "2024-01-01"
+    product.size = 1024
+    product.checksum = "abc123"
+    product.missions = ["TestMission"]
+    product.observers = ["TestObserver"]
+    product.targets = ["TestTarget"]
+    return product
+
+
+class TestPDS3LabelInit:
+    """Covers PDS3Label.__init__ – inherited, version-agnostic behavior."""
+
+    def test_construction_succeeds(self):
+        setup = _make_setup_pds3()
+        product = _make_product()
+        label = PDS3Label(setup, product)
+        assert label.setup is setup
+        assert label.product is product
+
+    def test_no_pds4_attrs_present(self):
+        """PDS3Label must never pick up PDS4-only attributes."""
+        setup = _make_setup_pds3()
+        product = _make_product()
+        label = PDS3Label(setup, product)
+        assert not hasattr(label, "XML_MODEL")
+        assert not hasattr(label, "SCHEMA_LOCATION")
+        assert not hasattr(label, "PDS4_MISSION_NAME")
+        assert not hasattr(label, "MISSIONS")
+
+
+class TestPDS3LabelExtensionAndEol:
+    """Covers the _label_extension/_eol properties consumed by write_label."""
+
+    def test_label_extension_is_lbl(self):
+        setup = _make_setup_pds3()
+        product = _make_product()
+        label = PDS3Label(setup, product)
+        assert label._label_extension == ".lbl"
+
+    def test_eol_reads_setup_eol_pds3(self):
+        setup = _make_setup_pds3(eol_pds3="\n")
+        product = _make_product()
+        label = PDS3Label(setup, product)
+        assert label._eol == "\n"

--- a/tests/npb/test_classes_label_pds3.py
+++ b/tests/npb/test_classes_label_pds3.py
@@ -7,6 +7,7 @@ behavior is the _label_extension/_eol pair consumed by PDSLabel.write_label,
 and by construction it must not pick up any PDS4-only attribute.
 """
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 from pds.naif_pds4_bundler.classes.label.pds3_label import PDS3Label
@@ -72,3 +73,32 @@ class TestPDS3LabelExtensionAndEol:
         product = _make_product()
         label = PDS3Label(setup, product)
         assert label._eol == "\n"
+
+
+class TestPDS3LabelWriteLabelIntegration:
+    """Integration test: PDS3Label wired into the real (inherited)
+    PDSLabel.write_label. The isolated behavior of write_label itself is
+    covered, decoupled from PDS3Label/PDS4Label, in
+    test_classes_label.py::TestPDSLabelWriteLabel; this verifies the two
+    classes actually work together end to end.
+    """
+
+    def test_write_label_produces_lbl_file_with_pds3_eol(self, tmp_path):
+        setup = _make_setup_pds3(eol_pds3="\r\n")
+        setup.staging_directory = str(tmp_path)
+        setup.diff = False
+        setup.args.silent = True
+
+        product = _make_product()
+        product.path = str(tmp_path / "test_kernel.bc")
+        product.extension = "bc"
+
+        label = PDS3Label(setup, product)
+        label.template = str(tmp_path / "template.lbl")
+        Path(label.template).write_text("Static content line\n")
+
+        label.write_label()
+
+        written = Path(label.name)
+        assert written.suffix == ".lbl"
+        assert written.read_bytes() == b"Static content line\r\n"

--- a/tests/npb/test_classes_label_pds3_checksum.py
+++ b/tests/npb/test_classes_label_pds3_checksum.py
@@ -109,7 +109,7 @@ class TestChecksumPDS3Label:
             Path(tmp_path / "templates")
             / "template_product_checksum_table.lbl"
         )
-        assert label.template == expected
+        assert label._template == expected
 
     def test_setup_and_product_reference_stored(self, tmp_path):
         setup = _make_setup(tmp_path)

--- a/tests/npb/test_classes_label_pds3_inventory.py
+++ b/tests/npb/test_classes_label_pds3_inventory.py
@@ -190,7 +190,7 @@ class TestInventoryPDS3LabelUnit:
         mock_write.assert_called_once()
 
         # Template path must embed root_dir and collection.type.
-        assert label.template == f"{tmp_path}/{expected_path}"
+        assert label._template == f"{tmp_path}/{expected_path}"
         assert label.collection ==  collection
         assert label.collection.type == collection_type
 

--- a/tests/npb/test_classes_label_pds3_spice_kernel.py
+++ b/tests/npb/test_classes_label_pds3_spice_kernel.py
@@ -11,7 +11,7 @@ from pds.naif_pds4_bundler.classes.label.pds3_spice_kernel import SpiceKernelPDS
 # Patch target strings (adjust if the real package path differs)
 # ---------------------------------------------------------------------------
 MODULE      = "pds.naif_pds4_bundler.classes.label.pds3_spice_kernel"
-PARENT_INIT = f"{MODULE}.PDSLabel.__init__"
+PARENT_INIT = f"{MODULE}.PDS3Label.__init__"
 WRITE_LABEL = f"{MODULE}.SpiceKernelPDS3Label.write_label"
 INSERT_TEXT = f"{MODULE}.SpiceKernelPDS3Label.insert_text_label"
 INSERT_BIN  = f"{MODULE}.SpiceKernelPDS3Label.insert_binary_label"

--- a/tests/npb/test_classes_label_pds3_spice_kernel.py
+++ b/tests/npb/test_classes_label_pds3_spice_kernel.py
@@ -102,9 +102,9 @@ class TestSpiceKernelPDS3LabelInit:
     """Tests for SpiceKernelPDS3Label.__init__."""
 
     def test_template_path_set(self):
-        """__init__ points self.template at the kernel label template file."""
+        """__init__ points self._template at the kernel label template file."""
         label = _build_label(_make_product("SPK"))
-        assert "template_product_spice_kernel.lbl" in label.template
+        assert "template_product_spice_kernel.lbl" in label._template
 
     def test_basic_attributes_set(self):
         product = _make_product("spk")

--- a/tests/npb/test_classes_label_pds4.py
+++ b/tests/npb/test_classes_label_pds4.py
@@ -10,6 +10,7 @@ test_classes_label_pds3.py for the (currently much thinner) PDS3Label
 coverage.
 """
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -385,3 +386,34 @@ class TestPDS4LabelDefaultReferenceTypes:
     def test_default_target_reference_type(self):
         label = object.__new__(PDS4Label)
         assert label._target_reference_type == "data_to_target"
+
+
+# ===========================================================================
+# PDS4Label + PDSLabel.write_label integration
+# ===========================================================================
+
+class TestPDS4LabelWriteLabelIntegration:
+    """Integration test: PDS4Label wired into the real (inherited)
+    PDSLabel.write_label. The isolated behavior of write_label itself is
+    covered, decoupled from PDS3Label/PDS4Label, in
+    test_classes_label.py::TestPDSLabelWriteLabel; this verifies the two
+    classes actually work together end to end.
+    """
+
+    def test_write_label_produces_xml_file_with_pds4_eol(
+            self, setup_pds4, product, tmp_path):
+        setup_pds4.staging_directory = str(tmp_path)
+        setup_pds4.diff = False
+        setup_pds4.args.silent = True
+        product.path = str(tmp_path / "test_kernel.bc")
+        product.extension = "bc"
+
+        label = PDS4Label(setup_pds4, product)
+        label.template = str(tmp_path / "template.xml")
+        Path(label.template).write_text("Static content line\n")
+
+        label.write_label()
+
+        written = Path(label.name)
+        assert written.suffix == ".xml"
+        assert written.read_bytes() == b"Static content line\r\n"

--- a/tests/npb/test_classes_label_pds4.py
+++ b/tests/npb/test_classes_label_pds4.py
@@ -409,8 +409,8 @@ class TestPDS4LabelWriteLabelIntegration:
         product.extension = "bc"
 
         label = PDS4Label(setup_pds4, product)
-        label.template = str(tmp_path / "template.xml")
-        Path(label.template).write_text("Static content line\n")
+        label._template = str(tmp_path / "template.xml")
+        Path(label._template).write_text("Static content line\n")
 
         label.write_label()
 

--- a/tests/npb/test_classes_label_pds4.py
+++ b/tests/npb/test_classes_label_pds4.py
@@ -366,7 +366,7 @@ class TestPDS4LabelGetTargets:
 
 
 # ===========================================================================
-# PDS4Label.get_mission_reference_type / get_target_reference_type
+# PDS4Label._mission_reference_type / _target_reference_type
 # ===========================================================================
 
 class TestPDS4LabelDefaultReferenceTypes:
@@ -380,8 +380,8 @@ class TestPDS4LabelDefaultReferenceTypes:
 
     def test_default_mission_reference_type(self):
         label = object.__new__(PDS4Label)
-        assert label.get_mission_reference_type() == "data_to_investigation"
+        assert label._mission_reference_type == "data_to_investigation"
 
     def test_default_target_reference_type(self):
         label = object.__new__(PDS4Label)
-        assert label.get_target_reference_type() == "data_to_target"
+        assert label._target_reference_type == "data_to_target"

--- a/tests/npb/test_classes_label_pds4.py
+++ b/tests/npb/test_classes_label_pds4.py
@@ -1,0 +1,477 @@
+"""
+Tests for PDS4Label class.
+
+PDS4Label carries everything that used to live behind
+``if setup.pds_version == "4":`` guards inside PDSLabel.__init__, plus the
+three PDS4-only context-product methods (get_missions/get_observers/
+get_targets) and the default reference-type values. See
+test_classes_label.py for the version-agnostic PDSLabel coverage and
+test_classes_label_pds3.py for the (currently much thinner) PDS3Label
+coverage.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pds.naif_pds4_bundler.classes.label.pds4_label import PDS4Label
+
+# Patch target — resolved to where the name is looked up inside pds4_label.py
+_PATCH_HANDLE_ERROR = "pds.naif_pds4_bundler.classes.label.pds4_label.handle_npb_error"
+
+
+# ---------------------------------------------------------------------------
+# Shared builder helpers
+# ---------------------------------------------------------------------------
+
+def _make_context_products():
+    """Return a minimal list of context product dicts used across tests."""
+    return [
+        {
+            "name": ["TestMission"],
+            "type": ["Mission"],
+            "lidvid": "urn:nasa:pds:testmission::1.0",
+        },
+        {
+            "name": ["TestObserver"],
+            "type": ["Spacecraft"],
+            "lidvid": "urn:nasa:pds:testobserver::1.0",
+        },
+        {
+            "name": ["TestTarget"],
+            "type": ["planet"],
+            "lidvid": "urn:nasa:pds:testtarget::1.0",
+        },
+    ]
+
+
+def _make_bundle(context_products=None):
+    bundle = MagicMock()
+    bundle.context_products = context_products or _make_context_products()
+    return bundle
+
+
+def _make_collection(bundle=None):
+    collection = MagicMock()
+    collection.bundle = bundle or _make_bundle()
+    collection.name = "spice_kernels"
+    return collection
+
+
+def _make_product(collection=None, bundle=None):
+    """Return a mock product that supplies all attributes PDS4Label touches."""
+    product = MagicMock()
+    product.collection = collection or _make_collection()
+    product.bundle = bundle or _make_bundle()
+    product.creation_time = "2024-01-01T00:00:00"
+    product.creation_date = "2024-01-01"
+    product.size = 1024
+    product.checksum = "abc123"
+    product.missions = ["TestMission"]
+    product.observers = ["TestObserver"]
+    product.targets = ["TestTarget"]
+    product.name = "test_kernel.bc"
+    product.extension = "bc"
+    product.path = "/staging/test_kernel.bc"
+    product.record_bytes = 80
+    return product
+
+
+def _make_setup_pds4(**kwargs):
+    """Return a mock setup object configured for PDS4."""
+    setup = MagicMock()
+    setup.pds_version = "4"
+    setup.root_dir = "/root"
+    setup.mission_acronym = "test"
+    setup.xml_model = "model"
+    setup.schema_location = "schema"
+    setup.information_model = ".".join(["1", "14", "0", "0"])
+    setup.information_model_float = 1014000000.0
+    setup.mission_name = "TestMission"
+    setup.observer = "TestObserver"
+    setup.target = "TestTarget"
+    setup.end_of_line = "CRLF"
+    setup.logical_identifier = "urn:nasa:pds:testmission"
+    setup.eol_pds4 = "\r\n"
+    setup.xml_tab = 2
+    setup.staging_directory = "/staging"
+    setup.working_directory = "/work"
+    setup.bundle_directory = "/bundle"
+    setup.diff = False
+    setup.args.silent = False
+    setup.args.verbose = False
+
+    # Ensure secondary_* attributes are NOT present by default
+    del setup.secondary_missions
+    del setup.secondary_observers
+    del setup.secondary_targets
+    del setup.creation_date_time
+
+    for k, v in kwargs.items():
+        setattr(setup, k, v)
+    return setup
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def setup_pds4():
+    return _make_setup_pds4()
+
+
+@pytest.fixture
+def product():
+    return _make_product()
+
+
+# ===========================================================================
+# PDS4Label.__init__
+# ===========================================================================
+
+class TestPDS4LabelInit:
+    """Covers PDS4Label.__init__ – all branches moved from PDSLabel."""
+
+    @staticmethod
+    @pytest.fixture
+    def mock_class_methods(mocker):
+        # Mocks all three methods at once
+        mocker.patch('pds.naif_pds4_bundler.classes.label.pds4_label.PDS4Label.get_missions',
+                     return_value='MockedMission')
+        mocker.patch('pds.naif_pds4_bundler.classes.label.pds4_label.PDS4Label.get_observers',
+                     return_value='MockedObserver')
+        mocker.patch('pds.naif_pds4_bundler.classes.label.pds4_label.PDS4Label.get_targets',
+                     return_value='MockedTarget')
+
+    def test_pds4_context_from_collection_bundle(self, setup_pds4, product):
+        """context products from collection.bundle"""
+        label = PDS4Label(setup_pds4, product)
+        assert label.setup is setup_pds4
+        assert label.product is product
+        assert label.name == ""
+
+    def test_pds4_context_falls_back_to_product_bundle(self, mock_class_methods, setup_pds4, product):
+        """context products from product.bundle
+           (collection.bundle.context_products is falsy => raises Exception)
+        """
+        product.collection.bundle.context_products = []
+        label = PDS4Label(setup_pds4, product)
+        assert label is not None
+
+    def test_pds4_context_attribute_error_falls_back(self, setup_pds4, product):
+        """collection.bundle raises AttributeError entirely"""
+        product.collection = MagicMock(spec=[])
+        label = PDS4Label(setup_pds4, product)
+        assert label is not None
+
+    def test_pds4_single_mission_name(self, mock_class_methods, setup_pds4, product):
+        label = PDS4Label(setup_pds4, product)
+        assert label.PDS4_MISSION_NAME == "TestMission"
+
+    @pytest.mark.parametrize("secondary_missions, expected_name",[
+        (["OtherMission"], "TestMission and OtherMission"),
+        (["MissionB", "MissionC"], "TestMission, MissionB, and MissionC"),
+    ])
+    def test_pds4_multiple_mission_name(self, mock_class_methods, setup_pds4, product, secondary_missions, expected_name):
+        setup_pds4.secondary_missions = secondary_missions
+        label = PDS4Label(setup_pds4, product)
+        assert label.PDS4_MISSION_NAME == expected_name
+
+    def test_pds4_single_observer_name(self, mock_class_methods, setup_pds4, product):
+        label = PDS4Label(setup_pds4, product)
+        assert label.PDS4_OBSERVER_NAME == "TestObserver spacecraft and its"
+
+    @pytest.mark.parametrize("secondary_observer, expected_name",[
+        (["OtherObserver"], "TestObserver and OtherObserver spacecraft and their"),
+        (["ObsB", "ObsC"], "TestObserver, ObsB, and ObsC spacecraft and their"),
+    ])
+    def test_pds4_multiple_observer_name(self, mock_class_methods, setup_pds4, product, secondary_observer, expected_name):
+        setup_pds4.secondary_observers = secondary_observer
+        label = PDS4Label(setup_pds4, product)
+        assert label.PDS4_OBSERVER_NAME == expected_name
+
+    @pytest.mark.parametrize("eol, expected_eol_name",[
+        ('LF', 'Line-Feed'),
+        ('CRLF', 'Carriage-Return Line-Feed')
+    ])
+    def test_pds4_end_of_line(self, product, eol, expected_eol_name):
+        setup = _make_setup_pds4(end_of_line=eol)
+        label = PDS4Label(setup, product)
+        assert label.END_OF_LINE == expected_eol_name
+
+    def test_pds4_end_of_line_invalid(self, product):
+        """end_of_line is invalid (neither CRLF nor LF)"""
+        setup = _make_setup_pds4(end_of_line="CR")
+        with pytest.raises(RuntimeError, match=r'End of Line provided via configuration '
+                                               r'is not CRLF nor LF\.'):
+            PDS4Label(setup, product)
+
+    # TODO: The following two test cases demonstrate an issue:
+    #       If they are not a list, the code to set up PDS4_MISSION_NAME
+    #       and PDS4_OBSERVER_NAME, results in a list of letters.
+    def test_pds4_secondary_missions_non_list_wrapped(self, mock_class_methods, setup_pds4, product):
+        setup_pds4.secondary_missions = "SingleMission"
+        label = PDS4Label(setup_pds4, product)
+        assert label.missions == ['TestMission', 'SingleMission']
+        # TODO: This is a bug!!!!
+        assert 'TestMission, S, i, n, g, l, e, M, i, s, s, i, o, and n' == label.PDS4_MISSION_NAME
+
+    def test_pds4_secondary_observers_non_list_wrapped(self, mock_class_methods, setup_pds4, product):
+        setup_pds4.secondary_observers = 'SingleObserver'
+        label = PDS4Label(setup_pds4, product)
+        assert label.observers == ['TestObserver', 'SingleObserver']
+        # TODO: This is a bug!!!
+        assert 'TestObserver, S, i, n, g, l, e, O, b, s, e, r, v, e, and r spacecraft and their' == label.PDS4_OBSERVER_NAME
+
+    def test_pds4_sets_missions_targets_observers(self, mock_class_methods, setup_pds4, product):
+        setup_pds4.secondary_missions = ["MissionB", "MissionC"]
+        setup_pds4.secondary_observers = ["ObsB", "ObsC"]
+        setup_pds4.secondary_targets = ["TargetB", "TargetC"]
+
+        # Since the mock is called, the values of the MISSIONS,
+        # OBSERVERS and TARGETS should be the ones provided as return_value
+        # in the mock.
+        label = PDS4Label(setup_pds4, product)
+        assert label.MISSIONS == 'MockedMission'
+        assert label.OBSERVERS == 'MockedObserver'
+        assert label.TARGETS == 'MockedTarget'
+
+
+# ===========================================================================
+# PDS4Label.get_missions
+# ===========================================================================
+
+class TestPDS4LabelGetMissions:
+    """Covers PDS4Label.get_missions – all branches."""
+
+    @pytest.fixture
+    def label_for(self):
+        """Factory fixture: returns a callable that builds a bare label."""
+        def _build(missions, context_products=None, fallback_to_bundle=False):
+            setup = _make_setup_pds4()
+            product = _make_product()
+            ctx = context_products or _make_context_products()
+            if fallback_to_bundle:
+                product.collection = MagicMock(spec=[])  # no .bundle
+                product.bundle.context_products = ctx
+            else:
+                product.collection.bundle.context_products = ctx
+            label = PDS4Label.__new__(PDS4Label)
+            label.setup = setup
+            label.product = product
+            label.missions = missions if isinstance(missions, list) else [missions]
+            return label
+        return _build
+
+    @pytest.mark.parametrize('missions, expected', [
+        (['TestMission'], '    <Investigation_Area>\r\n'
+                          '      <name>TestMission</name>\r\n'
+                          '      <type>Mission</type>\r\n'
+                          '      <Internal_Reference>\r\n'
+                          '        <lid_reference>urn:nasa:pds:testmission</lid_reference>\r\n'
+                          '        <reference_type>data_to_investigation</reference_type>\r\n'
+                          '      </Internal_Reference>\r\n'
+                          '    </Investigation_Area>\r\n'),
+        ('TestMission', '    <Investigation_Area>\r\n'
+                        '      <name>TestMission</name>\r\n'
+                        '      <type>Mission</type>\r\n'
+                        '      <Internal_Reference>\r\n'
+                        '        <lid_reference>urn:nasa:pds:testmission</lid_reference>\r\n'
+                        '        <reference_type>data_to_investigation</reference_type>\r\n'
+                        '      </Internal_Reference>\r\n'
+                        '    </Investigation_Area>\r\n')
+    ])
+    def test_mission(self, label_for, missions, expected):
+        label = label_for(missions)
+        label.missions = missions
+        result = label.get_missions()
+        assert result == expected
+
+    def test_context_falls_back_to_product_bundle(self, label_for):
+        result = label_for(["TestMission"], fallback_to_bundle=True).get_missions()
+        assert "TestMission" in result
+
+    def test_empty_mission_name_skipped_calls_error(self, label_for, mocker):
+        """A falsy mission entry (empty string) must be skipped."""
+        mock_err = mocker.patch(_PATCH_HANDLE_ERROR)
+        label_for([""]).get_missions()
+        mock_err.assert_called()
+
+    def test_other_investigation_type_accepted(self, label_for):
+        ctx = [
+            {
+                "name": ["TestMission"],
+                "type": ["Other Investigation"],
+                "lidvid": "urn:nasa:pds:testmission::1.0",
+            }
+        ]
+        result = label_for(["TestMission"], context_products=ctx).get_missions()
+        assert result == ('    <Investigation_Area>\r\n'
+                          '      <name>TestMission</name>\r\n'
+                          '      <type>Other Investigation</type>\r\n'
+                          '      <Internal_Reference>\r\n'
+                          '        <lid_reference>urn:nasa:pds:testmission</lid_reference>\r\n'
+                          '        <reference_type>data_to_investigation</reference_type>\r\n'
+                          '      </Internal_Reference>\r\n'
+                          '    </Investigation_Area>\r\n')
+
+    def test_no_lid_found_calls_handle_npb_error(self, label_for, mocker):
+        """No context product matches → mission_lid never set → handle_npb_error."""
+        ctx = [
+            {
+                "name": ["Different"],
+                "type": ["Mission"],
+                "lidvid": "urn:nasa:pds:different::1.0",
+            }
+        ]
+        mock_err = mocker.patch(_PATCH_HANDLE_ERROR)
+        label_for(["TestMission"], context_products=ctx).get_missions()
+        mock_err.assert_called()
+
+
+# ===========================================================================
+# PDS4Label.get_observers
+# ===========================================================================
+
+class TestPDS4LabelGetObservers:
+    """Covers PDS4Label.get_observers – all branches."""
+
+    @pytest.fixture
+    def label_for(self):
+        """Factory fixture: builds a bare label with given observers."""
+        def _build(observers, context_products=None, fallback_to_bundle=False):
+            setup = _make_setup_pds4()
+            product = _make_product()
+            ctx = context_products or _make_context_products()
+            if fallback_to_bundle:
+                product.collection = MagicMock(spec=[])
+                product.bundle.context_products = ctx
+            else:
+                product.collection.bundle.context_products = ctx
+            label = PDS4Label.__new__(PDS4Label)
+            label.setup = setup
+            label.product = product
+            label.observers = observers if isinstance(observers, list) else [observers]
+            return label
+        return _build
+
+    def test_single_observer_spacecraft(self, label_for):
+        result = label_for(["TestObserver"]).get_observers()
+        assert "TestObserver" in result
+        assert "Observing_System_Component" in result
+
+    def test_observers_not_a_list_wrapped(self, label_for):
+        label = label_for("TestObserver")
+        label.observers = "TestObserver"  # scalar
+        assert "TestObserver" in label.get_observers()
+
+    def test_context_fallback_to_product_bundle(self, label_for):
+        result = label_for(["TestObserver"], fallback_to_bundle=True).get_observers()
+        assert "TestObserver" in result
+
+    def test_rover_type_accepted(self, label_for):
+        ctx = [{"name": ["TestObserver"], "type": ["Rover"], "lidvid": "urn:x::1.0"}]
+        assert "Rover" in label_for(["TestObserver"], ctx).get_observers()
+
+    def test_lander_type_accepted(self, label_for):
+        ctx = [{"name": ["TestObserver"], "type": ["Lander"], "lidvid": "urn:x::1.0"}]
+        assert "Lander" in label_for(["TestObserver"], ctx).get_observers()
+
+    def test_host_type_accepted(self, label_for):
+        ctx = [{"name": ["TestObserver"], "type": ["Host"], "lidvid": "urn:x::1.0"}]
+        assert "Host" in label_for(["TestObserver"], ctx).get_observers()
+
+    def test_comma_in_observer_name_strips_suffix(self, label_for):
+        """Observer names like 'Name, suffix' → only 'Name' used for look-up."""
+        ctx = [{"name": ["TestObserver"], "type": ["Spacecraft"], "lidvid": "urn:x::1.0"}]
+        assert "TestObserver" in label_for(["TestObserver, extra"], ctx).get_observers()
+
+    def test_empty_observer_skipped_calls_error(self, label_for, mocker):
+        mock_err = mocker.patch(_PATCH_HANDLE_ERROR)
+        label_for([""]).get_observers()
+        mock_err.assert_called()
+
+    def test_no_lid_calls_handle_npb_error(self, label_for, mocker):
+        ctx = [{"name": ["NoMatch"], "type": ["Spacecraft"], "lidvid": "urn:x::1.0"}]
+        mock_err = mocker.patch(_PATCH_HANDLE_ERROR)
+        label_for(["TestObserver"], ctx).get_observers()
+        mock_err.assert_called()
+
+    def test_trailing_eol_appended(self, label_for):
+        assert label_for(["TestObserver"]).get_observers().endswith("\r\n")
+
+
+# ===========================================================================
+# PDS4Label.get_targets
+# ===========================================================================
+
+class TestPDS4LabelGetTargets:
+    """Covers PDS4Label.get_targets – all branches."""
+
+    @pytest.fixture
+    def label_for(self):
+        """Factory fixture: builds a bare label with given targets."""
+        def _build(targets, context_products=None, fallback_to_bundle=False):
+            setup = _make_setup_pds4()
+            product = _make_product()
+            ctx = context_products or _make_context_products()
+            if fallback_to_bundle:
+                product.collection = MagicMock(spec=[])
+                product.bundle.context_products = ctx
+            else:
+                product.collection.bundle.context_products = ctx
+            label = PDS4Label.__new__(PDS4Label)
+            label.setup = setup
+            label.product = product
+            label.targets = targets if isinstance(targets, list) else [targets]
+            return label
+        return _build
+
+    def test_single_target(self, label_for):
+        result = label_for(["TestTarget"]).get_targets()
+        assert "TestTarget" in result
+        assert "Target_Identification" in result
+
+    def test_targets_not_a_list_wrapped(self, label_for):
+        label = label_for("TestTarget")
+        label.targets = "TestTarget"  # scalar
+        assert "TestTarget" in label.get_targets()
+
+    def test_context_fallback_to_product_bundle(self, label_for):
+        result = label_for(["TestTarget"], fallback_to_bundle=True).get_targets()
+        assert "TestTarget" in result
+
+    def test_case_insensitive_name_match(self, label_for):
+        ctx = [{"name": ["TESTTARGET"], "type": ["planet"], "lidvid": "urn:x::1.0"}]
+        assert "testtarget" in label_for(["testtarget"], ctx).get_targets()
+
+    def test_empty_target_skipped_calls_error(self, label_for, mocker):
+        mock_err = mocker.patch(_PATCH_HANDLE_ERROR)
+        label_for([""]).get_targets()
+        mock_err.assert_called()
+
+    def test_trailing_eol_appended(self, label_for):
+        assert label_for(["TestTarget"]).get_targets().endswith("\r\n")
+
+
+# ===========================================================================
+# PDS4Label.get_mission_reference_type / get_target_reference_type
+# ===========================================================================
+
+class TestPDS4LabelDefaultReferenceTypes:
+    """Covers PDS4Label's own default reference types.
+
+    Per-leaf overrides (Checksum/Bundle/Document/Inventory/OrbnumFile) are
+    covered in each leaf class's own test file; SpiceKernelPDS4Label and
+    MetaKernelPDS4Label have no override and so are covered by inheriting
+    this same default, exercised here directly on PDS4Label.
+    """
+
+    def test_default_mission_reference_type(self):
+        label = object.__new__(PDS4Label)
+        assert label.get_mission_reference_type() == "data_to_investigation"
+
+    def test_default_target_reference_type(self):
+        label = object.__new__(PDS4Label)
+        assert label.get_target_reference_type() == "data_to_target"

--- a/tests/npb/test_classes_label_pds4.py
+++ b/tests/npb/test_classes_label_pds4.py
@@ -63,18 +63,23 @@ class TestPDS4LabelInit:
         assert label.name == ""
 
     def test_pds4_context_falls_back_to_product_bundle(self, mock_class_methods, setup_pds4, product):
-        """context products from product.bundle
-           (collection.bundle.context_products is falsy => raises Exception)
+        """Construction does not raise when collection.bundle.context_products
+        is falsy. The internal try/except silently falls back to
+        product.bundle.context_products; whether that fallback value is
+        used correctly is covered separately by each of get_missions/
+        get_observers/get_targets' own test_context_fallback_to_product_bundle
+        test.
         """
         product.collection.bundle.context_products = []
-        label = PDS4Label(setup_pds4, product)
-        assert label is not None
+        PDS4Label(setup_pds4, product)
 
     def test_pds4_context_attribute_error_falls_back(self, setup_pds4, product):
-        """collection.bundle raises AttributeError entirely"""
+        """Construction does not raise when product.collection.bundle is
+        entirely inaccessible (AttributeError); the try/except in __init__
+        swallows it and falls back to product.bundle.context_products.
+        """
         product.collection = MagicMock(spec=[])
-        label = PDS4Label(setup_pds4, product)
-        assert label is not None
+        PDS4Label(setup_pds4, product)
 
     def test_pds4_single_mission_name(self, mock_class_methods, setup_pds4, product):
         label = PDS4Label(setup_pds4, product)

--- a/tests/npb/test_classes_label_pds4.py
+++ b/tests/npb/test_classes_label_pds4.py
@@ -21,109 +21,19 @@ _PATCH_HANDLE_ERROR = "pds.naif_pds4_bundler.classes.label.pds4_label.handle_npb
 
 
 # ---------------------------------------------------------------------------
-# Shared builder helpers
-# ---------------------------------------------------------------------------
-
-def _make_context_products():
-    """Return a minimal list of context product dicts used across tests."""
-    return [
-        {
-            "name": ["TestMission"],
-            "type": ["Mission"],
-            "lidvid": "urn:nasa:pds:testmission::1.0",
-        },
-        {
-            "name": ["TestObserver"],
-            "type": ["Spacecraft"],
-            "lidvid": "urn:nasa:pds:testobserver::1.0",
-        },
-        {
-            "name": ["TestTarget"],
-            "type": ["planet"],
-            "lidvid": "urn:nasa:pds:testtarget::1.0",
-        },
-    ]
-
-
-def _make_bundle(context_products=None):
-    bundle = MagicMock()
-    bundle.context_products = context_products or _make_context_products()
-    return bundle
-
-
-def _make_collection(bundle=None):
-    collection = MagicMock()
-    collection.bundle = bundle or _make_bundle()
-    collection.name = "spice_kernels"
-    return collection
-
-
-def _make_product(collection=None, bundle=None):
-    """Return a mock product that supplies all attributes PDS4Label touches."""
-    product = MagicMock()
-    product.collection = collection or _make_collection()
-    product.bundle = bundle or _make_bundle()
-    product.creation_time = "2024-01-01T00:00:00"
-    product.creation_date = "2024-01-01"
-    product.size = 1024
-    product.checksum = "abc123"
-    product.missions = ["TestMission"]
-    product.observers = ["TestObserver"]
-    product.targets = ["TestTarget"]
-    product.name = "test_kernel.bc"
-    product.extension = "bc"
-    product.path = "/staging/test_kernel.bc"
-    product.record_bytes = 80
-    return product
-
-
-def _make_setup_pds4(**kwargs):
-    """Return a mock setup object configured for PDS4."""
-    setup = MagicMock()
-    setup.pds_version = "4"
-    setup.root_dir = "/root"
-    setup.mission_acronym = "test"
-    setup.xml_model = "model"
-    setup.schema_location = "schema"
-    setup.information_model = ".".join(["1", "14", "0", "0"])
-    setup.information_model_float = 1014000000.0
-    setup.mission_name = "TestMission"
-    setup.observer = "TestObserver"
-    setup.target = "TestTarget"
-    setup.end_of_line = "CRLF"
-    setup.logical_identifier = "urn:nasa:pds:testmission"
-    setup.eol_pds4 = "\r\n"
-    setup.xml_tab = 2
-    setup.staging_directory = "/staging"
-    setup.working_directory = "/work"
-    setup.bundle_directory = "/bundle"
-    setup.diff = False
-    setup.args.silent = False
-    setup.args.verbose = False
-
-    # Ensure secondary_* attributes are NOT present by default
-    del setup.secondary_missions
-    del setup.secondary_observers
-    del setup.secondary_targets
-    del setup.creation_date_time
-
-    for k, v in kwargs.items():
-        setattr(setup, k, v)
-    return setup
-
-
-# ---------------------------------------------------------------------------
 # Shared fixtures
 # ---------------------------------------------------------------------------
+# make_context_products/make_product/make_setup_pds4 come from conftest.py's
+# label_test_helpers fixture, shared with test_classes_label.py.
 
 @pytest.fixture
-def setup_pds4():
-    return _make_setup_pds4()
+def setup_pds4(label_test_helpers):
+    return label_test_helpers.make_setup_pds4()
 
 
 @pytest.fixture
-def product():
-    return _make_product()
+def product(label_test_helpers):
+    return label_test_helpers.make_product()
 
 
 # ===========================================================================
@@ -195,14 +105,14 @@ class TestPDS4LabelInit:
         ('LF', 'Line-Feed'),
         ('CRLF', 'Carriage-Return Line-Feed')
     ])
-    def test_pds4_end_of_line(self, product, eol, expected_eol_name):
-        setup = _make_setup_pds4(end_of_line=eol)
+    def test_pds4_end_of_line(self, label_test_helpers, product, eol, expected_eol_name):
+        setup = label_test_helpers.make_setup_pds4(end_of_line=eol)
         label = PDS4Label(setup, product)
         assert label.END_OF_LINE == expected_eol_name
 
-    def test_pds4_end_of_line_invalid(self, product):
+    def test_pds4_end_of_line_invalid(self, label_test_helpers, product):
         """end_of_line is invalid (neither CRLF nor LF)"""
-        setup = _make_setup_pds4(end_of_line="CR")
+        setup = label_test_helpers.make_setup_pds4(end_of_line="CR")
         with pytest.raises(RuntimeError, match=r'End of Line provided via configuration '
                                                r'is not CRLF nor LF\.'):
             PDS4Label(setup, product)
@@ -246,12 +156,12 @@ class TestPDS4LabelGetMissions:
     """Covers PDS4Label.get_missions – all branches."""
 
     @pytest.fixture
-    def label_for(self):
+    def label_for(self, label_test_helpers):
         """Factory fixture: returns a callable that builds a bare label."""
         def _build(missions, context_products=None, fallback_to_bundle=False):
-            setup = _make_setup_pds4()
-            product = _make_product()
-            ctx = context_products or _make_context_products()
+            setup = label_test_helpers.make_setup_pds4()
+            product = label_test_helpers.make_product()
+            ctx = context_products or label_test_helpers.make_context_products()
             if fallback_to_bundle:
                 product.collection = MagicMock(spec=[])  # no .bundle
                 product.bundle.context_products = ctx
@@ -338,12 +248,12 @@ class TestPDS4LabelGetObservers:
     """Covers PDS4Label.get_observers – all branches."""
 
     @pytest.fixture
-    def label_for(self):
+    def label_for(self, label_test_helpers):
         """Factory fixture: builds a bare label with given observers."""
         def _build(observers, context_products=None, fallback_to_bundle=False):
-            setup = _make_setup_pds4()
-            product = _make_product()
-            ctx = context_products or _make_context_products()
+            setup = label_test_helpers.make_setup_pds4()
+            product = label_test_helpers.make_product()
+            ctx = context_products or label_test_helpers.make_context_products()
             if fallback_to_bundle:
                 product.collection = MagicMock(spec=[])
                 product.bundle.context_products = ctx
@@ -410,12 +320,12 @@ class TestPDS4LabelGetTargets:
     """Covers PDS4Label.get_targets – all branches."""
 
     @pytest.fixture
-    def label_for(self):
+    def label_for(self, label_test_helpers):
         """Factory fixture: builds a bare label with given targets."""
         def _build(targets, context_products=None, fallback_to_bundle=False):
-            setup = _make_setup_pds4()
-            product = _make_product()
-            ctx = context_products or _make_context_products()
+            setup = label_test_helpers.make_setup_pds4()
+            product = label_test_helpers.make_product()
+            ctx = context_products or label_test_helpers.make_context_products()
             if fallback_to_bundle:
                 product.collection = MagicMock(spec=[])
                 product.bundle.context_products = ctx

--- a/tests/npb/test_classes_label_pds4_bundle.py
+++ b/tests/npb/test_classes_label_pds4_bundle.py
@@ -183,7 +183,7 @@ class TestBundlePDS4Label:
             self, label: BundlePDS4Label) -> None:
         # The template path is fixed to 'template_bundle.xml' under the
         # configured templates' directory.
-        assert label.template == str(
+        assert label._template == str(
             Path(label.setup.templates_directory) / 'template_bundle.xml')
 
     def test_constructor_does_not_set_name_attribute(
@@ -631,7 +631,7 @@ class TestBundlePDS4LabelIntegration:
 
         label = BundlePDS4Label(setup, readme)
 
-        assert label.template == str(template_path)
+        assert label._template == str(template_path)
         assert Path(label.name) == label_path
         assert label_path.exists()
         assert '$' not in label_path.read_text(encoding='utf-8')

--- a/tests/npb/test_classes_label_pds4_bundle.py
+++ b/tests/npb/test_classes_label_pds4_bundle.py
@@ -210,14 +210,14 @@ class TestBundlePDS4Label:
         mock_write.assert_called_once_with(label)
 
     # ------------------------------------------------------------------
-    # get_*_reference_type overrides
+    # _*_reference_type overrides
     # ------------------------------------------------------------------
 
-    def test_get_mission_reference_type(self, label: BundlePDS4Label) -> None:
-        assert label.get_mission_reference_type() == 'bundle_to_investigation'
+    def test_mission_reference_type(self, label: BundlePDS4Label) -> None:
+        assert label._mission_reference_type == 'bundle_to_investigation'
 
-    def test_get_target_reference_type(self, label: BundlePDS4Label) -> None:
-        assert label.get_target_reference_type() == 'bundle_to_target'
+    def test_target_reference_type(self, label: BundlePDS4Label) -> None:
+        assert label._target_reference_type == 'bundle_to_target'
 
     # ------------------------------------------------------------------
     # BUNDLE_MEMBER_ENTRIES – per-collection rendering

--- a/tests/npb/test_classes_label_pds4_checksum.py
+++ b/tests/npb/test_classes_label_pds4_checksum.py
@@ -113,14 +113,14 @@ class TestChecksumPDS4Label:
         assert label.name == 'checksum.xml'
 
     # ------------------------------------------------------------------
-    # get_*_reference_type overrides
+    # _*_reference_type overrides
     # ------------------------------------------------------------------
 
-    def test_get_mission_reference_type(self, label: ChecksumPDS4Label) -> None:
-        assert label.get_mission_reference_type() == 'ancillary_to_investigation'
+    def test_mission_reference_type(self, label: ChecksumPDS4Label) -> None:
+        assert label._mission_reference_type == 'ancillary_to_investigation'
 
-    def test_get_target_reference_type(self, label: ChecksumPDS4Label) -> None:
-        assert label.get_target_reference_type() == 'ancillary_to_target'
+    def test_target_reference_type(self, label: ChecksumPDS4Label) -> None:
+        assert label._target_reference_type == 'ancillary_to_target'
 
     def test_constructor_stores_references_and_writes_label_once(
             self, tmp_path: Path, helpers: SimpleNamespace) -> None:

--- a/tests/npb/test_classes_label_pds4_checksum.py
+++ b/tests/npb/test_classes_label_pds4_checksum.py
@@ -286,7 +286,7 @@ class TestChecksumPDS4LabelIntegration:
         label = ChecksumPDS4Label(setup, product)
 
         # Check that the class resolved the configured checksum template.
-        assert label.template == str(template_path)
+        assert label._template == str(template_path)
 
         # Check that the final checksum.xml file has been created in staging.
         assert label_path.exists()

--- a/tests/npb/test_classes_label_pds4_checksum.py
+++ b/tests/npb/test_classes_label_pds4_checksum.py
@@ -112,6 +112,16 @@ class TestChecksumPDS4Label:
         # name.
         assert label.name == 'checksum.xml'
 
+    # ------------------------------------------------------------------
+    # get_*_reference_type overrides
+    # ------------------------------------------------------------------
+
+    def test_get_mission_reference_type(self, label: ChecksumPDS4Label) -> None:
+        assert label.get_mission_reference_type() == 'ancillary_to_investigation'
+
+    def test_get_target_reference_type(self, label: ChecksumPDS4Label) -> None:
+        assert label.get_target_reference_type() == 'ancillary_to_target'
+
     def test_constructor_stores_references_and_writes_label_once(
             self, tmp_path: Path, helpers: SimpleNamespace) -> None:
         # Validate constructor wiring and its single write_label side effect.

--- a/tests/npb/test_classes_label_pds4_document.py
+++ b/tests/npb/test_classes_label_pds4_document.py
@@ -57,8 +57,8 @@ class TestDocumentPDS4LabelInit:
         # Check that the class stores the same references as those received.
         assert document_label.setup is setup
         assert document_label.collection is collection
-        assert document_label.template == str(Path(setup.templates_directory) /
-                                              'template_product_html_document.xml')
+        assert document_label._template == str(Path(setup.templates_directory) /
+                                               'template_product_html_document.xml')
 
         # Check the product details.
         assert document_label.PRODUCT_LID == inventory.lid
@@ -209,7 +209,7 @@ class TestDocumentPDS4LabelIntegration:
         label = DocumentPDS4Label(setup, collection, inventory)
 
         # DocumentPDS4Label must resolve the document-specific template.
-        assert label.template == str(template_path)
+        assert label._template == str(template_path)
 
         # The real writer mutates label.name to the generated XML file path.
         assert Path(label.name) == label_path

--- a/tests/npb/test_classes_label_pds4_document.py
+++ b/tests/npb/test_classes_label_pds4_document.py
@@ -250,22 +250,22 @@ class TestDocumentPDS4LabelIntegration:
         setup.add_file.assert_called_once_with(expected_label_path)
 
     # ------------------------------------------------------------------
-    # get_*_reference_type overrides
+    # _*_reference_type overrides
     # ------------------------------------------------------------------
 
-    def test_get_mission_reference_type(
+    def test_mission_reference_type(
             self,
             env: tuple[SimpleNamespace, SimpleNamespace, SimpleNamespace, Path, Path]) -> None:
         # DocumentPDS4Label overrides the mission reference type only; the
         # target reference type keeps PDS4Label's default (see below).
         setup, collection, inventory, _, _ = env
         label = DocumentPDS4Label(setup, collection, inventory)
-        assert label.get_mission_reference_type() == 'document_to_investigation'
+        assert label._mission_reference_type == 'document_to_investigation'
 
-    def test_get_target_reference_type(
+    def test_target_reference_type(
             self,
             env: tuple[SimpleNamespace, SimpleNamespace, SimpleNamespace, Path, Path]) -> None:
         # No override on DocumentPDS4Label: falls back to PDS4Label's default.
         setup, collection, inventory, _, _ = env
         label = DocumentPDS4Label(setup, collection, inventory)
-        assert label.get_target_reference_type() == 'data_to_target'
+        assert label._target_reference_type == 'data_to_target'

--- a/tests/npb/test_classes_label_pds4_document.py
+++ b/tests/npb/test_classes_label_pds4_document.py
@@ -39,9 +39,9 @@ class TestDocumentPDS4LabelInit:
         setup, collection, inventory = self.make_document_label_inputs(tmp_path)
 
         # This mock allows you to verify that the call is made, but without
-        # executing the actual logic of PDSLabel.
+        # executing the actual logic of PDS4Label.
         parent_init_mock = mocker.patch(
-            'pds.naif_pds4_bundler.classes.label.pds4_document.PDSLabel.__init__',
+            'pds.naif_pds4_bundler.classes.label.pds4_document.PDS4Label.__init__',
             autospec=True)
 
         # Mock write_label to verify that label generation is requested without
@@ -79,7 +79,7 @@ class TestDocumentPDS4LabelInit:
             tmp_path, collection_name='collection.document_inventory_v001.csv')
 
         mocker.patch(
-            'pds.naif_pds4_bundler.classes.label.pds4_document.PDSLabel.__init__',
+            'pds.naif_pds4_bundler.classes.label.pds4_document.PDS4Label.__init__',
             autospec=True)
 
         mocker.patch.object(DocumentPDS4Label, 'write_label', autospec=True)
@@ -248,3 +248,24 @@ class TestDocumentPDS4LabelIntegration:
 
         # The generated XML label must be registered exactly once.
         setup.add_file.assert_called_once_with(expected_label_path)
+
+    # ------------------------------------------------------------------
+    # get_*_reference_type overrides
+    # ------------------------------------------------------------------
+
+    def test_get_mission_reference_type(
+            self,
+            env: tuple[SimpleNamespace, SimpleNamespace, SimpleNamespace, Path, Path]) -> None:
+        # DocumentPDS4Label overrides the mission reference type only; the
+        # target reference type keeps PDS4Label's default (see below).
+        setup, collection, inventory, _, _ = env
+        label = DocumentPDS4Label(setup, collection, inventory)
+        assert label.get_mission_reference_type() == 'document_to_investigation'
+
+    def test_get_target_reference_type(
+            self,
+            env: tuple[SimpleNamespace, SimpleNamespace, SimpleNamespace, Path, Path]) -> None:
+        # No override on DocumentPDS4Label: falls back to PDS4Label's default.
+        setup, collection, inventory, _, _ = env
+        label = DocumentPDS4Label(setup, collection, inventory)
+        assert label.get_target_reference_type() == 'data_to_target'

--- a/tests/npb/test_classes_label_pds4_inventory.py
+++ b/tests/npb/test_classes_label_pds4_inventory.py
@@ -181,7 +181,7 @@ class TestInventoryPDS4Label:
             Path(label.setup.templates_directory)
             / 'template_collection_spice_kernels.xml')
 
-        assert label.template == expected_template
+        assert label._template == expected_template
 
     def test_constructor_stores_references_and_writes_label_once(
             self, tmp_path: Path, helpers: SimpleNamespace) -> None:
@@ -239,7 +239,7 @@ class TestInventoryPDS4Label:
                    'PDSLabel.write_label', autospec=True):
             label = InventoryPDS4Label(setup, collection, inventory)
 
-        assert label.template == str(
+        assert label._template == str(
             Path(setup.templates_directory)
             / f'template_collection_{coll_type}.xml')
 
@@ -525,7 +525,7 @@ class TestInventoryPDS4LabelIntegration:
         label = InventoryPDS4Label(setup, collection, inventory)
 
         # The class resolved the template from collection.type.
-        assert label.template == str(template_path)
+        assert label._template == str(template_path)
 
         # The real writer mutates label.name to the generated XML file path.
         assert Path(label.name) == label_path

--- a/tests/npb/test_classes_label_pds4_inventory.py
+++ b/tests/npb/test_classes_label_pds4_inventory.py
@@ -204,16 +204,16 @@ class TestInventoryPDS4Label:
         mock_write.assert_called_once_with(label)
 
     # ------------------------------------------------------------------
-    # get_*_reference_type – the two fixed-string overrides
+    # _*_reference_type – the two fixed-string overrides
     # ------------------------------------------------------------------
 
-    def test_get_mission_reference_type(self, label: InventoryPDS4Label) -> None:
-        # The override returns the literal collection_to_investigation string.
-        assert label.get_mission_reference_type() == 'collection_to_investigation'
+    def test_mission_reference_type(self, label: InventoryPDS4Label) -> None:
+        # The override is the literal collection_to_investigation string.
+        assert label._mission_reference_type == 'collection_to_investigation'
 
-    def test_get_target_reference_type(self, label: InventoryPDS4Label) -> None:
-        # The override returns the literal collection_to_target string.
-        assert label.get_target_reference_type() == 'collection_to_target'
+    def test_target_reference_type(self, label: InventoryPDS4Label) -> None:
+        # The override is the literal collection_to_target string.
+        assert label._target_reference_type == 'collection_to_target'
 
     # ------------------------------------------------------------------
     # Template path is parametrized on collection.type

--- a/tests/npb/test_classes_label_pds4_metakernel.py
+++ b/tests/npb/test_classes_label_pds4_metakernel.py
@@ -168,7 +168,7 @@ class TestMetaKernelPDS4Label:
             Path(label.setup.templates_directory)
             / 'template_product_spice_kernel_mk.xml')
 
-        assert label.template == expected_template
+        assert label._template == expected_template
 
     def test_constructor_stores_references_and_writes_label_once(
             self, tmp_path: Path, helpers: SimpleNamespace) -> None:
@@ -604,7 +604,7 @@ class TestMetaKernelPDS4LabelIntegration:
         label = MetaKernelPDS4Label(setup, product)
 
         # Check that the class resolved the configured MK template.
-        assert label.template == str(template_path)
+        assert label._template == str(template_path)
 
         # The real writer mutates label.name to the generated XML file path.
         assert Path(label.name) == label_path

--- a/tests/npb/test_classes_label_pds4_orbnum_file.py
+++ b/tests/npb/test_classes_label_pds4_orbnum_file.py
@@ -240,7 +240,7 @@ class TestOrbnumFilePDS4Label:
         assert label.template == expected_template
 
     # ------------------------------------------------------------------
-    # get_*_reference_type overrides
+    # _*_reference_type overrides
     # ------------------------------------------------------------------
 
     @pytest.mark.parametrize('information_model_float, expected_mission, expected_target', [
@@ -255,8 +255,8 @@ class TestOrbnumFilePDS4Label:
         instance = object.__new__(OrbnumFilePDS4Label)
         instance.setup = SimpleNamespace(information_model_float=information_model_float)
 
-        assert instance.get_mission_reference_type() == expected_mission
-        assert instance.get_target_reference_type() == expected_target
+        assert instance._mission_reference_type == expected_mission
+        assert instance._target_reference_type == expected_target
 
     def test_constructor_stores_references_and_writes_label_once(
             self, tmp_path: Path, helpers: SimpleNamespace) -> None:

--- a/tests/npb/test_classes_label_pds4_orbnum_file.py
+++ b/tests/npb/test_classes_label_pds4_orbnum_file.py
@@ -237,7 +237,7 @@ class TestOrbnumFilePDS4Label:
             Path(label.setup.templates_directory)
             / 'template_product_orbnum_table.xml')
 
-        assert label.template == expected_template
+        assert label._template == expected_template
 
     # ------------------------------------------------------------------
     # _*_reference_type overrides
@@ -880,7 +880,7 @@ class TestOrbnumFilePDS4LabelIntegration:
         label = OrbnumFilePDS4Label(setup, product)
 
         # Check that the class resolved the configured OrbNum template.
-        assert label.template == str(template_path)
+        assert label._template == str(template_path)
 
         # The real writer mutates label.name to the generated XML file path.
         assert Path(label.name) == label_path

--- a/tests/npb/test_classes_label_pds4_orbnum_file.py
+++ b/tests/npb/test_classes_label_pds4_orbnum_file.py
@@ -239,6 +239,25 @@ class TestOrbnumFilePDS4Label:
 
         assert label.template == expected_template
 
+    # ------------------------------------------------------------------
+    # get_*_reference_type overrides
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize('information_model_float, expected_mission, expected_target', [
+        (1014000000.0, 'ancillary_to_investigation', 'ancillary_to_target'),
+        (1013000000.0, 'data_to_investigation', 'data_to_target'),
+    ])
+    def test_reference_type_threshold(
+            self, information_model_float, expected_mission, expected_target) -> None:
+        # Both overrides depend only on setup.information_model_float, so a
+        # bare instance with just that attribute set is enough to exercise
+        # the >= 1014000000.0 threshold on both sides.
+        instance = object.__new__(OrbnumFilePDS4Label)
+        instance.setup = SimpleNamespace(information_model_float=information_model_float)
+
+        assert instance.get_mission_reference_type() == expected_mission
+        assert instance.get_target_reference_type() == expected_target
+
     def test_constructor_stores_references_and_writes_label_once(
             self, tmp_path: Path, helpers: SimpleNamespace) -> None:
         # Validate constructor wiring and its single write_label side effect.

--- a/tests/npb/test_classes_label_pds4_spice_kernel.py
+++ b/tests/npb/test_classes_label_pds4_spice_kernel.py
@@ -153,7 +153,7 @@ class TestSpiceKernelPDS4Label:
             Path(label.setup.templates_directory)
             / 'template_product_spice_kernel.xml')
 
-        assert label.template == expected_template
+        assert label._template == expected_template
 
     def test_constructor_stores_references_and_writes_label_once(
             self, tmp_path: Path, helpers: SimpleNamespace) -> None:
@@ -381,7 +381,7 @@ class TestSpiceKernelPDS4LabelIntegration:
         label = SpiceKernelPDS4Label(setup, product)
 
         # Check that the class resolved the configured SPICE kernel template.
-        assert label.template == str(template_path)
+        assert label._template == str(template_path)
 
         # The real writer mutates label.name to the generated XML file path.
         assert Path(label.name) == label_path


### PR DESCRIPTION
## 🗒️ Summary
Splits `PDSLabel` into a version-agnostic base plus `PDS3Label`/`PDS4Label` intermediate classes. Removes every `if setup.pds_version == "4":` guard and the `get_missions`/`get_observers`/`get_targets` methods from `PDSLabel`, relocating them to `PDS4Label`. Replaces the `self.__class__.__name__ ==` dispatch chain in `get_mission_reference_type`/`get_target_reference_type` with per-subclass overrides — `PDSLabel` now raises `NotImplementedError`, `PDS4Label` supplies the default, and five leaf classes (`ChecksumPDS4Label`, `DocumentPDS4Label`, `OrbnumFilePDS4Label`, plus the pre-existing `BundlePDS4Label`/`InventoryPDS4Label` overrides) override where they differ. `write_label()` now reads `_label_extension`/`_eol` from the label's own class instead of branching on `setup.pds_version`.

All 10 leaf label classes re-parented accordingly. No leaf constructor signatures changed, no product-facing behavior changes, no `classes/product/*.py` call sites touched.

## ⚙️ Test Data and/or Report
Full existing regression suite, extended to cover the moved/added code:
- `pytest tests/npb/test_classes_label*.py --cov-branch` → 371 passed, 100% coverage on every touched label file
- `pytest tests/npb/ --cov-branch` (merge gate) → 1764 passed, 8 skipped, 1 xfailed, 99% overall coverage
- New: `test_classes_label_pds3.py`, `test_classes_label_pds4.py`. Trimmed: `test_classes_label.py` (now version-agnostic only). Extended: reference-type override tests added to the checksum/document/orbnum leaf test files.

## ♻️ Related Issues
Fixes #297