### PR TITLE
Migrate label module (pds4_label.py, pds3_spice_kernel.py) to raise NPBError

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/label/pds3_spice_kernel.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds3_spice_kernel.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import spiceypy
 
 from .pds3_label import PDS3Label
-from ...pipeline.runtime import handle_npb_error
+from ..exceptions import NPBError
 from ...utils import (
     ck_coverage,
     extract_comment,
@@ -170,7 +170,7 @@ class SpiceKernelPDS3Label(PDS3Label):
             if "KPL/" in kernel_lines[0]:
                 kernel.write(kernel_lines[0])
             else:
-                handle_npb_error(
+                raise NPBError(
                     f"Kernel {self.product.name} does not have "
                     f"architecture spec as first line."
                 )

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_label.py
@@ -3,7 +3,7 @@
 from typing import Optional, Tuple
 
 from .label import PDSLabel
-from ...pipeline.runtime import handle_npb_error
+from ..exceptions import NPBError
 
 
 class PDS4Label(PDSLabel):
@@ -80,9 +80,8 @@ class PDS4Label(PDSLabel):
         elif setup.end_of_line == "LF":
             self.END_OF_LINE = "Line-Feed"
         else:
-            handle_npb_error(
-                "End of Line provided via configuration is not CRLF nor LF.",
-                setup=self.setup,
+            raise NPBError(
+                "End of Line provided via configuration is not CRLF nor LF."
             )
 
         self.BUNDLE_DESCRIPTION_LID = f"{setup.logical_identifier}:document:spiceds"
@@ -180,9 +179,8 @@ class PDS4Label(PDSLabel):
                 )
 
                 if not mission_lid:
-                    handle_npb_error(
-                        f"LID has not been obtained for mission {mis}.",
-                        setup=self.setup,
+                    raise NPBError(
+                        f"LID has not been obtained for mission {mis}."
                     )
 
                 mis_list_for_label += self._render_context_entry(
@@ -190,9 +188,7 @@ class PDS4Label(PDSLabel):
                     mis, mission_type, mission_lid, self._mission_reference_type,
                 )
         if not mis_list_for_label:
-            handle_npb_error(
-                f"{self.product.name} missions not defined.", setup=self.setup
-            )
+            raise NPBError(f"{self.product.name} missions not defined.")
 
         # Strip trailing whitespace from the last rendered entry, then
         # append exactly one EOL.
@@ -218,9 +214,8 @@ class PDS4Label(PDSLabel):
                 )
 
                 if not ob_lid:
-                    handle_npb_error(
-                        f"LID has not been obtained for observer {ob}.",
-                        setup=self.setup,
+                    raise NPBError(
+                        f"LID has not been obtained for observer {ob}."
                     )
 
                 obs_list_for_label += self._render_context_entry(
@@ -229,9 +224,7 @@ class PDS4Label(PDSLabel):
                 )
 
         if not obs_list_for_label:
-            handle_npb_error(
-                f"{self.product.name} observers not defined.", setup=self.setup
-            )
+            raise NPBError(f"{self.product.name} observers not defined.")
 
         # Strip trailing whitespace from the last rendered entry, then
         # append exactly one EOL.
@@ -274,7 +267,7 @@ class PDS4Label(PDSLabel):
                 )
 
         if not tar_list_for_label:
-            handle_npb_error(f"{self.product.name} targets not defined.", setup=self.setup)
+            raise NPBError(f"{self.product.name} targets not defined.")
 
         # Strip trailing whitespace from the last rendered entry, then
         # append exactly one EOL.

--- a/src/pds/naif_pds4_bundler/classes/label/pds4_label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/pds4_label.py
@@ -252,7 +252,7 @@ class PDS4Label(PDSLabel):
                     target_name, case_insensitive=True
                 )
                 # TODO: BUG, unlike get_missions/get_observers above, no
-                #       handle_npb_error is raised here when target_lid is
+                #       NPBError is raised here when target_lid is
                 #       None (no context product matched). lid/type instead
                 #       fall through as the literal string "None" into the
                 #       rendered label. Pre-existing behaviour, preserved by

--- a/tests/npb/test_classes_label_pds3_spice_kernel.py
+++ b/tests/npb/test_classes_label_pds3_spice_kernel.py
@@ -397,7 +397,7 @@ class TestSpiceKernelPDS3LabelInsertTextLabel:
         assert len(kernel_opens) >= 1
 
     def test_raises_on_missing_kpl_header(self, text_label):
-        """handle_npb_error is called when the kernel lacks a KPL/ first line."""
+        """NPBError is raised when the kernel lacks a KPL/ first line."""
         bad_kernel = "NOT_KPL\nsome data\n"
 
         with patch("builtins.open", side_effect=_open_factory(kernel_data=bad_kernel)):

--- a/tests/npb/test_classes_label_pds3_spice_kernel.py
+++ b/tests/npb/test_classes_label_pds3_spice_kernel.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
+from pds.naif_pds4_bundler.classes.exceptions import NPBError
 from pds.naif_pds4_bundler.classes.label.pds3_spice_kernel import SpiceKernelPDS3Label
 
 # ---------------------------------------------------------------------------
@@ -401,7 +402,7 @@ class TestSpiceKernelPDS3LabelInsertTextLabel:
         bad_kernel = "NOT_KPL\nsome data\n"
 
         with patch("builtins.open", side_effect=_open_factory(kernel_data=bad_kernel)):
-            with pytest.raises(RuntimeError, match='architecture spec as first line.'):
+            with pytest.raises(NPBError, match='architecture spec as first line.'):
                 text_label.insert_text_label()
 
     @pytest.mark.parametrize("kernel_data, expected, logs", [

--- a/tests/npb/test_classes_label_pds4.py
+++ b/tests/npb/test_classes_label_pds4.py
@@ -120,8 +120,8 @@ class TestPDS4LabelInit:
     def test_pds4_end_of_line_invalid(self, label_test_helpers, product):
         """end_of_line is invalid (neither CRLF nor LF)"""
         setup = label_test_helpers.make_setup_pds4(end_of_line="CR")
-        with pytest.raises(RuntimeError, match=r'End of Line provided via configuration '
-                                               r'is not CRLF nor LF\.'):
+        with pytest.raises(NPBError, match=r'End of Line provided via configuration '
+                                            r'is not CRLF nor LF\.'):
             PDS4Label(setup, product)
 
     # TODO: The following two test cases demonstrate an issue:

--- a/tests/npb/test_classes_label_pds4.py
+++ b/tests/npb/test_classes_label_pds4.py
@@ -16,10 +16,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from pds.naif_pds4_bundler.classes.exceptions import NPBError
 from pds.naif_pds4_bundler.classes.label.pds4_label import PDS4Label
-
-# Patch target — resolved to where the name is looked up inside pds4_label.py
-_PATCH_HANDLE_ERROR = "pds.naif_pds4_bundler.classes.label.pds4_label.handle_npb_error"
 
 
 # ---------------------------------------------------------------------------
@@ -352,11 +350,10 @@ class TestPDS4LabelGetMissions:
         result = label.get_missions()
         assert result == expected
 
-    def test_empty_mission_name_skipped_calls_error(self, label_for, mocker):
+    def test_empty_mission_name_skipped_calls_error(self, label_for):
         """A falsy mission entry (empty string) must be skipped."""
-        mock_err = mocker.patch(_PATCH_HANDLE_ERROR)
-        label_for([""]).get_missions()
-        mock_err.assert_called()
+        with pytest.raises(NPBError, match="missions not defined"):
+            label_for([""]).get_missions()
 
     def test_other_investigation_type_accepted(self, label_for):
         ctx = [
@@ -376,8 +373,8 @@ class TestPDS4LabelGetMissions:
                           '      </Internal_Reference>\r\n'
                           '    </Investigation_Area>\r\n')
 
-    def test_no_lid_found_calls_handle_npb_error(self, label_for, mocker):
-        """No context product matches → mission_lid never set → handle_npb_error."""
+    def test_no_lid_found_raises_npberror(self, label_for):
+        """No context product matches → mission_lid never set → NPBError."""
         ctx = [
             {
                 "name": ["Different"],
@@ -385,9 +382,8 @@ class TestPDS4LabelGetMissions:
                 "lidvid": "urn:nasa:pds:different::1.0",
             }
         ]
-        mock_err = mocker.patch(_PATCH_HANDLE_ERROR)
-        label_for(["TestMission"], context_products=ctx).get_missions()
-        mock_err.assert_called()
+        with pytest.raises(NPBError, match="LID has not been obtained for mission"):
+            label_for(["TestMission"], context_products=ctx).get_missions()
 
 
 # ===========================================================================
@@ -445,16 +441,14 @@ class TestPDS4LabelGetObservers:
         ctx = [{"name": ["TestObserver"], "type": ["Spacecraft"], "lidvid": "urn:x::1.0"}]
         assert "TestObserver" in label_for(["TestObserver, extra"], ctx).get_observers()
 
-    def test_empty_observer_skipped_calls_error(self, label_for, mocker):
-        mock_err = mocker.patch(_PATCH_HANDLE_ERROR)
-        label_for([""]).get_observers()
-        mock_err.assert_called()
+    def test_empty_observer_skipped_calls_error(self, label_for):
+        with pytest.raises(NPBError, match="observers not defined"):
+            label_for([""]).get_observers()
 
-    def test_no_lid_calls_handle_npb_error(self, label_for, mocker):
+    def test_no_lid_raises_npberror(self, label_for):
         ctx = [{"name": ["NoMatch"], "type": ["Spacecraft"], "lidvid": "urn:x::1.0"}]
-        mock_err = mocker.patch(_PATCH_HANDLE_ERROR)
-        label_for(["TestObserver"], ctx).get_observers()
-        mock_err.assert_called()
+        with pytest.raises(NPBError, match="LID has not been obtained for observer"):
+            label_for(["TestObserver"], ctx).get_observers()
 
     def test_trailing_eol_appended(self, label_for):
         assert label_for(["TestObserver"]).get_observers().endswith("\r\n")
@@ -502,24 +496,22 @@ class TestPDS4LabelGetTargets:
         ctx = [{"name": ["TESTTARGET"], "type": ["planet"], "lidvid": "urn:x::1.0"}]
         assert "testtarget" in label_for(["testtarget"], ctx).get_targets()
 
-    def test_no_match_renders_none_without_raising(self, label_for, mocker):
+    def test_no_match_renders_none_without_raising(self, label_for):
         """Characterizes a known gap (tracked separately, not fixed here):
         unlike get_missions/get_observers, a target with no matching
-        context product does not call handle_npb_error — lid/type fall
+        context product does not raise NPBError — lid/type fall
         through as the literal string "None" instead. This pins the
         current behavior, so it can't change silently; it is not an
-        endorsement of it."""
-        mock_err = mocker.patch(_PATCH_HANDLE_ERROR)
+        endorsement of it. No exception is raised, which is itself the
+        thing being characterized."""
         ctx = [{"name": ["Different"], "type": ["Target"], "lidvid": "urn:x:different::1.0"}]
         result = label_for(["TestTarget"], ctx).get_targets()
-        mock_err.assert_not_called()
         assert "<lid_reference>None</lid_reference>" in result
         assert "<type>None</type>" in result
 
-    def test_empty_target_skipped_calls_error(self, label_for, mocker):
-        mock_err = mocker.patch(_PATCH_HANDLE_ERROR)
-        label_for([""]).get_targets()
-        mock_err.assert_called()
+    def test_empty_target_skipped_calls_error(self, label_for):
+        with pytest.raises(NPBError, match="targets not defined"):
+            label_for([""]).get_targets()
 
     def test_trailing_eol_appended(self, label_for):
         assert label_for(["TestTarget"]).get_targets().endswith("\r\n")

--- a/tests/npb/test_classes_label_pds4.py
+++ b/tests/npb/test_classes_label_pds4.py
@@ -352,8 +352,9 @@ class TestPDS4LabelGetMissions:
 
     def test_empty_mission_name_skipped_calls_error(self, label_for):
         """A falsy mission entry (empty string) must be skipped."""
+        label = label_for([""])
         with pytest.raises(NPBError, match="missions not defined"):
-            label_for([""]).get_missions()
+            label.get_missions()
 
     def test_other_investigation_type_accepted(self, label_for):
         ctx = [
@@ -382,8 +383,9 @@ class TestPDS4LabelGetMissions:
                 "lidvid": "urn:nasa:pds:different::1.0",
             }
         ]
+        label = label_for(["TestMission"], context_products=ctx)
         with pytest.raises(NPBError, match="LID has not been obtained for mission"):
-            label_for(["TestMission"], context_products=ctx).get_missions()
+            label.get_missions()
 
 
 # ===========================================================================
@@ -442,13 +444,15 @@ class TestPDS4LabelGetObservers:
         assert "TestObserver" in label_for(["TestObserver, extra"], ctx).get_observers()
 
     def test_empty_observer_skipped_calls_error(self, label_for):
+        label = label_for([""])
         with pytest.raises(NPBError, match="observers not defined"):
-            label_for([""]).get_observers()
+            label.get_observers()
 
     def test_no_lid_raises_npberror(self, label_for):
         ctx = [{"name": ["NoMatch"], "type": ["Spacecraft"], "lidvid": "urn:x::1.0"}]
+        label = label_for(["TestObserver"], ctx)
         with pytest.raises(NPBError, match="LID has not been obtained for observer"):
-            label_for(["TestObserver"], ctx).get_observers()
+            label.get_observers()
 
     def test_trailing_eol_appended(self, label_for):
         assert label_for(["TestObserver"]).get_observers().endswith("\r\n")
@@ -510,8 +514,9 @@ class TestPDS4LabelGetTargets:
         assert "<type>None</type>" in result
 
     def test_empty_target_skipped_calls_error(self, label_for):
+        label = label_for([""])
         with pytest.raises(NPBError, match="targets not defined"):
-            label_for([""]).get_targets()
+            label.get_targets()
 
     def test_trailing_eol_appended(self, label_for):
         assert label_for(["TestTarget"]).get_targets().endswith("\r\n")


### PR DESCRIPTION
## 🗒️ Summary
Converts `classes/label/pds4_label.py` and `classes/label/pds3_spice_kernel.py` to raise `NPBError` instead of calling `handle_npb_error` directly from `pipeline.runtime`, completing the label-module portion of the `handle_npb_error` → `NPBError` migration. Also updates `tests/npb/test_classes_label_pds4.py` (6 tests that previously mocked `handle_npb_error`) and fixes two stale docstring/comment references left over from the source change.

## ⚙️ Test Data and/or Report
Regression tests included: existing `test_classes_label_pds4.py` / `test_classes_label_pds3_spice_kernel.py` suites, rewritten to assert `pytest.raises(NPBError, ...)` in place of the old `handle_npb_error` mocks.

    pytest tests/npb/test_classes_label_pds4.py tests/npb/test_classes_label_pds3_spice_kernel.py -v --cov-branch
    93 passed

    Name                                                           Stmts   Miss Branch BrPart  Cover
    ------------------------------------------------------------------------------------------------
    src/pds/naif_pds4_bundler/classes/label/pds4_label.py            107      0     54      0   100%
    src/pds/naif_pds4_bundler/classes/label/pds3_spice_kernel.py     142      0     74      0   100%

    Full merge-gate suite (pytest tests/npb/ -v --cov-branch):
    1823 passed, 7 skipped, 1 xfailed

Manual verification:
* `grep -rn "handle_npb_error\|from.*pipeline.runtime" src/pds/naif_pds4_bundler/classes/label/pds4_label.py src/pds/naif_pds4_bundler/classes/label/pds3_spice_kernel.py` → no output

## ♻️ Related Issues
Fixes #317
