### PR TITLE
updated code to skip validation for ten files

### DIFF
--- a/src/pds/naif_pds4_bundler/utils/files.py
+++ b/src/pds/naif_pds4_bundler/utils/files.py
@@ -993,16 +993,17 @@ def check_kernel_integrity(path):
     # Filter out Text EKs since they are not loaded into SPICE and validate them
     # differently
     if extension == "ten":
+        # Try to read the file as UTF-8
         try:
             with open(path, 'r', encoding='utf-8') as f:
                 content = f.read(2000)
-            if '\\header' not in content or '\\text' not in content:
-                return (f"Kernel {name} does not contain required text event "
-                        f"kernel markers (\\header, \\text).")
         except UnicodeDecodeError:
             return f"Kernel {name} is not a valid text file (encoding error)."
-        except Exception as e:
-            return f"Kernel {name} could not be read: {e}."
+
+        # Validate content after successful read
+        if '\\header' not in content or '\\text' not in content:
+            return (f"Kernel {name} does not contain required text event "
+                    f"kernel markers (\\header, \\text).")
 
         return ""  # Valid .ten file
 

--- a/src/pds/naif_pds4_bundler/utils/files.py
+++ b/src/pds/naif_pds4_bundler/utils/files.py
@@ -974,9 +974,9 @@ def check_kernel_integrity(path):
 
     Text kernels must have ``KPL`` (Kernel Pool File) architecture.
 
-    **Note:** Text event kernels (``.ten``) are not validated by
-    this function as they use a different format and are not loaded via
-    standard SPICE routines.
+    **Note:** Text event kernels (``.ten``) are validated differently
+    because they use a different format than other text kernels and are not
+    loaded via standard SPICE routines.
 
     NPB checks if binary kernels have a ``DAF`` architecture and text kernels
     a ``KPL`` architecture.
@@ -990,9 +990,21 @@ def check_kernel_integrity(path):
     name = path.split(os.sep)[-1].strip()
     extension = path.split(".")[-1].strip().lower()
 
-    # Filter out Text EKs since they are not loaded into SPICE
-    if extension in "ten":
-        return ""  # No validation needed for .ten - not loadable in SPICE
+    # Filter out Text EKs since they are not loaded into SPICE and validate them
+    # differently
+    if extension == "ten":
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                content = f.read(2000)
+            if '\\header' not in content or '\\text' not in content:
+                return (f"Kernel {name} does not contain required text event "
+                        f"kernel markers (\\header, \\text).")
+        except UnicodeDecodeError:
+            return f"Kernel {name} is not a valid text file (encoding error)."
+        except Exception as e:
+            return f"Kernel {name} could not be read: {e}."
+
+        return ""  # Valid .ten file
 
     type_file = extension_to_type(name).upper()
 

--- a/src/pds/naif_pds4_bundler/utils/files.py
+++ b/src/pds/naif_pds4_bundler/utils/files.py
@@ -124,7 +124,6 @@ def extension_to_type(kernel):
         "TLS": "LSK",
         "TPC": "PCK",
         "TEN": "EK",
-        "TEP": "EK",
         "BC": "CK",
         "BSP": "SPK",
         "BPC": "PCK",
@@ -229,7 +228,7 @@ def type_to_extension(kernel_type):
         "CK": ["bc"],
         "SPK": ["bsp"],
         "DSK": ["bds"],
-        "EK": ["bes", "bpe", "bep", "bdb", "ten", "tep"],
+        "EK": ["bes", "bpe", "bep", "bdb", "ten"],
         "ORB": ["nrb","orb"],
     }
 
@@ -975,6 +974,10 @@ def check_kernel_integrity(path):
 
     Text kernels must have ``KPL`` (Kernel Pool File) architecture.
 
+    **Note:** Text event kernels (``.ten``) are not validated by
+    this function as they use a different format and are not loaded via
+    standard SPICE routines.
+
     NPB checks if binary kernels have a ``DAF`` architecture and text kernels
     a ``KPL`` architecture.
 
@@ -985,16 +988,19 @@ def check_kernel_integrity(path):
     """
     error = ""
     name = path.split(os.sep)[-1].strip()
-    extension = path.split(".")[-1].strip()
+    extension = path.split(".")[-1].strip().lower()
+
+    # Filter out Text EKs since they are not loaded into SPICE
+    if extension in "ten":
+        return ""  # No validation needed for .ten - not loadable in SPICE
+
     type_file = extension_to_type(name).upper()
 
     #
     # Determine if it is a binary or a text kernel.
     #
-    if extension[0].lower() == "b":
-        file_format = "Binary"
-    else:
-        file_format = "Character"
+
+    file_format = "Binary" if extension[0] == "b" else "Character"
 
     #
     # All files that are to have labels generated must have a NAIF
@@ -1016,8 +1022,8 @@ def check_kernel_integrity(path):
         #
         if arch not in ('DAF', 'DAS'):
             error = f"Kernel {name} architecture {arch} is invalid."
-        else:
-            pass
+        # else:
+        #     pass
 
     else:  # file_format == "Character":
 

--- a/tests/npb/test_utils_files.py
+++ b/tests/npb/test_utils_files.py
@@ -358,11 +358,58 @@ def test_check_kernel_integrity_text_kernel(tmp_path):
     error = files.check_kernel_integrity(str(kernel_path))
     assert error
 
-    #subcase 6: ten file - not loadable in SPICE
-    ten_path = tmp_path / "test.ten"
-    ten_path.write_text("\\header\nAUTHOR = Test\n\\text\nTest content\n")
-    error = files.check_kernel_integrity(str(ten_path))
-    assert not error
+    #subcase 6: Text event kernel missing both markers should fail.
+    ten_file = tmp_path / "missing_markers.ten"
+    ten_file.write_text("This is just plain text with no event kernel markers\n")
+
+    error = files.check_kernel_integrity(str(ten_file))
+    assert error != ""
+    assert "does not contain required" in error
+    assert "\\header" in error
+    assert "\\text" in error
+
+    #subcase 6a: Text event kernel missing \\header marker should fail.
+    ten_file = tmp_path / "missing_header.ten"
+    ten_file.write_text("\\text\nSome event data\n")
+
+    error = files.check_kernel_integrity(str(ten_file))
+    assert error != ""
+    assert "does not contain required" in error
+
+    #subcase 6b: Text event kernel missing \\text marker should fail.
+    ten_file = tmp_path / "missing_text.ten"
+    ten_file.write_text("\\header\nSome header data\n")
+
+    error = files.check_kernel_integrity(str(ten_file))
+    assert error != ""
+    assert "does not contain required" in error
+
+def test_check_kernel_integrity_text_event_kernel(tmp_path, monkeypatch):
+    """Comprehensive test ensuring all exceptions are exercised for text EKs (.ten)."""
+    ten_file = tmp_path / "coverage.ten"
+
+    # Test 1: Normal operation (no exception)
+    ten_file.write_text("\\header\n\\text\n")
+    error = files.check_kernel_integrity(str(ten_file))
+    assert error == ""  # Success path
+
+    # Test 2: UnicodeDecodeError path
+    with open(ten_file, 'wb') as f:
+        f.write(b"\xff\xfe")
+    error = files.check_kernel_integrity(str(ten_file))
+    assert "encoding error" in error  # UnicodeDecodeError path
+
+    # Test 3: Generic Exception path
+    original_open = open
+
+    def mock_open_generic(*args, **kwargs):
+        if str(ten_file) in str(args[0]):
+            raise Exception("Generic exception path")
+        return original_open(*args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", mock_open_generic)
+    error = files.check_kernel_integrity(str(ten_file))
+    assert "could not be read" in error  # Generic Exception path
 
 # ----------------------------------------------------------------------------
 # files.check_kernel_integrity tests

--- a/tests/npb/test_utils_files.py
+++ b/tests/npb/test_utils_files.py
@@ -358,6 +358,12 @@ def test_check_kernel_integrity_text_kernel(tmp_path):
     error = files.check_kernel_integrity(str(kernel_path))
     assert error
 
+    #subcase 6: ten file - not loadable in SPICE
+    ten_path = tmp_path / "test.ten"
+    ten_path.write_text("\\header\nAUTHOR = Test\n\\text\nTest content\n")
+    error = files.check_kernel_integrity(str(ten_path))
+    assert not error
+
 # ----------------------------------------------------------------------------
 # files.check_kernel_integrity tests
 # ----------------------------------------------------------------------------
@@ -1450,7 +1456,7 @@ def test_string_in_file(kern, str_to_check, reps, expected):
     ("CK", ['bc']),
     ("SPK", ['bsp']),
     ("DSK", ['bds']),
-    ("EK", ['bes','bpe', 'bep', 'bdb', 'ten', 'tep']),
+    ("EK", ['bes','bpe', 'bep', 'bdb', 'ten']),
     ("ORB", ['nrb', 'orb']),
 ])
 def test_type_to_extension(inputs, outputs):
@@ -1470,7 +1476,6 @@ def test_type_to_extension(inputs, outputs):
     ("eros_n2000129x_v01.bpe", "ek"),
     ("S99_CIMSSSUPa.bep", "ek"),
     ("m01_mmdmt_ext10.ten", "ek"),
-    ("fakey.tep", "ek"),
     ("m2020_chronos_v01.tm", "mk"),
 ])
 def test_type_to_extension_object(kern, expected):

--- a/tests/npb/test_utils_files.py
+++ b/tests/npb/test_utils_files.py
@@ -399,18 +399,6 @@ def test_check_kernel_integrity_text_event_kernel(tmp_path, monkeypatch):
     error = files.check_kernel_integrity(str(ten_file))
     assert "encoding error" in error  # UnicodeDecodeError path
 
-    # Test 3: Generic Exception path
-    original_open = open
-
-    def mock_open_generic(*args, **kwargs):
-        if str(ten_file) in str(args[0]):
-            raise Exception("Generic exception path")
-        return original_open(*args, **kwargs)
-
-    monkeypatch.setattr("builtins.open", mock_open_generic)
-    error = files.check_kernel_integrity(str(ten_file))
-    assert "could not be read" in error  # Generic Exception path
-
 # ----------------------------------------------------------------------------
 # files.check_kernel_integrity tests
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## 🗒️ Summary
removed tep (not used in any archive) and removed validation for .ten extension text files only. 
.ten files are not loaded into SPICE and do have valid text kernel formatting. When they are included in an EK directory they are used for general context and documentation. 

## ⚙️ Test Data and/or Report
updated test_utils_files.py accordingly 

## ♻️ Related Issues
fixes #311 

