### PR TITLE
Broad pipeline try/except + migrate plan.py

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/plan.py
+++ b/src/pds/naif_pds4_bundler/classes/plan.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 import re
 
-from pds.naif_pds4_bundler.pipeline.runtime import handle_npb_error
+from pds.naif_pds4_bundler.classes.exceptions import NPBError
 
 
 class ReleasePlan:
@@ -51,7 +51,7 @@ class ReleasePlan:
                 pl.write(plan.split(os.sep)[-1])
 
         elif plan.suffix != ".plan":
-            handle_npb_error(
+            raise NPBError(
                 "Release plan requires *.plan extension. Single "
                 "kernels are only allowed in labeling mode."
             )
@@ -156,7 +156,7 @@ class ReleasePlan:
                 if os.path.isfile(mk_path):
                     kernels.append(mk_new_name)
                 else:
-                    handle_npb_error(
+                    raise NPBError(
                         f"Meta-kernel provided via configuration "
                         f"{mk_new_name} does not exist."
                     )

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -78,7 +78,10 @@ def run_pipeline(args: PipelineArgs) -> None:
     #     * Parse JSON into an object with attributes corresponding
     #       to dict keys.
     #
-    setup = Setup(args, __version__)
+    try:
+        setup = Setup(args, __version__)
+    except NPBError as exc:
+        handle_npb_error(str(exc))
 
     #
     # * Start the Log object
@@ -86,199 +89,410 @@ def run_pipeline(args: PipelineArgs) -> None:
     #      option is chosen.
     #    * The log file will be written in the working directory
     #
-    log = Log(setup, args)
+    try:
+        log = Log(setup, args)
 
-    #
-    # Indicate the Log object to start recording the output.
-    #
-    log.start()
+        #
+        # Indicate the Log object to start recording the output.
+        #
+        log.start()
 
-    #
-    # Add the log to the setup object with the sole purpose for the log
-    # to be accessible via setup to be able to write the product list file
-    # for an interrupted run.
-    #
-    setup.log = log
+        #
+        # Add the log to the setup object with the sole purpose for the log
+        # to be accessible via setup to be able to write the product list file
+        # for an interrupted run.
+        #
+        setup.log = log
 
-    #
-    # With the log started we check the current configuration
-    #
-    setup.check_configuration()
+        #
+        # With the log started we check the current configuration
+        #
+        setup.check_configuration()
 
-    #
-    # * Check the existence of a previous archive version.
-    #
-    log_step(setup, title='Setup the archive generation')
-    setup.set_release()
+        #
+        # * Check the existence of a previous archive version.
+        #
+        log_step(setup, title='Setup the archive generation')
+        setup.set_release()
 
-    #
-    # * If the pipeline is running to clean up a previous run, remove all the
-    #   files in the bundle and staging area indicated by the file list and
-    #   clean up the kernel list and log from the previous run.
-    #
-    if args.clear:
-        clear_run(setup)
+        #
+        # * If the pipeline is running to clean up a previous run, remove all the
+        #   files in the bundle and staging area indicated by the file list and
+        #   clean up the kernel list and log from the previous run.
+        #
+        if args.clear:
+            clear_run(setup)
 
-    #
-    #    * The pipeline can be stopped after cleaning up the previous run
-    #      by setting ``-f, --faucet`` to ``clear``.
-    #
-    if setup.faucet == "clear":
-        finish_execution(setup, log)
-        return
+        #
+        #    * The pipeline can be stopped after cleaning up the previous run
+        #      by setting ``-f, --faucet`` to ``clear``.
+        #
+        if setup.faucet == "clear":
+            finish_execution(setup, log)
+            return
 
-    #
-    # * Generate the Release Plan object.
-    # TODO: Should this one be renamed to 'Release Plan generation'?
-    log_step(setup, title='Kernel List generation')
-    release_plan = ReleasePlan(setup)
+        #
+        # * Generate the Release Plan object.
+        # TODO: Should this one be renamed to 'Release Plan generation'?
+        log_step(setup, title='Kernel List generation')
+        release_plan = ReleasePlan(setup)
 
-    #
-    #    * If a plan file is provided it is processed otherwise a plan is
-    #      generated from the kernels' directory.
-    #
-    #    * If NPB is run in label generation mode and no input products are
-    #      found, stop the execution.
-    #
-    if not args.kerlist:
-        if not args.plan or (".plan" not in args.plan):
+        #
+        #    * If a plan file is provided it is processed otherwise a plan is
+        #      generated from the kernels' directory.
+        #
+        #    * If NPB is run in label generation mode and no input products are
+        #      found, stop the execution.
+        #
+        if not args.kerlist:
+            if not args.plan or (".plan" not in args.plan):
 
-            # Stop the execution if we cannot write a release plan when we are
-            # running on "labels" mode.
-            if not release_plan.write_plan() and (args.faucet == "labels"):
-                return
+                # Stop the execution if we cannot write a release plan when we are
+                # running on "labels" mode.
+                if not release_plan.write_plan() and (args.faucet == "labels"):
+                    return
+            else:
+                release_plan.read_plan(Path(args.plan))
+
+        #
+        #    * The pipeline can be stopped after generating or reading the release
+        #      plan by setting ``-f, --faucet`` to ``plan``.
+        #
+        if setup.faucet == "plan":
+            finish_execution(setup, log)
+            return
+
+        #
+        # * Generate the Kernel List object.
+        #
+        #   If a release plan was either generated or loaded during the previous
+        #   step, load the obtained kernel_list into the KernelList object.
+        # TODO: Add kernel_list argument to the KernelList constructor.
+        # TODO: Remove this commented out code or uncomment it. The decision will
+        #       depend on whether we want to have a "step" for the generation of
+        #       the release plan or not.
+        # log_step(setup, title='Kernel List generation')
+        k_list = KernelList(setup)
+        k_list.kernel_list = release_plan.kernel_list
+
+        if not args.kerlist:
+            k_list.write_list()
         else:
-            release_plan.read_plan(Path(args.plan))
+            k_list.read_list(args.kerlist)
 
-    #
-    #    * The pipeline can be stopped after generating or reading the release
-    #      plan by setting ``-f, --faucet`` to ``plan``.
-    #
-    if setup.faucet == "plan":
-        finish_execution(setup, log)
-        return
-
-    #
-    # * Generate the Kernel List object.
-    #
-    #   If a release plan was either generated or loaded during the previous
-    #   step, load the obtained kernel_list into the KernelList object.
-    # TODO: Add kernel_list argument to the KernelList constructor.
-    # TODO: Remove this commented out code or uncomment it. The decision will
-    #       depend on whether we want to have a "step" for the generation of
-    #       the release plan or not.
-    # log_step(setup, title='Kernel List generation')
-    k_list = KernelList(setup)
-    k_list.kernel_list = release_plan.kernel_list
-
-    if not args.kerlist:
-        k_list.write_list()
-    else:
-        k_list.read_list(args.kerlist)
-
-    #
-    #    * The pipeline can be stopped after generating or reading the kernel
-    #      list plan by setting ``-f, --faucet`` to ``list``.
-    #
-    if setup.faucet == "list":
-        finish_execution(setup, log)
-        return
-
-    #
-    #    * Check the products present in the list (SPICE kernels and OrbNum
-    #      files)
-    log_step(setup, title='Check kernel list products')
-    k_list.check_products()
-
-    #
-    #    * The pipeline can be stopped after checking the kernel
-    #      list by setting ``-f, --faucet`` to ``checks``.
-    #
-    if setup.faucet == "checks":
-        finish_execution(setup, log)
-        return
-
-    #
-    # * Generate the PDS4 Bundle structure.
-    #
-    log_step(setup, title='Bundle/data set structure generation at staging area')
-    bundle = Bundle(setup)
-
-    #
-    # * Load LSK, FK and SCLK kernels for time conversions and coverage
-    #   computations.
-    #
-    log_step(setup, title='Load LSK, PCK, FK and SCLK kernels')
-    setup.load_kernels()
-
-    #
-    # * Initialize the SPICE Kernels Collection.
-    log_step(setup, title='SPICE kernel collection/data processing')
-    spice_kernels_collection = SpiceKernelsCollection(setup, bundle, k_list)
-
-    #
-    # * Initialize the Miscellaneous Collection.
-    #
-    miscellaneous_collection = MiscellaneousCollection(setup, bundle, k_list)
-
-    #
-    # * Generate the labels for each SPICE kernel or ORBNUM product and
-    #   populate the SPICE kernels collection or the Miscellaneous collection
-    #   accordingly.
-    #
-    for kernel in k_list.kernel_list:
         #
-        # * Each label is validated after generation.
+        #    * The pipeline can be stopped after generating or reading the kernel
+        #      list plan by setting ``-f, --faucet`` to ``list``.
         #
-        if (".nrb" in kernel.lower()) or (".orb" in kernel.lower()):
+        if setup.faucet == "list":
+            finish_execution(setup, log)
+            return
+
+        #
+        #    * Check the products present in the list (SPICE kernels and OrbNum
+        #      files)
+        log_step(setup, title='Check kernel list products')
+        k_list.check_products()
+
+        #
+        #    * The pipeline can be stopped after checking the kernel
+        #      list by setting ``-f, --faucet`` to ``checks``.
+        #
+        if setup.faucet == "checks":
+            finish_execution(setup, log)
+            return
+
+        #
+        # * Generate the PDS4 Bundle structure.
+        #
+        log_step(setup, title='Bundle/data set structure generation at staging area')
+        bundle = Bundle(setup)
+
+        #
+        # * Load LSK, FK and SCLK kernels for time conversions and coverage
+        #   computations.
+        #
+        log_step(setup, title='Load LSK, PCK, FK and SCLK kernels')
+        setup.load_kernels()
+
+        #
+        # * Initialize the SPICE Kernels Collection.
+        log_step(setup, title='SPICE kernel collection/data processing')
+        spice_kernels_collection = SpiceKernelsCollection(setup, bundle, k_list)
+
+        #
+        # * Initialize the Miscellaneous Collection.
+        #
+        miscellaneous_collection = MiscellaneousCollection(setup, bundle, k_list)
+
+        #
+        # * Generate the labels for each SPICE kernel or ORBNUM product and
+        #   populate the SPICE kernels collection or the Miscellaneous collection
+        #   accordingly.
+        #
+        for kernel in k_list.kernel_list:
             #
-            # The OrbnumFileProduct has to be provided the kernels collection
-            # because it might require to update the kernel list if the
-            # orbnum file name is updated.
+            # * Each label is validated after generation.
             #
-            try:
+            if (".nrb" in kernel.lower()) or (".orb" in kernel.lower()):
+                #
+                # The OrbnumFileProduct has to be provided the kernels collection
+                # because it might require to update the kernel list if the
+                # orbnum file name is updated.
+                #
                 miscellaneous_collection.add(
                     OrbnumFileProduct(
                         setup, kernel, miscellaneous_collection, spice_kernels_collection
                     )
                 )
-            except NPBError as exc:
-                handle_npb_error(str(exc), setup=setup)
-        elif ".tm" not in kernel.lower():
-            try:
+            elif ".tm" not in kernel.lower():
                 spice_kernels_collection.add(
                     SpiceKernelProduct(setup, kernel, spice_kernels_collection)
                 )
-            except NPBError as exc:
-                handle_npb_error(str(exc), setup=setup)
 
-    #
-    # * Generate the Meta-kernel(s).
-    #
-    log_step(setup, title='Generation of meta-kernel(s)')
-    meta_kernels = spice_kernels_collection.determine_meta_kernels()
-    if meta_kernels:
-        for mk in sorted(meta_kernels):
-            try:
+        #
+        # * Generate the Meta-kernel(s).
+        #
+        log_step(setup, title='Generation of meta-kernel(s)')
+        meta_kernels = spice_kernels_collection.determine_meta_kernels()
+        if meta_kernels:
+            for mk in sorted(meta_kernels):
                 meta_kernel = MetaKernelProduct(
                     setup, mk, spice_kernels_collection, user_input=meta_kernels[mk]
                 )
-            except NPBError as exc:
-                handle_npb_error(str(exc), setup=setup)
+                if setup.pds_version == "4":
+                    spice_kernels_collection.add(meta_kernel)
+                else:
+                    miscellaneous_collection.add(meta_kernel)
+
+        #
+        # * Faucet for labeling mode.
+        #
+        if args.faucet == "labels":
+
+            #
+            # * Add the SPICE Kernels Collection to the Bundle.
+            #
+            bundle.add(spice_kernels_collection)
+
+            #
+            # * List the files present in the staging area.
+            #
+            log_step(setup, title='Recap files in staging area')
+            bundle.files_in_staging()
+
+            #
+            # * Copy files to the bundle area.
+            #
+            log_step(setup, title='Copy files to the bundle area')
+            bundle.copy_to_bundle()
+
+            finish_execution(setup, log)
+            return
+
+        #
+        # * Determine the SPICE kernels Collection increment times and VID.
+        #
+        if setup.pds_version == "4":
+            log_step(setup, title='Determine archive increment start and finish times')
+            spice_kernels_collection.set_increment_times()
+            spice_kernels_collection.set_collection_vid()
+
+        #
+        # * Validate the SPICE Kernels collection:
+        #    * Note the validation of products is performed after writing the
+        #      product itself and, therefore, it is not explicitly executed
+        #      from at object initialization.
+        #    * Check if there is an XML label for each file under spice_kernels.
+        #
+        log_step(setup, title='Validate SPICE kernel collection generation')
+        spice_kernels_collection.validate()
+
+        #
+        # *  Generate the SPICE Kernels Collection Inventory product (if the
+        #    collection has been updated.)
+        #
+        if spice_kernels_collection.updated:
             if setup.pds_version == "4":
-                spice_kernels_collection.add(meta_kernel)
-            else:
-                miscellaneous_collection.add(meta_kernel)
+                spice_kernels_collection.set_collection_vid()
 
-    #
-    # * Faucet for labeling mode.
-    #
-    if args.faucet == "labels":
+            log_step(setup, title=f'Generation of {spice_kernels_collection.name} collection')
+            spice_kernels_collection_inventory = InventoryProduct(
+                setup, spice_kernels_collection
+            )
+            spice_kernels_collection.add(spice_kernels_collection_inventory)
 
-        #
-        # * Add the SPICE Kernels Collection to the Bundle.
-        #
-        bundle.add(spice_kernels_collection)
+        if setup.pds_version == "4":
+            #
+            # * Generate the Document Collection.
+            #
+            document_collection = DocumentCollection(setup, bundle)
+            document_collection.set_collection_vid()
+
+            #
+            # * Generate of SPICEDS document.
+            #
+            log_step(setup, title='Processing spiceds file')
+            spiceds = SpicedsProduct(setup, document_collection)
+
+            #
+            # * If the SPICEDS document is generated, generate the
+            #   Documents Collection Inventory.
+            #
+            if spiceds.generated:
+                document_collection.add(spiceds)
+
+                document_collection.set_collection_vid()
+
+                log_step(setup, title=f'Generation of {document_collection.name} collection')
+                document_collection_inventory = InventoryProduct(setup, document_collection)
+                document_collection.add(document_collection_inventory)
+
+            #
+            # * Add the SPICE Kernels Collection to the Bundle.
+            #   Note that the Collections are provided to the Bundle object
+            #   in a given order.
+            #
+            bundle.add(spice_kernels_collection)
+
+            #
+            # * Generate the Miscellaneous collection. The Checksum product
+            #   is initialized in such a way that its name can be obtained.
+            #
+            # * The first thing that is checked is whether if the current
+            #   Bundle has checksums, if not, all the checksums are generated,
+            #   including the corresponding Miscellaneous Collection Inventories
+            #   and labels.
+            #
+
+            # Report the Collection generation step.
+            log_step(setup, title=f'Generation of {miscellaneous_collection.kind} collection')
+
+            if setup.increment:
+                checksum_dir = (
+                    setup.bundle_directory
+                    + f"/{setup.mission_acronym}_spice/miscellaneous/checksum"
+                )
+                if not isdir(checksum_dir):
+                    for release in bundle.history.items():
+                        log_step(setup, title='Generate checksum file')
+                        release_checksum = ChecksumProduct(
+                            setup, miscellaneous_collection, add_previous_checksum=False
+                        )
+                        release_checksum.generate(history=release)
+
+                        #
+                        # Initialize a miscellaneous collection for this previous
+                        # release.
+                        #
+                        release_miscellaneous_collection = MiscellaneousCollection(
+                            setup, bundle, k_list
+                        )
+
+                        #
+                        # Add the checksum at the release miscellaneous collection
+                        # to generate the adequate inventory file and add it to
+                        # the current miscellaneous collection for it to be
+                        # present at the checksum.
+                        #
+                        release_miscellaneous_collection.add(release_checksum)
+
+                        miscellaneous_collection.add(release_checksum)
+
+                        release_miscellaneous_collection.set_collection_vid()
+
+                        # The release_miscellaneous_collection name is "miscellaneous"
+                        # (PDS4 branch), therefore, we do not log the step, as we do
+                        # every other time we generate an InventoryProduct.
+                        release_miscellaneous_collection_inventory = InventoryProduct(
+                            setup, release_miscellaneous_collection
+                        )
+
+                        release_miscellaneous_collection.add(
+                            release_miscellaneous_collection_inventory
+                        )
+                        miscellaneous_collection.add(
+                            release_miscellaneous_collection_inventory
+                        )
+
+                        #
+                        # Add release miscellaneous collection.
+                        #
+                        bundle.add(release_miscellaneous_collection)
+
+                #
+                # * Set the Miscellaneous collection VID.
+                #
+                miscellaneous_collection.set_collection_vid()
+
+            #
+            # * Add the Miscellaneous and Document Collections to the Bundle object.
+            #
+            bundle.add(miscellaneous_collection)
+            bundle.add(document_collection)
+
+            #
+            # * Generate Miscellaneous Collection and initialize the Checksum
+            #   product for the current release.
+            #    * The miscellaneous collection is the one to be guaranteed to be
+            #      updated.
+            #
+            log_step(setup, title='Generate checksum file')
+            checksum = ChecksumProduct(setup, miscellaneous_collection)
+
+            #
+            # Before adding the checksum to the current collection
+            # we need to specify that is not a new product.
+            #
+            for product in miscellaneous_collection.product:
+                if isinstance(product, ChecksumProduct):
+                    product.new_product = False
+
+            miscellaneous_collection.add(checksum)
+            miscellaneous_collection.set_collection_vid()
+
+            checksum.set_coverage()
+
+            # The miscellaneous_collection name is "miscellaneous" (PDS4 branch),
+            # therefore, we do not log the step, as we do every other time we
+            # generate an InventoryProduct.
+            miscellaneous_collection_inventory = InventoryProduct(
+                setup, miscellaneous_collection
+            )
+            miscellaneous_collection.add(miscellaneous_collection_inventory)
+
+            #
+            # * Generate the Bundle label and if necessary the readme file.
+            #
+            log_step(setup, title='Generation of bundle products')
+            bundle.readme = ReadmeProduct(setup, bundle)
+
+            #
+            # * Generate the Checksum product a posteriori in such a way
+            #   that the miscellaneous collection inventory includes the
+            #   checksum and the checksum includes the md5 hash of the
+            #   Miscellaneous Collection Inventory.
+            #
+            checksum.generate()
+            miscellaneous_collection.add(checksum)
+
+        else:  # if setup.pds_version == "3":
+
+            document_collection = DocumentCollection(setup, bundle)
+
+            log_step(setup, title='Generation of PDS3 products')
+            document_collection.get_pds3_documents()
+
+            bundle.add(spice_kernels_collection)
+            bundle.add(document_collection)
+            bundle.add(miscellaneous_collection)
+
+            log_step(setup, title='Generate checksum file')
+            checksum = ChecksumProduct(
+                setup, miscellaneous_collection, add_previous_checksum=False
+            )
+            checksum.generate()
+            miscellaneous_collection.add(checksum)
 
         #
         # * List the files present in the staging area.
@@ -287,311 +501,55 @@ def run_pipeline(args: PipelineArgs) -> None:
         bundle.files_in_staging()
 
         #
+        # * The pipeline can be stopped after generating the products and before
+        #   moving them to the ``bundle_directory`` by setting ``-f, --faucet``
+        #   to ``staging``.
+        #
+        if setup.faucet == "staging":
+            finish_execution(setup, log)
+            return
+
+        #
+        # Generate index files, this includes generating the complete
+        # kernel list.
+        #
+        # OnlyFor PDS3
+        # log_step(setup, title='Generation of complete kernel list')
+        # list.write_complete_list()
+        # spice_kernels_collection_inventory.write_index()
+
+        #
         # * Copy files to the bundle area.
         #
         log_step(setup, title='Copy files to the bundle area')
         bundle.copy_to_bundle()
 
-        finish_execution(setup, log)
-        return
+        #
+        # * The pipeline can be stopped after generating the moving the products
+        #   ``bundle_directory`` by setting ``-f, --faucet``. Ch
+        #   to ``bundle``.
+        #
+        if setup.faucet == "bundle":
+            finish_execution(setup, log)
+            return
 
-    #
-    # * Determine the SPICE kernels Collection increment times and VID.
-    #
-    if setup.pds_version == "4":
-        log_step(setup, title='Determine archive increment start and finish times')
-        spice_kernels_collection.set_increment_times()
-        spice_kernels_collection.set_collection_vid()
-
-    #
-    # * Validate the SPICE Kernels collection:
-    #    * Note the validation of products is performed after writing the
-    #      product itself and, therefore, it is not explicitly executed
-    #      from at object initialization.
-    #    * Check if there is an XML label for each file under spice_kernels.
-    #
-    log_step(setup, title='Validate SPICE kernel collection generation')
-    spice_kernels_collection.validate()
-
-    #
-    # *  Generate the SPICE Kernels Collection Inventory product (if the
-    #    collection has been updated.)
-    #
-    if spice_kernels_collection.updated:
+        #
+        # * Validate the Bundle by checking Checksum files against the updated
+        #   Bundle history and checking the bundle times.
+        #
         if setup.pds_version == "4":
-            spice_kernels_collection.set_collection_vid()
-
-        log_step(setup, title=f'Generation of {spice_kernels_collection.name} collection')
-        try:
-            spice_kernels_collection_inventory = InventoryProduct(
-                setup, spice_kernels_collection
-            )
-        except NPBError as exc:
-            handle_npb_error(str(exc), setup=setup)
-        spice_kernels_collection.add(spice_kernels_collection_inventory)
-
-    if setup.pds_version == "4":
-        #
-        # * Generate the Document Collection.
-        #
-        document_collection = DocumentCollection(setup, bundle)
-        document_collection.set_collection_vid()
+            log_step(setup, title='Validate bundle history with checksum files')
+            bundle.validate()
 
         #
-        # * Generate of SPICEDS document.
+        # * Validate Meta-kernel(s).
+        #   This is the last step since it unloads all kernels.
         #
-        log_step(setup, title='Processing spiceds file')
-        try:
-            spiceds = SpicedsProduct(setup, document_collection)
-        except NPBError as exc:
-            handle_npb_error(str(exc), setup=setup)
+        for kernel in spice_kernels_collection.product:
+            if isinstance(kernel, MetaKernelProduct):
+                log_step(setup, title=f'Meta-kernel {kernel.name} validation')
+                kernel.validate()
 
-        #
-        # * If the SPICEDS document is generated, generate the
-        #   Documents Collection Inventory.
-        #
-        if spiceds.generated:
-            document_collection.add(spiceds)
-
-            document_collection.set_collection_vid()
-
-            log_step(setup, title=f'Generation of {document_collection.name} collection')
-            try:
-                document_collection_inventory = InventoryProduct(setup, document_collection)
-            except NPBError as exc:
-                handle_npb_error(str(exc), setup=setup)
-            document_collection.add(document_collection_inventory)
-
-        #
-        # * Add the SPICE Kernels Collection to the Bundle.
-        #   Note that the Collections are provided to the Bundle object
-        #   in a given order.
-        #
-        bundle.add(spice_kernels_collection)
-
-        #
-        # * Generate the Miscellaneous collection. The Checksum product
-        #   is initialized in such a way that its name can be obtained.
-        #
-        # * The first thing that is checked is whether if the current
-        #   Bundle has checksums, if not, all the checksums are generated,
-        #   including the corresponding Miscellaneous Collection Inventories
-        #   and labels.
-        #
-
-        # Report the Collection generation step.
-        log_step(setup, title=f'Generation of {miscellaneous_collection.kind} collection')
-
-        if setup.increment:
-            checksum_dir = (
-                setup.bundle_directory
-                + f"/{setup.mission_acronym}_spice/miscellaneous/checksum"
-            )
-            if not isdir(checksum_dir):
-                for release in bundle.history.items():
-                    log_step(setup, title='Generate checksum file')
-                    try:
-                        release_checksum = ChecksumProduct(
-                            setup, miscellaneous_collection, add_previous_checksum=False
-                        )
-                    except NPBError as exc:
-                        handle_npb_error(str(exc), setup=setup)
-                    try:
-                        release_checksum.generate(history=release)
-                    except NPBError as exc:
-                        handle_npb_error(str(exc), setup=setup)
-
-                    #
-                    # Initialize a miscellaneous collection for this previous
-                    # release.
-                    #
-                    release_miscellaneous_collection = MiscellaneousCollection(
-                        setup, bundle, k_list
-                    )
-
-                    #
-                    # Add the checksum at the release miscellaneous collection
-                    # to generate the adequate inventory file and add it to
-                    # the current miscellaneous collection for it to be
-                    # present at the checksum.
-                    #
-                    release_miscellaneous_collection.add(release_checksum)
-
-                    miscellaneous_collection.add(release_checksum)
-
-                    release_miscellaneous_collection.set_collection_vid()
-
-                    # The release_miscellaneous_collection name is "miscellaneous"
-                    # (PDS4 branch), therefore, we do not log the step, as we do
-                    # every other time we generate an InventoryProduct.
-                    try:
-                        release_miscellaneous_collection_inventory = InventoryProduct(
-                            setup, release_miscellaneous_collection
-                        )
-                    except NPBError as exc:
-                        handle_npb_error(str(exc), setup=setup)
-
-                    release_miscellaneous_collection.add(
-                        release_miscellaneous_collection_inventory
-                    )
-                    miscellaneous_collection.add(
-                        release_miscellaneous_collection_inventory
-                    )
-
-                    #
-                    # Add release miscellaneous collection.
-                    #
-                    bundle.add(release_miscellaneous_collection)
-
-            #
-            # * Set the Miscellaneous collection VID.
-            #
-            miscellaneous_collection.set_collection_vid()
-
-        #
-        # * Add the Miscellaneous and Document Collections to the Bundle object.
-        #
-        bundle.add(miscellaneous_collection)
-        bundle.add(document_collection)
-
-        #
-        # * Generate Miscellaneous Collection and initialize the Checksum
-        #   product for the current release.
-        #    * The miscellaneous collection is the one to be guaranteed to be
-        #      updated.
-        #
-        log_step(setup, title='Generate checksum file')
-        try:
-            checksum = ChecksumProduct(setup, miscellaneous_collection)
-        except NPBError as exc:
-            handle_npb_error(str(exc), setup=setup)
-
-        #
-        # Before adding the checksum to the current collection
-        # we need to specify that is not a new product.
-        #
-        for product in miscellaneous_collection.product:
-            if isinstance(product, ChecksumProduct):
-                product.new_product = False
-
-        miscellaneous_collection.add(checksum)
-        miscellaneous_collection.set_collection_vid()
-
-        try:
-            checksum.set_coverage()
-        except NPBError as exc:
-            handle_npb_error(str(exc), setup=setup)
-
-        # The miscellaneous_collection name is "miscellaneous" (PDS4 branch),
-        # therefore, we do not log the step, as we do every other time we
-        # generate an InventoryProduct.
-        try:
-            miscellaneous_collection_inventory = InventoryProduct(
-                setup, miscellaneous_collection
-            )
-        except NPBError as exc:
-            handle_npb_error(str(exc), setup=setup)
-        miscellaneous_collection.add(miscellaneous_collection_inventory)
-
-        #
-        # * Generate the Bundle label and if necessary the readme file.
-        #
-        log_step(setup, title='Generation of bundle products')
-        try:
-            bundle.readme = ReadmeProduct(setup, bundle)
-        except NPBError as exc:
-            handle_npb_error(str(exc), setup=setup)
-
-        #
-        # * Generate the Checksum product a posteriori in such a way
-        #   that the miscellaneous collection inventory includes the
-        #   checksum and the checksum includes the md5 hash of the
-        #   Miscellaneous Collection Inventory.
-        #
-        try:
-            checksum.generate()
-        except NPBError as exc:
-            handle_npb_error(str(exc), setup=setup)
-        miscellaneous_collection.add(checksum)
-
-    else:  # if setup.pds_version == "3":
-
-        document_collection = DocumentCollection(setup, bundle)
-
-        log_step(setup, title='Generation of PDS3 products')
-        document_collection.get_pds3_documents()
-
-        bundle.add(spice_kernels_collection)
-        bundle.add(document_collection)
-        bundle.add(miscellaneous_collection)
-
-        log_step(setup, title='Generate checksum file')
-        try:
-            checksum = ChecksumProduct(
-                setup, miscellaneous_collection, add_previous_checksum=False
-            )
-        except NPBError as exc:
-            handle_npb_error(str(exc), setup=setup)
-        try:
-            checksum.generate()
-        except NPBError as exc:
-            handle_npb_error(str(exc), setup=setup)
-        miscellaneous_collection.add(checksum)
-
-    #
-    # * List the files present in the staging area.
-    #
-    log_step(setup, title='Recap files in staging area')
-    bundle.files_in_staging()
-
-    #
-    # * The pipeline can be stopped after generating the products and before
-    #   moving them to the ``bundle_directory`` by setting ``-f, --faucet``
-    #   to ``staging``.
-    #
-    if setup.faucet == "staging":
         finish_execution(setup, log)
-        return
-
-    #
-    # Generate index files, this includes generating the complete
-    # kernel list.
-    #
-    # OnlyFor PDS3
-    # log_step(setup, title='Generation of complete kernel list')
-    # list.write_complete_list()
-    # spice_kernels_collection_inventory.write_index()
-
-    #
-    # * Copy files to the bundle area.
-    #
-    log_step(setup, title='Copy files to the bundle area')
-    bundle.copy_to_bundle()
-
-    #
-    # * The pipeline can be stopped after generating the moving the products
-    #   ``bundle_directory`` by setting ``-f, --faucet``. Ch
-    #   to ``bundle``.
-    #
-    if setup.faucet == "bundle":
-        finish_execution(setup, log)
-        return
-
-    #
-    # * Validate the Bundle by checking Checksum files against the updated
-    #   Bundle history and checking the bundle times.
-    #
-    if setup.pds_version == "4":
-        log_step(setup, title='Validate bundle history with checksum files')
-        bundle.validate()
-
-    #
-    # * Validate Meta-kernel(s).
-    #   This is the last step since it unloads all kernels.
-    #
-    for kernel in spice_kernels_collection.product:
-        if isinstance(kernel, MetaKernelProduct):
-            log_step(setup, title=f'Meta-kernel {kernel.name} validation')
-            kernel.validate()
-
-    finish_execution(setup, log)
+    except NPBError as exc:
+        handle_npb_error(str(exc), setup=setup)

--- a/tests/npb/test_classes_plan.py
+++ b/tests/npb/test_classes_plan.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from pds.naif_pds4_bundler.classes.exceptions import NPBError
 from pds.naif_pds4_bundler.classes.plan import ReleasePlan
 
 
@@ -43,8 +44,8 @@ def test_read_plan_non_plan_extension_outside_labeling_mode_raises(tmp_path):
     setup = make_setup(tmp_path)
     rp = make_release_plan(setup)
 
-    with pytest.raises(RuntimeError, match=r'Release plan requires \*\.plan extension. '
-                                           'Single kernels are only allowed in labeling mode.'):
+    with pytest.raises(NPBError, match=r'Release plan requires \*\.plan extension. '
+                                       'Single kernels are only allowed in labeling mode.'):
         rp.read_plan(kernel_file)
 
 
@@ -68,8 +69,8 @@ def test_read_plan_txt_extension_outside_labeling_mode_raises(tmp_path):
     bad_file.write_text("maven_sc_rec_200101_200201_v01.bsp\n")
     rp = make_release_plan(setup)
 
-    with pytest.raises(RuntimeError, match=r'Release plan requires \*\.plan extension. '
-                                           'Single kernels are only allowed in labeling mode.'):
+    with pytest.raises(NPBError, match=r'Release plan requires \*\.plan extension. '
+                                       'Single kernels are only allowed in labeling mode.'):
         rp.read_plan(bad_file)
 
 # ---------------------------------------------------------------------------
@@ -712,8 +713,8 @@ def test_write_plan_missing_mk_raises_error(tmp_path):
     )
     rp = make_release_plan(setup)
 
-    with pytest.raises(RuntimeError, match="Meta-kernel provided via configuration "
-                                           "nonexistent.tm does not exist."):
+    with pytest.raises(NPBError, match="Meta-kernel provided via configuration "
+                                       "nonexistent.tm does not exist."):
         rp.write_plan()
 
 

--- a/tests/npb/test_pipeline_npb.py
+++ b/tests/npb/test_pipeline_npb.py
@@ -1069,7 +1069,9 @@ class TestNPBErrorHandling:
     # entirely since no setup instance exists yet. Each parametrized case
     # below forces one Block-B call site to raise NPBError and asserts both
     # that cleanup ran and that the RuntimeError carries the original
-    # message; the dedicated test below covers Block A's no-setup case.
+    # message. Two call sites need their own dedicated test instead of a
+    # table row: ReleasePlan.read_plan() (only reached with a non-default
+    # `args.plan`) and Setup() construction (Block A's no-setup case).
 
     @staticmethod
     def _apply_overrides(mocks, overrides):
@@ -1167,6 +1169,14 @@ class TestNPBErrorHandling:
             'ChecksumProduct.return_value.generate', 'boom checksum pds3 generate',
             id='pds3_checksum_generate',
         ),
+        # ReleasePlan.write_plan() is called with the default args (no
+        # kerlist, no .plan file), so it needs no extra overrides to be
+        # reached -- unlike read_plan(), which needs args.plan set to a
+        # .plan path and is covered separately below.
+        pytest.param(
+            {}, 'ReleasePlan.return_value.write_plan', 'boom write_plan',
+            id='release_plan_write_plan',
+        ),
     ])
     def test_npb_error_is_routed_to_handle_npb_error(self, mocks, overrides, target_attr, message):
         self._apply_overrides(mocks, overrides)
@@ -1174,6 +1184,21 @@ class TestNPBErrorHandling:
         args = _args()
 
         with pytest.raises(RuntimeError, match=message):
+            run_pipeline(args)
+
+        setup = mocks.Setup.return_value
+        setup.write_file_list.assert_called_once()
+        setup.write_checksum_registry.assert_called_once()
+
+    def test_npb_error_from_release_plan_read_plan_is_routed_to_handle_npb_error(self, mocks):
+        # read_plan() is only reached when args.plan is set to a .plan path
+        # (kerlist absent), so it can't be folded into the parametrize table
+        # above, which relies on the default args() reaching write_plan()
+        # instead.
+        mocks.ReleasePlan.return_value.read_plan.side_effect = NPBError('boom read_plan')
+        args = _args(plan='mission_release_01.plan')
+
+        with pytest.raises(RuntimeError, match='boom read_plan'):
             run_pipeline(args)
 
         setup = mocks.Setup.return_value

--- a/tests/npb/test_pipeline_npb.py
+++ b/tests/npb/test_pipeline_npb.py
@@ -1059,13 +1059,17 @@ class TestPhase12FinalValidation:
 # ---------------------------------------------------------------------------
 
 class TestNPBErrorHandling:
-    # Every direct product-construction call in run_pipeline is wrapped in a
-    # try/except that catches NPBError and forwards it to the *real*
-    # handle_npb_error (not mocked here), which performs cleanup -- writes the
-    # file list and checksum registry, removes template files, clears the SPICE
-    # kernel pool -- and then always raises RuntimeError with the same message.
-    # Each case forces one construction call to raise NPBError and asserts both
-    # that cleanup ran and that the RuntimeError carries the original message.
+    # run_pipeline wraps its body in two broad try/except blocks: Block A
+    # around Setup() construction alone, Block B around everything from
+    # Log() construction to the end. Both catch NPBError and forward it to
+    # the *real* handle_npb_error (not mocked here). Block B's handler
+    # performs cleanup -- writes the file list and checksum registry, removes
+    # template files, clears the SPICE kernel pool -- and then always raises
+    # RuntimeError with the same message; Block A's handler skips cleanup
+    # entirely since no setup instance exists yet. Each parametrized case
+    # below forces one Block-B call site to raise NPBError and asserts both
+    # that cleanup ran and that the RuntimeError carries the original
+    # message; the dedicated test below covers Block A's no-setup case.
 
     @staticmethod
     def _apply_overrides(mocks, overrides):
@@ -1175,3 +1179,19 @@ class TestNPBErrorHandling:
         setup = mocks.Setup.return_value
         setup.write_file_list.assert_called_once()
         setup.write_checksum_registry.assert_called_once()
+
+    def test_npb_error_from_setup_construction_is_routed_without_setup(self, mocks):
+        # Setup() itself failing is a special case (Block A): there is no
+        # setup instance yet, so handle_npb_error is called with no `setup`
+        # kwarg and no cleanup (write_file_list/write_checksum_registry) is
+        # attempted. Log must never be constructed either, since it depends
+        # on a successfully-built setup.
+        mocks.Setup.side_effect = NPBError('boom setup')
+        args = _args()
+
+        with pytest.raises(RuntimeError, match='boom setup'):
+            run_pipeline(args)
+
+        mocks.Log.assert_not_called()
+        mocks.Setup.return_value.write_file_list.assert_not_called()
+        mocks.Setup.return_value.write_checksum_registry.assert_not_called()


### PR DESCRIPTION
## 🗒️ Summary
Replaces the 16 per-site `try/except NPBError` wrappers added in #293 with two broad blocks in `run_pipeline`: Block A around `Setup()` construction alone (no `setup` available for cleanup), and Block B around everything from
`Log()` construction to the end (full cleanup via `handle_npb_error(str(exc), setup=setup)`). Also migrates `plan.py`'s two
`handle_npb_error` call sites to `raise NPBError(...)`.

## ⚙️ Test Data and/or Report
Regression tests included: existing `test_pipeline_npb.py` /`test_classes_plan.py` suites, plus a new test covering Block A (`Setup()` raising `NPBError`), which had no prior coverage.

    pytest tests/npb/test_pipeline_npb.py tests/npb/test_classes_plan.py -v --cov-branch
    171 passed, 4 skipped

    Name                                          Stmts   Miss Branch BrPart  Cover
    -------------------------------------------------------------------------------
    src/pds/naif_pds4_bundler/classes/plan.py       137      0     74      0   100%
    src/pds/naif_pds4_bundler/pipeline/npb.py       175      0     62      0   100%

    Full merge-gate suite (pytest tests/npb/ -v --cov-branch):
    1814 passed, 7 skipped, 1 xfailed

Manual verification:
* `grep -c "except NPBError" src/pds/naif_pds4_bundler/pipeline/npb.py` → `2`
* `grep -n "handle_npb_error\|from.*pipeline.runtime" src/pds/naif_pds4_bundler/classes/plan.py` → no output

## ♻️ Related Issues
Fixes #312
