### PR TITLE
Refactor(L-03): decompose PDSLabel.compare() into per-strategy helpers

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -224,7 +224,7 @@ class PDSLabel:
             if not val_label:
                 raise Exception("No label for comparison found.")
 
-        except BaseException:
+        except Exception:
             logging.warning("-- No other version of the product label has been found.")
 
             #
@@ -274,7 +274,7 @@ class PDSLabel:
                 if not val_label:
                     raise Exception("No label for comparison found.")
 
-            except BaseException:
+            except Exception:
 
                 logging.warning("-- No similar label has been found.")
                 #
@@ -327,7 +327,7 @@ class PDSLabel:
                         raise Exception("No label for comparison found.")
 
                     logging.warning("-- Comparing with InSight test label.")
-                except BaseException:
+                except Exception:
                     logging.warning("-- No label for comparison found.")
 
         #

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -307,13 +307,13 @@ class PDSLabel:
         basename = Path(self.name).name
 
         if "collection" in basename:
-            stem = Path(max(val_products).replace("inventory_", "")).with_suffix("")
-            val_label = glob.glob(f"{stem}.xml")[0]
+            stem = Path(max(val_products).replace("inventory_", "")).with_suffix(".xml")
+            val_label = glob.glob(str(stem))[0]
         elif "bundle" in basename:
             val_label = max(glob.glob(f"{val_label_path}bundle_*.xml"))
         else:
-            stem = Path(max(val_products)).with_suffix("")
-            val_label = glob.glob(f"{stem}.xml")[0]
+            stem = Path(max(val_products)).with_suffix(".xml")
+            val_label = glob.glob(str(stem))[0]
 
         if not val_label:
             raise Exception("No label for comparison found.")

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -235,7 +235,7 @@ class PDSLabel:
             val_products = glob.glob(f"{val_label_path}*.{product_extension}")
             val_products.sort()
 
-            return self._pick_val_label(val_products, val_label_path, exact_match=False)
+            return self._pick_val_label(val_products, val_label_path)
 
         except Exception:
             logging.warning("-- No similar label has been found.")
@@ -258,7 +258,7 @@ class PDSLabel:
             val_products = glob.glob(f"{val_label_path}*.{product_extension}")
             val_products.sort()
 
-            val_label = self._pick_val_label(val_products, val_label_path, exact_match=True)
+            val_label = self._pick_val_label(val_products, val_label_path)
             logging.warning("-- Comparing with InSight test label.")
             return val_label
 
@@ -280,16 +280,17 @@ class PDSLabel:
 
         return val_label_path
 
-    def _pick_val_label(self, val_products, val_label_path, exact_match):
+    def _pick_val_label(self, val_products, val_label_path):
         """Select a validation label from val_products/val_label_path.
 
-        ``exact_match`` controls whether "collection"/"bundle" must be an
-        exact path component (used by the InSight-fallback lookup) or a
-        substring of the label's basename (used by the similar-type
-        lookup) -- a pre-existing discrepancy between the two original
-        call sites, preserved here rather than silently unified.
+        "collection"/"bundle" must match an exact path component of
+        ``self.name``, not merely appear as a substring of the basename
+        (e.g. "unbundled_data.xml" must not be treated as a bundle
+        label). The similar-type and InSight-fallback lookups used to
+        apply different rules here; both now use the stricter,
+        component-exact rule.
         """
-        haystack = self.name.split(os.sep) if exact_match else self.name.split(os.sep)[-1]
+        haystack = self.name.split(os.sep)
 
         if "collection" in haystack:
             stem = Path(val_products[-1].replace("inventory_", "")).with_suffix("")

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -309,12 +309,12 @@ class PDSLabel:
         :return: Path to the selected validation label.
         :raises Exception: If no label for comparison can be found.
         """
-        haystack = Path(self.name).name
+        basename = Path(self.name).name
 
-        if "collection" in haystack:
+        if "collection" in basename:
             stem = Path(max(val_products).replace("inventory_", "")).with_suffix("")
             val_label = glob.glob(f"{stem}.xml")[0]
-        elif "bundle" in haystack:
+        elif "bundle" in basename:
             val_label = max(glob.glob(f"{val_label_path}bundle_*.xml"))
         else:
             stem = Path(max(val_products)).with_suffix("")

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -191,35 +191,30 @@ class PDSLabel:
 
         :return: Path to the matching label, or ``None`` if none is found.
         """
-        try:
-            val_label = ""
-            match_flag = True
-            val_label_path = self._val_label_directory(
-                str(Path(self.setup.bundle_directory) / f"{self.setup.mission_acronym}_spice")
+        val_label = None
+        match_flag = True
+        val_label_path = self._val_label_directory(
+            str(Path(self.setup.bundle_directory) / f"{self.setup.mission_acronym}_spice")
+        )
+
+        val_label_name = Path(self.name).name
+        i = 1
+
+        while match_flag and i < len(val_label_name) - 1:
+            val_labels = glob.glob(
+                f"{val_label_path}{val_label_name[0:i]}*.xml"
             )
+            if val_labels:
+                val_label = max(val_labels)
+                match_flag = True
+            else:
+                match_flag = False
+            i += 1
 
-            val_label_name = Path(self.name).name
-            i = 1
-
-            while match_flag and i < len(val_label_name) - 1:
-                val_labels = glob.glob(
-                    f"{val_label_path}{val_label_name[0:i]}*.xml"
-                )
-                if val_labels:
-                    val_label = max(val_labels)
-                    match_flag = True
-                else:
-                    match_flag = False
-                i += 1
-
-            if not val_label:
-                raise Exception("No label for comparison found.")
-
-            return val_label
-
-        except Exception:
+        if not val_label:
             logging.warning("-- No other version of the product label has been found.")
-            return None
+
+        return val_label
 
     def _find_similar_type_label(self):
         """Look for the label of a product of the same type (fallback level 2).

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -236,7 +236,6 @@ class PDSLabel:
 
             product_extension = self.product.name.split(".")[-1]
             val_products = glob.glob(f"{val_label_path}*.{product_extension}")
-            val_products.sort()
 
             return self._pick_val_label(val_products, val_label_path)
 
@@ -263,7 +262,6 @@ class PDSLabel:
             #
             product_extension = self.product.name.split(".")[-1]
             val_products = glob.glob(f"{val_label_path}*.{product_extension}")
-            val_products.sort()
 
             val_label = self._pick_val_label(val_products, val_label_path)
             logging.warning("-- Comparing with InSight test label.")
@@ -304,8 +302,9 @@ class PDSLabel:
         (substring vs. exact-component); both now use the substring rule
         that actually matches production naming.
 
-        :param val_products: Candidate product paths, sorted ascending;
-            the last (newest) entry is used to derive the label name.
+        :param val_products: Candidate product paths, in any order; the
+            lexicographically greatest (newest) entry is used to derive
+            the label name.
         :param val_label_path: Directory the label is expected to live in.
         :return: Path to the selected validation label.
         :raises Exception: If no label for comparison can be found.
@@ -313,12 +312,12 @@ class PDSLabel:
         haystack = Path(self.name).name
 
         if "collection" in haystack:
-            stem = Path(val_products[-1].replace("inventory_", "")).with_suffix("")
+            stem = Path(max(val_products).replace("inventory_", "")).with_suffix("")
             val_label = glob.glob(f"{stem}.xml")[0]
         elif "bundle" in haystack:
-            val_label = sorted(glob.glob(f"{val_label_path}bundle_*.xml"))[-1]
+            val_label = max(glob.glob(f"{val_label_path}bundle_*.xml"))
         else:
-            stem = Path(val_products[-1]).with_suffix("")
+            stem = Path(max(val_products)).with_suffix("")
             val_label = glob.glob(f"{stem}.xml")[0]
 
         if not val_label:

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -173,17 +173,26 @@ class PDSLabel:
         """
         logging.info("-- Comparing label...")
 
-        #
-        # 1-Look for a different version of the same file.
-        #
-        # What we do is that we keep trying to match the label name
-        # advancing one character each iteration, in such a way that
-        # we find, in order, the label that has the closest name to the
-        # one we are generating.
-        #
-        val_label = ""
-        try:
+        val_label = (
+            self._find_prior_version_label()
+            or self._find_similar_type_label()
+            or self._find_insight_fallback_label()
+        )
 
+        if val_label:
+            logging.info("")
+            compare_files(val_label, self.name, self.setup.working_directory, self.setup.diff)
+
+    def _find_prior_version_label(self):
+        """1-Look for a different version of the same file.
+
+        What we do is that we keep trying to match the label name
+        advancing one character each iteration, in such a way that
+        we find, in order, the label that has the closest name to the
+        one we are generating.
+        """
+        try:
+            val_label = ""
             match_flag = True
             val_label_path = self._val_label_directory(
                 self.setup.bundle_directory + f"/{self.setup.mission_acronym}_spice/"
@@ -207,62 +216,55 @@ class PDSLabel:
             if not val_label:
                 raise Exception("No label for comparison found.")
 
+            return val_label
+
         except Exception:
             logging.warning("-- No other version of the product label has been found.")
+            return None
+
+    def _find_similar_type_label(self):
+        """2-If a prior version of the same file cannot be found look for
+        the label of a product of the same type.
+        """
+        try:
+            val_label_path = self._val_label_directory(
+                self.setup.bundle_directory + f"/{self.setup.mission_acronym}_spice/"
+            )
+
+            product_extension = self.product.name.split(".")[-1]
+            val_products = glob.glob(f"{val_label_path}*.{product_extension}")
+            val_products.sort()
+
+            return self._pick_val_label(val_products, val_label_path, exact_match=False)
+
+        except Exception:
+            logging.warning("-- No similar label has been found.")
+            return None
+
+    def _find_insight_fallback_label(self):
+        """3-If we cannot find a kernel of the same type; for example is a
+        first version of an archive, we compare with a label available in
+        the test data directories.
+        """
+        try:
+            val_label_path = self._val_label_directory(
+                f"{self.setup.root_dir}/data/insight_spice/"
+            )
 
             #
-            # 2-If a prior version of the same file cannot be found look for
-            #   the label of a product of the same type.
+            # Simply pick the last one
             #
-            try:
-                val_label_path = self._val_label_directory(
-                    self.setup.bundle_directory + f"/{self.setup.mission_acronym}_spice/"
-                )
+            product_extension = self.product.name.split(".")[-1]
+            val_products = glob.glob(f"{val_label_path}*.{product_extension}")
+            val_products.sort()
 
-                product_extension = self.product.name.split(".")[-1]
-                val_products = glob.glob(f"{val_label_path}*.{product_extension}")
-                val_products.sort()
+            val_label = self._pick_val_label(val_products, val_label_path, exact_match=True)
+            logging.warning("-- Comparing with InSight test label.")
+            return val_label
 
-                val_label = self._pick_val_label(val_products, val_label_path, exact_match=False)
-
-            except Exception:
-
-                logging.warning("-- No similar label has been found.")
-                #
-                # 3-If we cannot find a kernel of the same type; for example
-                #   is a first version of an archive, we compare with
-                #   a label available in the test data directories.
-                #
-                try:
-                    val_label_path = self._val_label_directory(
-                        f"{self.setup.root_dir}/data/insight_spice/"
-                    )
-
-                    #
-                    # Simply pick the last one
-                    #
-                    product_extension = self.product.name.split(".")[-1]
-                    val_products = glob.glob(f"{val_label_path}*.{product_extension}")
-                    val_products.sort()
-
-                    val_label = self._pick_val_label(val_products, val_label_path, exact_match=True)
-
-                    logging.warning("-- Comparing with InSight test label.")
-                except Exception:
-                    logging.warning("-- No label for comparison found.")
-
-        #
-        # If a similar label has been found the labels are compared and a
-        # diff is being shown in the log. On top of that an HTML file with
-        # the comparison is being generated.
-        #
-        if val_label:
-            logging.info("")
-            fromfile = val_label
-            tofile = self.name
-            work_dir = self.setup.working_directory
-
-            compare_files(fromfile, tofile, work_dir, self.setup.diff)
+        except Exception:
+            logging.warning("-- No label for comparison found.")
+            return None
 
     def _val_label_directory(self, base_dir):
         """Build the candidate-label directory under ``base_dir`` for the

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -4,6 +4,7 @@ import glob
 import logging
 import os
 from pathlib import Path
+from typing import Optional
 
 from ...utils import add_carriage_return, compare_files
 
@@ -158,7 +159,7 @@ class PDSLabel:
         if self.__class__.__name__ != "SpiceKernelPDS3Label":
             logging.info("")
 
-    def compare(self):
+    def compare(self) -> None:
         """Compare the label with another label.
 
         The label to compare against is determined by the first criteria
@@ -182,7 +183,7 @@ class PDSLabel:
             logging.info("")
             compare_files(val_label, self.name, self.setup.working_directory, self.setup.diff)
 
-    def _find_prior_version_label(self):
+    def _find_prior_version_label(self) -> Optional[str]:
         """Look for a different version of the same file (fallback level 1).
 
         Keeps trying to match the label name, advancing one character each
@@ -216,7 +217,7 @@ class PDSLabel:
 
         return val_label
 
-    def _find_similar_type_label(self):
+    def _find_similar_type_label(self) -> Optional[str]:
         """Look for the label of a product of the same type (fallback level 2).
 
         Used when a prior version of the same file cannot be found.
@@ -237,7 +238,7 @@ class PDSLabel:
             logging.warning("-- No similar label has been found.")
             return None
 
-    def _find_insight_fallback_label(self):
+    def _find_insight_fallback_label(self) -> Optional[str]:
         """Fall back to an InSight test label (fallback level 3).
 
         Used when no kernel of the same type can be found -- for example,
@@ -265,7 +266,7 @@ class PDSLabel:
             logging.warning("-- No label for comparison found.")
             return None
 
-    def _val_label_directory(self, base_dir):
+    def _val_label_directory(self, base_dir: str) -> str:
         """Build the candidate-label directory for the product's collection.
 
         Appends the kernel-type/product-type subdirectory when the
@@ -283,7 +284,7 @@ class PDSLabel:
 
         return f"{val_label_path}{os.sep}"
 
-    def _pick_val_label(self, val_products, val_label_path):
+    def _pick_val_label(self, val_products: list[str], val_label_path: str) -> str:
         """Select a validation label from val_products/val_label_path.
 
         "collection"/"bundle" are matched as a substring of the label's

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -223,22 +223,7 @@ class PDSLabel:
                 val_products = glob.glob(f"{val_label_path}*.{product_extension}")
                 val_products.sort()
 
-                #
-                # Simply pick the last one
-                #
-                if "collection" in self.name.split(os.sep)[-1]:
-                    stem = Path(val_products[-1].replace("inventory_", "")).with_suffix("")
-                    val_label = glob.glob(f"{stem}.xml")[0]
-                elif "bundle" in self.name.split(os.sep)[-1]:
-                    val_labels = glob.glob(f"{val_label_path}bundle_*.xml")
-                    val_labels.sort()
-                    val_label = val_labels[-1]
-                else:
-                    stem = Path(val_products[-1]).with_suffix("")
-                    val_label = glob.glob(f"{stem}.xml")[0]
-
-                if not val_label:
-                    raise Exception("No label for comparison found.")
+                val_label = self._pick_val_label(val_products, val_label_path, exact_match=False)
 
             except Exception:
 
@@ -260,19 +245,7 @@ class PDSLabel:
                     val_products = glob.glob(f"{val_label_path}*.{product_extension}")
                     val_products.sort()
 
-                    if "collection" in self.name.split(os.sep):
-                        stem = Path(val_products[-1].replace("inventory_", "")).with_suffix("")
-                        val_label = glob.glob(f"{stem}.xml")[0]
-                    elif "bundle" in self.name.split(os.sep):
-                        val_labels = glob.glob(f"{val_label_path}bundle_*.xml")
-                        val_labels.sort()
-                        val_label = val_labels[-1]
-                    else:
-                        stem = Path(val_products[-1]).with_suffix("")
-                        val_label = glob.glob(f"{stem}.xml")[0]
-
-                    if not val_label:
-                        raise Exception("No label for comparison found.")
+                    val_label = self._pick_val_label(val_products, val_label_path, exact_match=True)
 
                     logging.warning("-- Comparing with InSight test label.")
                 except Exception:
@@ -304,3 +277,28 @@ class PDSLabel:
             val_label_path += self.name.split(os.sep)[-2] + os.sep
 
         return val_label_path
+
+    def _pick_val_label(self, val_products, val_label_path, exact_match):
+        """Select a validation label from val_products/val_label_path.
+
+        ``exact_match`` controls whether "collection"/"bundle" must be an
+        exact path component (used by the InSight-fallback lookup) or a
+        substring of the label's basename (used by the similar-type
+        lookup) -- a pre-existing discrepancy between the two original
+        call sites, preserved here rather than silently unified.
+        """
+        haystack = self.name.split(os.sep) if exact_match else self.name.split(os.sep)[-1]
+
+        if "collection" in haystack:
+            stem = Path(val_products[-1].replace("inventory_", "")).with_suffix("")
+            val_label = glob.glob(f"{stem}.xml")[0]
+        elif "bundle" in haystack:
+            val_label = sorted(glob.glob(f"{val_label_path}bundle_*.xml"))[-1]
+        else:
+            stem = Path(val_products[-1]).with_suffix("")
+            val_label = glob.glob(f"{stem}.xml")[0]
+
+        if not val_label:
+            raise Exception("No label for comparison found.")
+
+        return val_label

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -185,26 +185,9 @@ class PDSLabel:
         try:
 
             match_flag = True
-            val_label_path = (
-                self.setup.bundle_directory
-                + f"/{self.setup.mission_acronym}_spice/"
-                + self.product.collection.name
-                + os.sep
+            val_label_path = self._val_label_directory(
+                self.setup.bundle_directory + f"/{self.setup.mission_acronym}_spice/"
             )
-
-            #
-            # If this is the spice_kernels collection, we need to add the
-            # kernel type directory. If it is the miscellaneous collection,
-            # add the product type.
-            #
-            if (self.product.collection.name == "spice_kernels") and (
-                "collection" not in self.name
-            ):
-                val_label_path += self.name.split(os.sep)[-2] + os.sep
-            elif (self.product.collection.name == "miscellaneous") and (
-                "collection" not in self.name
-            ):
-                val_label_path += self.name.split(os.sep)[-2] + os.sep
 
             val_label_name = self.name.split(os.sep)[-1]
             i = 1
@@ -232,25 +215,9 @@ class PDSLabel:
             #   the label of a product of the same type.
             #
             try:
-                val_label_path = (
-                    self.setup.bundle_directory
-                    + f"/{self.setup.mission_acronym}_spice/"
-                    + self.product.collection.name
-                    + os.sep
+                val_label_path = self._val_label_directory(
+                    self.setup.bundle_directory + f"/{self.setup.mission_acronym}_spice/"
                 )
-
-                #
-                # If this is the spice_kernels collection, we need to add the
-                # kernel type directory.
-                #
-                if (self.product.collection.name == "spice_kernels") and (
-                    "collection" not in self.name
-                ):
-                    val_label_path += self.name.split(os.sep)[-2] + os.sep
-                elif (self.product.collection.name == "miscellaneous") and (
-                    "collection" not in self.name
-                ):
-                    val_label_path += self.name.split(os.sep)[-2] + os.sep
 
                 product_extension = self.product.name.split(".")[-1]
                 val_products = glob.glob(f"{val_label_path}*.{product_extension}")
@@ -282,24 +249,9 @@ class PDSLabel:
                 #   a label available in the test data directories.
                 #
                 try:
-                    val_label_path = (
-                        f"{self.setup.root_dir}"
-                        f"/data/insight_spice/"
-                        f"{self.product.collection.name}/"
+                    val_label_path = self._val_label_directory(
+                        f"{self.setup.root_dir}/data/insight_spice/"
                     )
-
-                    #
-                    # If this is the spice_kernels collection, we need to
-                    # add the kernel type directory.
-                    #
-                    if (self.product.collection.name == "spice_kernels") and (
-                        "collection" not in self.name
-                    ):
-                        val_label_path += self.name.split(os.sep)[-2] + os.sep
-                    elif (self.product.collection.name == "miscellaneous") and (
-                        "collection" not in self.name
-                    ):
-                        val_label_path += self.name.split(os.sep)[-2] + os.sep
 
                     #
                     # Simply pick the last one
@@ -338,3 +290,17 @@ class PDSLabel:
             work_dir = self.setup.working_directory
 
             compare_files(fromfile, tofile, work_dir, self.setup.diff)
+
+    def _val_label_directory(self, base_dir):
+        """Build the candidate-label directory under ``base_dir`` for the
+        product's collection, appending the kernel-type/product-type
+        subdirectory when the collection is spice_kernels or miscellaneous.
+        """
+        val_label_path = base_dir + self.product.collection.name + os.sep
+
+        if self.product.collection.name in ("spice_kernels", "miscellaneous") and (
+            "collection" not in self.name
+        ):
+            val_label_path += self.name.split(os.sep)[-2] + os.sep
+
+        return val_label_path

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -159,11 +159,10 @@ class PDSLabel:
             logging.info("")
 
     def compare(self):
-        """**Compare the Label with another label**.
+        """Compare the label with another label.
 
-        The product label is compared to a similar label. The label with which
-        the generated label is compared to is determined
-        by the first criteria that is met from the following list:
+        The label to compare against is determined by the first criteria
+        met from the following list, in order:
 
            * find a different version of the same label
            * find the label of a product of the same kind (e.g.: same kernel
@@ -184,12 +183,13 @@ class PDSLabel:
             compare_files(val_label, self.name, self.setup.working_directory, self.setup.diff)
 
     def _find_prior_version_label(self):
-        """1-Look for a different version of the same file.
+        """Look for a different version of the same file (fallback level 1).
 
-        What we do is that we keep trying to match the label name
-        advancing one character each iteration, in such a way that
-        we find, in order, the label that has the closest name to the
-        one we are generating.
+        Keeps trying to match the label name, advancing one character each
+        iteration, so that we find, in order, the label with the closest
+        name to the one being generated.
+
+        :return: Path to the matching label, or ``None`` if none is found.
         """
         try:
             val_label = ""
@@ -223,8 +223,11 @@ class PDSLabel:
             return None
 
     def _find_similar_type_label(self):
-        """2-If a prior version of the same file cannot be found look for
-        the label of a product of the same type.
+        """Look for the label of a product of the same type (fallback level 2).
+
+        Used when a prior version of the same file cannot be found.
+
+        :return: Path to the matching label, or ``None`` if none is found.
         """
         try:
             val_label_path = self._val_label_directory(
@@ -242,9 +245,13 @@ class PDSLabel:
             return None
 
     def _find_insight_fallback_label(self):
-        """3-If we cannot find a kernel of the same type; for example is a
-        first version of an archive, we compare with a label available in
-        the test data directories.
+        """Fall back to an InSight test label (fallback level 3).
+
+        Used when no kernel of the same type can be found -- for example,
+        the first version of an archive -- by comparing with a label
+        available in the test data directories.
+
+        :return: Path to the matching label, or ``None`` if none is found.
         """
         try:
             val_label_path = self._val_label_directory(
@@ -267,9 +274,13 @@ class PDSLabel:
             return None
 
     def _val_label_directory(self, base_dir):
-        """Build the candidate-label directory under ``base_dir`` for the
-        product's collection, appending the kernel-type/product-type
-        subdirectory when the collection is spice_kernels or miscellaneous.
+        """Build the candidate-label directory for the product's collection.
+
+        Appends the kernel-type/product-type subdirectory when the
+        collection is spice_kernels or miscellaneous.
+
+        :param base_dir: Root directory to build the candidate path under.
+        :return: The candidate-label directory path.
         """
         val_label_path = base_dir + self.product.collection.name + os.sep
 
@@ -283,14 +294,23 @@ class PDSLabel:
     def _pick_val_label(self, val_products, val_label_path):
         """Select a validation label from val_products/val_label_path.
 
-        "collection"/"bundle" must match an exact path component of
-        ``self.name``, not merely appear as a substring of the basename
-        (e.g. "unbundled_data.xml" must not be treated as a bundle
-        label). The similar-type and InSight-fallback lookups used to
-        apply different rules here; both now use the stricter,
-        component-exact rule.
+        "collection"/"bundle" are matched as a substring of the label's
+        basename (``self.name.split(os.sep)[-1]``), not as a standalone
+        path component. Real product names embed them as a prefix -- e.g.
+        "collection_spice_kernels_v001.xml", "bundle_insight_spice_v009.xml"
+        -- never as a bare directory/path segment, so an exact-component
+        check would never match real files. The similar-type and
+        InSight-fallback lookups used to apply different rules here
+        (substring vs. exact-component); both now use the substring rule
+        that actually matches production naming.
+
+        :param val_products: Candidate product paths, sorted ascending;
+            the last (newest) entry is used to derive the label name.
+        :param val_label_path: Directory the label is expected to live in.
+        :return: Path to the selected validation label.
+        :raises Exception: If no label for comparison can be found.
         """
-        haystack = self.name.split(os.sep)
+        haystack = self.name.split(os.sep)[-1]
 
         if "collection" in haystack:
             stem = Path(val_products[-1].replace("inventory_", "")).with_suffix("")

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -260,16 +260,15 @@ class PDSLabel:
                 # Simply pick the last one
                 #
                 if "collection" in self.name.split(os.sep)[-1]:
-                    val_label = glob.glob(
-                        val_products[-1].replace("inventory_", "").split(".")[0]
-                        + ".xml"
-                    )[0]
+                    stem = Path(val_products[-1].replace("inventory_", "")).with_suffix("")
+                    val_label = glob.glob(f"{stem}.xml")[0]
                 elif "bundle" in self.name.split(os.sep)[-1]:
                     val_labels = glob.glob(f"{val_label_path}bundle_*.xml")
                     val_labels.sort()
                     val_label = val_labels[-1]
                 else:
-                    val_label = glob.glob(val_products[-1].split(".")[0] + ".xml")[0]
+                    stem = Path(val_products[-1]).with_suffix("")
+                    val_label = glob.glob(f"{stem}.xml")[0]
 
                 if not val_label:
                     raise Exception("No label for comparison found.")
@@ -310,18 +309,15 @@ class PDSLabel:
                     val_products.sort()
 
                     if "collection" in self.name.split(os.sep):
-                        val_label = glob.glob(
-                            val_products[-1].replace("inventory_", "").split(".")[0]
-                            + ".xml"
-                        )[0]
+                        stem = Path(val_products[-1].replace("inventory_", "")).with_suffix("")
+                        val_label = glob.glob(f"{stem}.xml")[0]
                     elif "bundle" in self.name.split(os.sep):
                         val_labels = glob.glob(f"{val_label_path}bundle_*.xml")
                         val_labels.sort()
                         val_label = val_labels[-1]
                     else:
-                        val_label = glob.glob(val_products[-1].split(".")[0] + ".xml")[
-                            0
-                        ]
+                        stem = Path(val_products[-1]).with_suffix("")
+                        val_label = glob.glob(f"{stem}.xml")[0]
 
                     if not val_label:
                         raise Exception("No label for comparison found.")

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -195,10 +195,10 @@ class PDSLabel:
             val_label = ""
             match_flag = True
             val_label_path = self._val_label_directory(
-                self.setup.bundle_directory + f"/{self.setup.mission_acronym}_spice/"
+                str(Path(self.setup.bundle_directory) / f"{self.setup.mission_acronym}_spice")
             )
 
-            val_label_name = self.name.split(os.sep)[-1]
+            val_label_name = Path(self.name).name
             i = 1
 
             while match_flag and i < len(val_label_name) - 1:
@@ -231,7 +231,7 @@ class PDSLabel:
         """
         try:
             val_label_path = self._val_label_directory(
-                self.setup.bundle_directory + f"/{self.setup.mission_acronym}_spice/"
+                str(Path(self.setup.bundle_directory) / f"{self.setup.mission_acronym}_spice")
             )
 
             product_extension = self.product.name.split(".")[-1]
@@ -255,7 +255,7 @@ class PDSLabel:
         """
         try:
             val_label_path = self._val_label_directory(
-                f"{self.setup.root_dir}/data/insight_spice/"
+                str(Path(self.setup.root_dir) / "data" / "insight_spice")
             )
 
             #
@@ -282,21 +282,21 @@ class PDSLabel:
         :param base_dir: Root directory to build the candidate path under.
         :return: The candidate-label directory path.
         """
-        val_label_path = base_dir + self.product.collection.name + os.sep
+        val_label_path = Path(base_dir) / self.product.collection.name
 
         if self.product.collection.name in ("spice_kernels", "miscellaneous") and (
             "collection" not in self.name
         ):
-            val_label_path += self.name.split(os.sep)[-2] + os.sep
+            val_label_path = val_label_path / Path(self.name).parent.name
 
-        return val_label_path
+        return f"{val_label_path}{os.sep}"
 
     def _pick_val_label(self, val_products, val_label_path):
         """Select a validation label from val_products/val_label_path.
 
         "collection"/"bundle" are matched as a substring of the label's
-        basename (``self.name.split(os.sep)[-1]``), not as a standalone
-        path component. Real product names embed them as a prefix -- e.g.
+        basename (``Path(self.name).name``), not as a standalone path
+        component. Real product names embed them as a prefix -- e.g.
         "collection_spice_kernels_v001.xml", "bundle_insight_spice_v009.xml"
         -- never as a bare directory/path segment, so an exact-component
         check would never match real files. The similar-type and
@@ -310,7 +310,7 @@ class PDSLabel:
         :return: Path to the selected validation label.
         :raises Exception: If no label for comparison can be found.
         """
-        haystack = self.name.split(os.sep)[-1]
+        haystack = Path(self.name).name
 
         if "collection" in haystack:
             stem = Path(val_products[-1].replace("inventory_", "")).with_suffix("")

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -206,8 +206,7 @@ class PDSLabel:
                     f"{val_label_path}{val_label_name[0:i]}*.xml"
                 )
                 if val_labels:
-                    val_labels = sorted(val_labels)
-                    val_label = val_labels[-1]
+                    val_label = max(val_labels)
                     match_flag = True
                 else:
                     match_flag = False

--- a/tests/npb/test_classes_label.py
+++ b/tests/npb/test_classes_label.py
@@ -364,7 +364,7 @@ class TestPDSLabelCompare:
     def test_level2_collection_label(self, label_for, mocker):
         mocker.patch(_PATCH_COMPARE)
         label = label_for(label_name_part="collection")
-        label.name = f"/staging/spice_kernels{os.sep}collection_label.xml"
+        label.name = f"/staging/spice_kernels{os.sep}collection{os.sep}label.xml"
         mocker.patch(_PATCH_GLOB, side_effect=[
             [],  # level-1: first (and only) call → miss, exits loop
             ["/bundle/.../inventory_coll.bc"],  # level-2: val_products glob
@@ -378,7 +378,7 @@ class TestPDSLabelCompare:
     def test_level2_bundle_label(self, label_for, mocker):
         mocker.patch(_PATCH_COMPARE)
         label = label_for(label_name_part="bundle")
-        label.name = f"/staging{os.sep}bundle_label.xml"
+        label.name = f"/staging{os.sep}bundle{os.sep}label.xml"
         mocker.patch(_PATCH_GLOB, side_effect=[
             [],  # level-1: miss
             ["/bundle/kernel.bc"],  # level-2: val_products glob
@@ -652,34 +652,32 @@ class TestPDSLabelCompareHelpers:
         result = label._val_label_directory("/bundle/test_spice/")
         assert result == expected
 
-    # -- _pick_val_label: branch selection, both substring (level-2) and
-    #    exact-component (level-3) matching rules ------------------------
+    # -- _pick_val_label: branch selection, unified exact-component
+    #    matching rule (used by both the similar-type and InSight-fallback
+    #    call sites) ------------------------------------------------------
 
     @pytest.mark.parametrize(
-        "exact_match, name, val_products, val_label_path, glob_return, expected, expected_glob_call",
+        "name, val_products, val_label_path, glob_return, expected, expected_glob_call",
         [
             pytest.param(
-                False,
-                f"/staging/spice_kernels{os.sep}collection_inventory.xml",
-                ["/bundle/ck/inventory_old.v1.bc"],
-                "/bundle/ck/",
-                ["/bundle/ck/old_collection.xml"],
-                "/bundle/ck/old_collection.xml",
-                "/bundle/ck/old.v1.xml",
-                id="substring-collection-branch",
+                f"/staging{os.sep}collection{os.sep}label.xml",
+                ["/insight/ck/inventory_old.bc"],
+                "/insight/ck/",
+                ["/insight/ck/old_collection.xml"],
+                "/insight/ck/old_collection.xml",
+                "/insight/ck/old.xml",
+                id="collection-branch",
             ),
             pytest.param(
-                False,
-                f"/staging{os.sep}bundle_label.xml",
+                f"/staging{os.sep}bundle{os.sep}label.xml",
                 [],
-                "/bundle/",
-                ["/bundle/bundle_v1.xml"],
-                "/bundle/bundle_v1.xml",
-                "/bundle/bundle_*.xml",
-                id="substring-bundle-branch",
+                "/insight/",
+                ["/insight/bundle_v1.xml"],
+                "/insight/bundle_v1.xml",
+                "/insight/bundle_*.xml",
+                id="bundle-branch",
             ),
             pytest.param(
-                False,
                 f"/staging/ck{os.sep}kernel.xml",
                 ["/bundle/ck/kernel.v01.bc"],
                 "/bundle/ck/",
@@ -689,42 +687,31 @@ class TestPDSLabelCompareHelpers:
                 # Also a regression case for the .split(".")[0] truncation
                 # bug: the stem must keep everything but the final
                 # extension, not just the text before the first dot.
-                id="substring-else-branch-multidot-stem",
+                id="else-branch-multidot-stem",
             ),
             pytest.param(
-                True,
-                f"/staging{os.sep}collection{os.sep}label.xml",
-                ["/insight/ck/inventory_old.bc"],
-                "/insight/ck/",
-                ["/insight/ck/old_collection.xml"],
-                "/insight/ck/old_collection.xml",
-                "/insight/ck/old.xml",
-                id="exact-match-collection-branch",
-            ),
-            pytest.param(
-                True,
-                f"/staging{os.sep}bundle{os.sep}label.xml",
-                [],
-                "/insight/",
-                ["/insight/bundle_v1.xml"],
-                "/insight/bundle_v1.xml",
-                "/insight/bundle_*.xml",
-                id="exact-match-bundle-branch",
-            ),
-            pytest.param(
-                True,
-                # Same basename as "substring-collection-branch" above, but
-                # here it must NOT trigger the collection branch: "collection"
-                # is only a substring of this basename, not an exact path
-                # component, and exact_match=True requires the latter. This
-                # documents the preserved level-2/level-3 discrepancy.
+                # "collection" is only a substring of this basename, not an
+                # exact path component -- must fall through to the else
+                # branch rather than the collection branch.
                 f"/staging/spice_kernels{os.sep}collection_inventory.xml",
                 ["/insight/ck/kernel.bc"],
                 "/insight/ck/",
                 ["/insight/ck/kernel.xml"],
                 "/insight/ck/kernel.xml",
                 "/insight/ck/kernel.xml",
-                id="exact-match-requires-full-component",
+                id="collection-substring-does-not-trigger-branch",
+            ),
+            pytest.param(
+                # "bundle" is only a substring of "unbundled_data.xml" (from
+                # "unbundled"), not an exact path component -- must fall
+                # through to the else branch rather than the bundle branch.
+                f"/staging/spice_kernels{os.sep}unbundled_data.xml",
+                ["/insight/ck/unbundled_data.bc"],
+                "/insight/ck/",
+                ["/insight/ck/unbundled_data.xml"],
+                "/insight/ck/unbundled_data.xml",
+                "/insight/ck/unbundled_data.xml",
+                id="bundle-substring-does-not-trigger-branch",
             ),
         ],
     )
@@ -732,7 +719,6 @@ class TestPDSLabelCompareHelpers:
         self,
         label_for_helper,
         mocker,
-        exact_match,
         name,
         val_products,
         val_label_path,
@@ -743,7 +729,7 @@ class TestPDSLabelCompareHelpers:
         label = label_for_helper()
         label.name = name
         mock_glob = mocker.patch(_PATCH_GLOB, return_value=glob_return)
-        result = label._pick_val_label(val_products, val_label_path, exact_match=exact_match)
+        result = label._pick_val_label(val_products, val_label_path)
         assert result == expected
         mock_glob.assert_called_once_with(expected_glob_call)
 
@@ -754,13 +740,13 @@ class TestPDSLabelCompareHelpers:
         label.name = f"/staging/ck{os.sep}kernel.xml"
         mocker.patch(_PATCH_GLOB, return_value=[""])
         with pytest.raises(Exception, match="No label for comparison found."):
-            label._pick_val_label(["/bundle/ck/kernel.bc"], "/bundle/ck/", exact_match=False)
+            label._pick_val_label(["/bundle/ck/kernel.bc"], "/bundle/ck/")
 
     def test_pick_val_label_raises_indexerror_on_empty_products(self, label_for_helper):
         label = label_for_helper()
         label.name = f"/staging/ck{os.sep}kernel.xml"
         with pytest.raises(IndexError):
-            label._pick_val_label([], "/bundle/ck/", exact_match=False)
+            label._pick_val_label([], "/bundle/ck/")
 
     # -- _find_prior_version_label ---------------------------------------
 

--- a/tests/npb/test_classes_label.py
+++ b/tests/npb/test_classes_label.py
@@ -378,7 +378,7 @@ class TestPDSLabelCompare:
     def test_level2_bundle_label(self, label_for, mocker):
         mocker.patch(_PATCH_COMPARE)
         label = label_for(label_name_part="bundle")
-        label.name = f"/staging{os.sep}bundle_label.xml"
+        label.name = str(Path("/staging/bundle_label.xml"))
         mocker.patch(_PATCH_GLOB, side_effect=[
             [],  # level-1: miss
             ["/bundle/kernel.bc"],  # level-2: val_products glob
@@ -442,7 +442,7 @@ class TestPDSLabelCompare:
     def test_level3_bundle_label(self, label_for, mocker):
         mocker.patch(_PATCH_COMPARE)
         label = label_for()
-        label.name = f"/staging{os.sep}bundle_label.xml"
+        label.name = str(Path("/staging/bundle_label.xml"))
         mocker.patch(_PATCH_GLOB, side_effect=[
             [],  # level-1: miss
             [],  # level-2: val_products empty
@@ -620,22 +620,22 @@ class TestPDSLabelCompareHelpers:
             (
                 "spice_kernels",
                 None,
-                f"/bundle/test_spice/spice_kernels{os.sep}ck{os.sep}",
+                str(Path("/bundle/test_spice", "spice_kernels", "ck")) + os.sep,
             ),
             (
                 "miscellaneous",
-                f"/staging/miscellaneous/orb{os.sep}orbnum.xml",
-                f"/bundle/test_spice/miscellaneous{os.sep}orb{os.sep}",
+                str(Path("/staging/miscellaneous/orb/orbnum.xml")),
+                str(Path("/bundle/test_spice", "miscellaneous", "orb")) + os.sep,
             ),
             (
                 "document",
                 None,
-                "/bundle/test_spice/document" + os.sep,
+                str(Path("/bundle/test_spice", "document")) + os.sep,
             ),
             (
                 "spice_kernels",
-                f"/staging/spice_kernels{os.sep}collection.xml",
-                "/bundle/test_spice/spice_kernels" + os.sep,
+                str(Path("/staging/spice_kernels/collection.xml")),
+                str(Path("/bundle/test_spice", "spice_kernels")) + os.sep,
             ),
         ],
         ids=[
@@ -668,7 +668,7 @@ class TestPDSLabelCompareHelpers:
                 "/insight/ck/",
                 ["/insight/ck/old_collection.xml"],
                 "/insight/ck/old_collection.xml",
-                "/insight/ck/old.xml",
+                str(Path("/insight/ck/old.xml")),
                 id="collection-branch-realistic-name",
             ),
             pytest.param(
@@ -686,7 +686,7 @@ class TestPDSLabelCompareHelpers:
                 "/bundle/ck/",
                 ["/bundle/ck/kernel.v01.xml"],
                 "/bundle/ck/kernel.v01.xml",
-                "/bundle/ck/kernel.v01.xml",
+                str(Path("/bundle/ck/kernel.v01.xml")),
                 # Also a regression case for the .split(".")[0] truncation
                 # bug: the stem must keep everything but the final
                 # extension, not just the text before the first dot.
@@ -702,7 +702,7 @@ class TestPDSLabelCompareHelpers:
                 "/insight/ck/",
                 ["/insight/ck/kernel.xml"],
                 "/insight/ck/kernel.xml",
-                "/insight/ck/kernel.xml",
+                str(Path("/insight/ck/kernel.xml")),
                 id="collection-directory-without-basename-match-falls-to-else",
             ),
             pytest.param(

--- a/tests/npb/test_classes_label.py
+++ b/tests/npb/test_classes_label.py
@@ -614,98 +614,136 @@ class TestPDSLabelCompareHelpers:
 
     # -- _val_label_directory ------------------------------------------
 
-    def test_val_label_directory_appends_subdir_for_spice_kernels(self, label_for):
-        label = label_for(collection_name="spice_kernels", label_name_part="kernel")
+    @pytest.mark.parametrize(
+        "collection_name, name_override, expected",
+        [
+            pytest.param(
+                "spice_kernels",
+                None,
+                f"/bundle/test_spice/spice_kernels{os.sep}ck{os.sep}",
+                id="spice_kernels-appends-subdir",
+            ),
+            pytest.param(
+                "miscellaneous",
+                f"/staging/miscellaneous/orb{os.sep}orbnum.xml",
+                f"/bundle/test_spice/miscellaneous{os.sep}orb{os.sep}",
+                id="miscellaneous-appends-subdir",
+            ),
+            pytest.param(
+                "document",
+                None,
+                "/bundle/test_spice/document" + os.sep,
+                id="other-collection-no-subdir",
+            ),
+            pytest.param(
+                "spice_kernels",
+                f"/staging/spice_kernels{os.sep}collection.xml",
+                "/bundle/test_spice/spice_kernels" + os.sep,
+                id="collection-in-name-suppresses-subdir",
+            ),
+        ],
+    )
+    def test_val_label_directory(self, label_for, collection_name, name_override, expected):
+        label = label_for(collection_name=collection_name)
+        if name_override:
+            label.name = name_override
         result = label._val_label_directory("/bundle/test_spice/")
-        assert result == f"/bundle/test_spice/spice_kernels{os.sep}ck{os.sep}"
+        assert result == expected
 
-    def test_val_label_directory_appends_subdir_for_miscellaneous(self, label_for):
-        label = label_for(collection_name="miscellaneous", label_name_part="orbnum")
-        label.name = f"/staging/miscellaneous/orb{os.sep}orbnum.xml"
-        result = label._val_label_directory("/bundle/test_spice/")
-        assert result == f"/bundle/test_spice/miscellaneous{os.sep}orb{os.sep}"
+    # -- _pick_val_label: branch selection, both substring (level-2) and
+    #    exact-component (level-3) matching rules ------------------------
 
-    def test_val_label_directory_no_subdir_for_other_collection(self, label_for):
-        label = label_for(collection_name="document")
-        result = label._val_label_directory("/bundle/test_spice/")
-        assert result == "/bundle/test_spice/document" + os.sep
-
-    def test_val_label_directory_no_subdir_when_collection_in_name(self, label_for):
-        label = label_for(collection_name="spice_kernels")
-        label.name = f"/staging/spice_kernels{os.sep}collection.xml"
-        result = label._val_label_directory("/bundle/test_spice/")
-        assert result == "/bundle/test_spice/spice_kernels" + os.sep
-
-    # -- _pick_val_label: exact_match=False (level-2 substring rule) ---
-
-    def test_pick_val_label_substring_collection_branch(self, label_for, mocker):
+    @pytest.mark.parametrize(
+        "exact_match, name, val_products, val_label_path, glob_return, expected, expected_glob_call",
+        [
+            pytest.param(
+                False,
+                f"/staging/spice_kernels{os.sep}collection_inventory.xml",
+                ["/bundle/ck/inventory_old.v1.bc"],
+                "/bundle/ck/",
+                ["/bundle/ck/old_collection.xml"],
+                "/bundle/ck/old_collection.xml",
+                "/bundle/ck/old.v1.xml",
+                id="substring-collection-branch",
+            ),
+            pytest.param(
+                False,
+                f"/staging{os.sep}bundle_label.xml",
+                [],
+                "/bundle/",
+                ["/bundle/bundle_v1.xml"],
+                "/bundle/bundle_v1.xml",
+                "/bundle/bundle_*.xml",
+                id="substring-bundle-branch",
+            ),
+            pytest.param(
+                False,
+                f"/staging/ck{os.sep}kernel.xml",
+                ["/bundle/ck/kernel.v01.bc"],
+                "/bundle/ck/",
+                ["/bundle/ck/kernel.v01.xml"],
+                "/bundle/ck/kernel.v01.xml",
+                "/bundle/ck/kernel.v01.xml",
+                # Also a regression case for the .split(".")[0] truncation
+                # bug: the stem must keep everything but the final
+                # extension, not just the text before the first dot.
+                id="substring-else-branch-multidot-stem",
+            ),
+            pytest.param(
+                True,
+                f"/staging{os.sep}collection{os.sep}label.xml",
+                ["/insight/ck/inventory_old.bc"],
+                "/insight/ck/",
+                ["/insight/ck/old_collection.xml"],
+                "/insight/ck/old_collection.xml",
+                "/insight/ck/old.xml",
+                id="exact-match-collection-branch",
+            ),
+            pytest.param(
+                True,
+                f"/staging{os.sep}bundle{os.sep}label.xml",
+                [],
+                "/insight/",
+                ["/insight/bundle_v1.xml"],
+                "/insight/bundle_v1.xml",
+                "/insight/bundle_*.xml",
+                id="exact-match-bundle-branch",
+            ),
+            pytest.param(
+                True,
+                # Same basename as "substring-collection-branch" above, but
+                # here it must NOT trigger the collection branch: "collection"
+                # is only a substring of this basename, not an exact path
+                # component, and exact_match=True requires the latter. This
+                # documents the preserved level-2/level-3 discrepancy.
+                f"/staging/spice_kernels{os.sep}collection_inventory.xml",
+                ["/insight/ck/kernel.bc"],
+                "/insight/ck/",
+                ["/insight/ck/kernel.xml"],
+                "/insight/ck/kernel.xml",
+                "/insight/ck/kernel.xml",
+                id="exact-match-requires-full-component",
+            ),
+        ],
+    )
+    def test_pick_val_label_branch_selection(
+        self,
+        label_for,
+        mocker,
+        exact_match,
+        name,
+        val_products,
+        val_label_path,
+        glob_return,
+        expected,
+        expected_glob_call,
+    ):
         label = label_for()
-        label.name = f"/staging/spice_kernels{os.sep}collection_inventory.xml"
-        mock_glob = mocker.patch(_PATCH_GLOB, return_value=["/bundle/ck/old_collection.xml"])
-        result = label._pick_val_label(
-            ["/bundle/ck/inventory_old.v1.bc"], "/bundle/ck/", exact_match=False
-        )
-        assert result == "/bundle/ck/old_collection.xml"
-        mock_glob.assert_called_once_with("/bundle/ck/old.v1.xml")
-
-    def test_pick_val_label_substring_bundle_branch(self, label_for, mocker):
-        label = label_for()
-        label.name = f"/staging{os.sep}bundle_label.xml"
-        mock_glob = mocker.patch(_PATCH_GLOB, return_value=["/bundle/bundle_v1.xml"])
-        result = label._pick_val_label([], "/bundle/", exact_match=False)
-        assert result == "/bundle/bundle_v1.xml"
-        mock_glob.assert_called_once_with("/bundle/bundle_*.xml")
-
-    def test_pick_val_label_substring_else_branch_keeps_multidot_stem(self, label_for, mocker):
-        """Also a regression test for the .split('.')[0] truncation bug:
-        the stem must keep everything but the final extension, not just
-        the text before the first dot.
-        """
-        label = label_for()
-        label.name = f"/staging/ck{os.sep}kernel.xml"
-        mock_glob = mocker.patch(_PATCH_GLOB, return_value=["/bundle/ck/kernel.v01.xml"])
-        result = label._pick_val_label(
-            ["/bundle/ck/kernel.v01.bc"], "/bundle/ck/", exact_match=False
-        )
-        assert result == "/bundle/ck/kernel.v01.xml"
-        mock_glob.assert_called_once_with("/bundle/ck/kernel.v01.xml")
-
-    # -- _pick_val_label: exact_match=True (level-3 exact-component rule)
-
-    def test_pick_val_label_exact_match_collection_branch(self, label_for, mocker):
-        label = label_for()
-        label.name = f"/staging{os.sep}collection{os.sep}label.xml"
-        mock_glob = mocker.patch(_PATCH_GLOB, return_value=["/insight/ck/old_collection.xml"])
-        result = label._pick_val_label(
-            ["/insight/ck/inventory_old.bc"], "/insight/ck/", exact_match=True
-        )
-        assert result == "/insight/ck/old_collection.xml"
-        mock_glob.assert_called_once_with("/insight/ck/old.xml")
-
-    def test_pick_val_label_exact_match_bundle_branch(self, label_for, mocker):
-        label = label_for()
-        label.name = f"/staging{os.sep}bundle{os.sep}label.xml"
-        mock_glob = mocker.patch(_PATCH_GLOB, return_value=["/insight/bundle_v1.xml"])
-        result = label._pick_val_label([], "/insight/", exact_match=True)
-        assert result == "/insight/bundle_v1.xml"
-        mock_glob.assert_called_once_with("/insight/bundle_*.xml")
-
-    def test_pick_val_label_exact_match_requires_full_path_component(self, label_for, mocker):
-        """Documents the preserved level-2/level-3 discrepancy: a basename
-        that merely CONTAINS "collection" must NOT trigger the collection
-        branch when exact_match=True -- only an exact path component does.
-        """
-        label = label_for()
-        label.name = f"/staging/spice_kernels{os.sep}collection_inventory.xml"
-        mock_glob = mocker.patch(_PATCH_GLOB, return_value=["/insight/ck/kernel.xml"])
-        result = label._pick_val_label(
-            ["/insight/ck/kernel.bc"], "/insight/ck/", exact_match=True
-        )
-        # "collection_inventory.xml" contains "collection" as a substring but
-        # is not an exact path component, so this falls to the else branch,
-        # unlike the equivalent exact_match=False case above.
-        assert result == "/insight/ck/kernel.xml"
-        mock_glob.assert_called_once_with("/insight/ck/kernel.xml")
+        label.name = name
+        mock_glob = mocker.patch(_PATCH_GLOB, return_value=glob_return)
+        result = label._pick_val_label(val_products, val_label_path, exact_match=exact_match)
+        assert result == expected
+        mock_glob.assert_called_once_with(expected_glob_call)
 
     # -- _pick_val_label: failure paths ---------------------------------
 

--- a/tests/npb/test_classes_label.py
+++ b/tests/npb/test_classes_label.py
@@ -749,10 +749,10 @@ class TestPDSLabelCompareHelpers:
         with pytest.raises(Exception, match="No label for comparison found."):
             label._pick_val_label(["/bundle/ck/kernel.bc"], "/bundle/ck/")
 
-    def test_pick_val_label_raises_indexerror_on_empty_products(self, label_for_helper):
+    def test_pick_val_label_raises_valueerror_on_empty_products(self, label_for_helper):
         label = label_for_helper()
         label.name = f"/staging/ck{os.sep}kernel.xml"
-        with pytest.raises(IndexError):
+        with pytest.raises(ValueError):
             label._pick_val_label([], "/bundle/ck/")
 
     # -- _find_prior_version_label ---------------------------------------

--- a/tests/npb/test_classes_label.py
+++ b/tests/npb/test_classes_label.py
@@ -364,7 +364,7 @@ class TestPDSLabelCompare:
     def test_level2_collection_label(self, label_for, mocker):
         mocker.patch(_PATCH_COMPARE)
         label = label_for(label_name_part="collection")
-        label.name = f"/staging/spice_kernels{os.sep}collection{os.sep}label.xml"
+        label.name = f"/staging/spice_kernels{os.sep}collection_label.xml"
         mocker.patch(_PATCH_GLOB, side_effect=[
             [],  # level-1: first (and only) call → miss, exits loop
             ["/bundle/.../inventory_coll.bc"],  # level-2: val_products glob
@@ -378,7 +378,7 @@ class TestPDSLabelCompare:
     def test_level2_bundle_label(self, label_for, mocker):
         mocker.patch(_PATCH_COMPARE)
         label = label_for(label_name_part="bundle")
-        label.name = f"/staging{os.sep}bundle{os.sep}label.xml"
+        label.name = f"/staging{os.sep}bundle_label.xml"
         mocker.patch(_PATCH_GLOB, side_effect=[
             [],  # level-1: miss
             ["/bundle/kernel.bc"],  # level-2: val_products glob
@@ -422,12 +422,12 @@ class TestPDSLabelCompare:
         mock_cmp.assert_not_called()
 
     # ------------------------------------------------------------------
-    # Level 3: "collection" segment in the name path (split by os.sep)
+    # Level 3: "collection" substring in the label's basename
     # ------------------------------------------------------------------
-    def test_level3_collection_in_name_path(self, label_for, mocker):
+    def test_level3_collection_label(self, label_for, mocker):
         mocker.patch(_PATCH_COMPARE)
         label = label_for()
-        label.name = f"/staging{os.sep}collection{os.sep}label.xml"
+        label.name = f"/staging/spice_kernels{os.sep}collection_label.xml"
         mocker.patch(_PATCH_GLOB, side_effect=[
             [],  # level-1: miss
             [],  # level-2: val_products empty
@@ -437,12 +437,12 @@ class TestPDSLabelCompare:
         label.compare()
 
     # ------------------------------------------------------------------
-    # Level 3: "bundle" segment in the name path
+    # Level 3: "bundle" substring in the label's basename
     # ------------------------------------------------------------------
-    def test_level3_bundle_in_name_path(self, label_for, mocker):
+    def test_level3_bundle_label(self, label_for, mocker):
         mocker.patch(_PATCH_COMPARE)
         label = label_for()
-        label.name = f"/staging{os.sep}bundle{os.sep}label.xml"
+        label.name = f"/staging{os.sep}bundle_label.xml"
         mocker.patch(_PATCH_GLOB, side_effect=[
             [],  # level-1: miss
             [],  # level-2: val_products empty
@@ -652,30 +652,33 @@ class TestPDSLabelCompareHelpers:
         result = label._val_label_directory("/bundle/test_spice/")
         assert result == expected
 
-    # -- _pick_val_label: branch selection, unified exact-component
+    # -- _pick_val_label: branch selection, unified substring-of-basename
     #    matching rule (used by both the similar-type and InSight-fallback
-    #    call sites) ------------------------------------------------------
+    #    call sites). Real product names embed "collection"/"bundle" as a
+    #    basename prefix (e.g. "collection_spice_kernels_v001.xml",
+    #    "bundle_insight_spice_v009.xml"), never as a standalone path
+    #    component, so the match must be substring-based to work at all. --
 
     @pytest.mark.parametrize(
         "name, val_products, val_label_path, glob_return, expected, expected_glob_call",
         [
             pytest.param(
-                f"/staging{os.sep}collection{os.sep}label.xml",
+                f"/staging/spice_kernels{os.sep}collection_spice_kernels_v001.xml",
                 ["/insight/ck/inventory_old.bc"],
                 "/insight/ck/",
                 ["/insight/ck/old_collection.xml"],
                 "/insight/ck/old_collection.xml",
                 "/insight/ck/old.xml",
-                id="collection-branch",
+                id="collection-branch-realistic-name",
             ),
             pytest.param(
-                f"/staging{os.sep}bundle{os.sep}label.xml",
+                f"/staging{os.sep}bundle_insight_spice_v009.xml",
                 [],
                 "/insight/",
                 ["/insight/bundle_v1.xml"],
                 "/insight/bundle_v1.xml",
                 "/insight/bundle_*.xml",
-                id="bundle-branch",
+                id="bundle-branch-realistic-name",
             ),
             pytest.param(
                 f"/staging/ck{os.sep}kernel.xml",
@@ -690,28 +693,32 @@ class TestPDSLabelCompareHelpers:
                 id="else-branch-multidot-stem",
             ),
             pytest.param(
-                # "collection" is only a substring of this basename, not an
-                # exact path component -- must fall through to the else
-                # branch rather than the collection branch.
-                f"/staging/spice_kernels{os.sep}collection_inventory.xml",
+                # A directory literally named "collection" must NOT trigger
+                # the collection branch -- only the basename is checked, not
+                # the full path. The basename here ("label.xml") has no
+                # "collection" substring, so this falls through to else.
+                f"/staging{os.sep}collection{os.sep}label.xml",
                 ["/insight/ck/kernel.bc"],
                 "/insight/ck/",
                 ["/insight/ck/kernel.xml"],
                 "/insight/ck/kernel.xml",
                 "/insight/ck/kernel.xml",
-                id="collection-substring-does-not-trigger-branch",
+                id="collection-directory-without-basename-match-falls-to-else",
             ),
             pytest.param(
-                # "bundle" is only a substring of "unbundled_data.xml" (from
-                # "unbundled"), not an exact path component -- must fall
-                # through to the else branch rather than the bundle branch.
+                # Known, accepted trade-off of substring matching: "bundle"
+                # is a substring of "unbundled_data.xml" (from "unbundled"),
+                # so this still triggers the bundle branch even though the
+                # file is not actually a bundle label. This is the price of
+                # a rule that must also match real names like
+                # "bundle_insight_spice_v009.xml".
                 f"/staging/spice_kernels{os.sep}unbundled_data.xml",
-                ["/insight/ck/unbundled_data.bc"],
+                [],
                 "/insight/ck/",
-                ["/insight/ck/unbundled_data.xml"],
-                "/insight/ck/unbundled_data.xml",
-                "/insight/ck/unbundled_data.xml",
-                id="bundle-substring-does-not-trigger-branch",
+                ["/insight/ck/bundle_v2.xml"],
+                "/insight/ck/bundle_v2.xml",
+                "/insight/ck/bundle_*.xml",
+                id="bundle-substring-collision-is-accepted-trade-off",
             ),
         ],
     )

--- a/tests/npb/test_classes_label.py
+++ b/tests/npb/test_classes_label.py
@@ -573,7 +573,7 @@ class TestPDSLabelCompareHelpers:
     """Direct calls to the fallback-strategy helpers extracted from compare()."""
 
     @pytest.fixture
-    def label_for(self, label_test_helpers):
+    def label_for_helper(self, label_test_helpers):
         """Factory fixture: builds a bare label ready for compare().
 
         Duplicated from TestPDSLabelCompare rather than inherited via
@@ -581,7 +581,7 @@ class TestPDSLabelCompareHelpers:
         tests to be collected and re-run a second time under this class.
         """
 
-        def _build(collection_name="spice_kernels", label_name_part="kernel"):
+        def _build(collection_name="spice_kernels", label_name_part="kernel", subdir="ck"):
             setup = label_test_helpers.make_setup_pds4()
             setup.diff = "html"
             product = label_test_helpers.make_product()
@@ -591,7 +591,7 @@ class TestPDSLabelCompareHelpers:
             label = PDSLabel.__new__(PDSLabel)
             label.setup = setup
             label.product = product
-            label.name = str(Path(f"/staging/spice_kernels/ck/{label_name_part}.xml"))
+            label.name = str(Path(f"/staging/{collection_name}/{subdir}/{label_name_part}.xml"))
             return label
 
         return _build
@@ -615,36 +615,38 @@ class TestPDSLabelCompareHelpers:
     # -- _val_label_directory ------------------------------------------
 
     @pytest.mark.parametrize(
-        "collection_name, name_override, expected",
+        ["collection_name", "name_override", "expected"],
         [
-            pytest.param(
+            (
                 "spice_kernels",
                 None,
                 f"/bundle/test_spice/spice_kernels{os.sep}ck{os.sep}",
-                id="spice_kernels-appends-subdir",
             ),
-            pytest.param(
+            (
                 "miscellaneous",
                 f"/staging/miscellaneous/orb{os.sep}orbnum.xml",
                 f"/bundle/test_spice/miscellaneous{os.sep}orb{os.sep}",
-                id="miscellaneous-appends-subdir",
             ),
-            pytest.param(
+            (
                 "document",
                 None,
                 "/bundle/test_spice/document" + os.sep,
-                id="other-collection-no-subdir",
             ),
-            pytest.param(
+            (
                 "spice_kernels",
                 f"/staging/spice_kernels{os.sep}collection.xml",
                 "/bundle/test_spice/spice_kernels" + os.sep,
-                id="collection-in-name-suppresses-subdir",
             ),
         ],
+        ids=[
+            "spice_kernels-appends-subdir",
+            "miscellaneous-appends-subdir",
+            "other-collection-no-subdir",
+            "collection-in-name-suppresses-subdir",
+        ],
     )
-    def test_val_label_directory(self, label_for, collection_name, name_override, expected):
-        label = label_for(collection_name=collection_name)
+    def test_val_label_directory(self, label_for_helper, collection_name, name_override, expected):
+        label = label_for_helper(collection_name=collection_name)
         if name_override:
             label.name = name_override
         result = label._val_label_directory("/bundle/test_spice/")
@@ -728,7 +730,7 @@ class TestPDSLabelCompareHelpers:
     )
     def test_pick_val_label_branch_selection(
         self,
-        label_for,
+        label_for_helper,
         mocker,
         exact_match,
         name,
@@ -738,7 +740,7 @@ class TestPDSLabelCompareHelpers:
         expected,
         expected_glob_call,
     ):
-        label = label_for()
+        label = label_for_helper()
         label.name = name
         mock_glob = mocker.patch(_PATCH_GLOB, return_value=glob_return)
         result = label._pick_val_label(val_products, val_label_path, exact_match=exact_match)
@@ -747,51 +749,51 @@ class TestPDSLabelCompareHelpers:
 
     # -- _pick_val_label: failure paths ---------------------------------
 
-    def test_pick_val_label_raises_when_result_falsy(self, label_for, mocker):
-        label = label_for()
+    def test_pick_val_label_raises_when_result_falsy(self, label_for_helper, mocker):
+        label = label_for_helper()
         label.name = f"/staging/ck{os.sep}kernel.xml"
         mocker.patch(_PATCH_GLOB, return_value=[""])
         with pytest.raises(Exception, match="No label for comparison found."):
             label._pick_val_label(["/bundle/ck/kernel.bc"], "/bundle/ck/", exact_match=False)
 
-    def test_pick_val_label_raises_indexerror_on_empty_products(self, label_for):
-        label = label_for()
+    def test_pick_val_label_raises_indexerror_on_empty_products(self, label_for_helper):
+        label = label_for_helper()
         label.name = f"/staging/ck{os.sep}kernel.xml"
         with pytest.raises(IndexError):
             label._pick_val_label([], "/bundle/ck/", exact_match=False)
 
     # -- _find_prior_version_label ---------------------------------------
 
-    def test_find_prior_version_label_returns_hit(self, label_for, mocker):
-        label = label_for()
+    def test_find_prior_version_label_returns_hit(self, label_for_helper, mocker):
+        label = label_for_helper()
         hit = "/bundle/spice_kernels/ck/kernel_old.xml"
         mocker.patch(_PATCH_GLOB, side_effect=self._level1_hit(hit))
         assert label._find_prior_version_label() == hit
 
-    def test_find_prior_version_label_returns_none_on_no_match(self, label_for, mocker):
-        label = label_for()
+    def test_find_prior_version_label_returns_none_on_no_match(self, label_for_helper, mocker):
+        label = label_for_helper()
         mocker.patch(_PATCH_GLOB, return_value=[])
         assert label._find_prior_version_label() is None
 
     # -- _find_similar_type_label -----------------------------------------
 
-    def test_find_similar_type_label_returns_hit(self, label_for, mocker):
-        label = label_for()
+    def test_find_similar_type_label_returns_hit(self, label_for_helper, mocker):
+        label = label_for_helper()
         mocker.patch(_PATCH_GLOB, side_effect=[
             ["/bundle/spice_kernels/ck/kern.bc"],
             ["/bundle/spice_kernels/ck/kern.xml"],
         ])
         assert label._find_similar_type_label() == "/bundle/spice_kernels/ck/kern.xml"
 
-    def test_find_similar_type_label_returns_none_when_val_products_empty(self, label_for, mocker):
-        label = label_for()
+    def test_find_similar_type_label_returns_none_when_val_products_empty(self, label_for_helper, mocker):
+        label = label_for_helper()
         mocker.patch(_PATCH_GLOB, return_value=[])
         assert label._find_similar_type_label() is None
 
     # -- _find_insight_fallback_label -------------------------------------
 
-    def test_find_insight_fallback_label_returns_hit_and_logs(self, label_for, mocker):
-        label = label_for()
+    def test_find_insight_fallback_label_returns_hit_and_logs(self, label_for_helper, mocker):
+        label = label_for_helper()
         mocker.patch(_PATCH_GLOB, side_effect=[
             ["/root/data/insight_spice/spice_kernels/ck/insight_ck.bc"],
             ["/root/data/insight_spice/spice_kernels/ck/insight_ck.xml"],
@@ -803,8 +805,8 @@ class TestPDSLabelCompareHelpers:
         # must be the ONLY warning logged (no leftover "not found" message).
         mock_log.assert_called_once_with("-- Comparing with InSight test label.")
 
-    def test_find_insight_fallback_label_returns_none_when_val_products_empty(self, label_for, mocker):
-        label = label_for()
+    def test_find_insight_fallback_label_returns_none_when_val_products_empty(self, label_for_helper, mocker):
+        label = label_for_helper()
         mocker.patch(_PATCH_GLOB, return_value=[])
         mock_log = mocker.patch("pds.naif_pds4_bundler.classes.label.label.logging.warning")
         assert label._find_insight_fallback_label() is None

--- a/tests/npb/test_classes_label.py
+++ b/tests/npb/test_classes_label.py
@@ -558,3 +558,216 @@ class TestPDSLabelCompare:
         # The raise on line 611 is caught on line 615; val_label stays falsy
         # so compare_files must not have been called.
         mock_cmp.assert_not_called()
+
+
+# ===========================================================================
+# PDSLabel._val_label_directory / _pick_val_label / _find_* — direct tests
+# ===========================================================================
+# The TestPDSLabelCompare tests above only exercise these through compare(),
+# by controlling glob.glob's call sequence. That pins compare()'s overall
+# behavior but never calls the extracted helpers directly, so it doesn't
+# prove each one is independently correct in isolation. These tests call
+# them directly instead.
+
+class TestPDSLabelCompareHelpers:
+    """Direct calls to the fallback-strategy helpers extracted from compare()."""
+
+    @pytest.fixture
+    def label_for(self, label_test_helpers):
+        """Factory fixture: builds a bare label ready for compare().
+
+        Duplicated from TestPDSLabelCompare rather than inherited via
+        subclassing, since subclassing a pytest test class would cause its
+        tests to be collected and re-run a second time under this class.
+        """
+
+        def _build(collection_name="spice_kernels", label_name_part="kernel"):
+            setup = label_test_helpers.make_setup_pds4()
+            setup.diff = "html"
+            product = label_test_helpers.make_product()
+            product.collection.name = collection_name
+            product.name = "kernel.bc"
+            product.extension = "bc"
+            label = PDSLabel.__new__(PDSLabel)
+            label.setup = setup
+            label.product = product
+            label.name = str(Path(f"/staging/spice_kernels/ck/{label_name_part}.xml"))
+            return label
+
+        return _build
+
+    @staticmethod
+    def _level1_hit(hit):
+        """Return a side_effect callable that simulates finding a prior-version
+        label in the level-1 while loop, then cleanly exits that loop.
+        """
+        call_count = [0]
+
+        def _side_effect(_):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [hit]
+            else:
+                return []
+
+        return _side_effect
+
+    # -- _val_label_directory ------------------------------------------
+
+    def test_val_label_directory_appends_subdir_for_spice_kernels(self, label_for):
+        label = label_for(collection_name="spice_kernels", label_name_part="kernel")
+        result = label._val_label_directory("/bundle/test_spice/")
+        assert result == f"/bundle/test_spice/spice_kernels{os.sep}ck{os.sep}"
+
+    def test_val_label_directory_appends_subdir_for_miscellaneous(self, label_for):
+        label = label_for(collection_name="miscellaneous", label_name_part="orbnum")
+        label.name = f"/staging/miscellaneous/orb{os.sep}orbnum.xml"
+        result = label._val_label_directory("/bundle/test_spice/")
+        assert result == f"/bundle/test_spice/miscellaneous{os.sep}orb{os.sep}"
+
+    def test_val_label_directory_no_subdir_for_other_collection(self, label_for):
+        label = label_for(collection_name="document")
+        result = label._val_label_directory("/bundle/test_spice/")
+        assert result == "/bundle/test_spice/document" + os.sep
+
+    def test_val_label_directory_no_subdir_when_collection_in_name(self, label_for):
+        label = label_for(collection_name="spice_kernels")
+        label.name = f"/staging/spice_kernels{os.sep}collection.xml"
+        result = label._val_label_directory("/bundle/test_spice/")
+        assert result == "/bundle/test_spice/spice_kernels" + os.sep
+
+    # -- _pick_val_label: exact_match=False (level-2 substring rule) ---
+
+    def test_pick_val_label_substring_collection_branch(self, label_for, mocker):
+        label = label_for()
+        label.name = f"/staging/spice_kernels{os.sep}collection_inventory.xml"
+        mock_glob = mocker.patch(_PATCH_GLOB, return_value=["/bundle/ck/old_collection.xml"])
+        result = label._pick_val_label(
+            ["/bundle/ck/inventory_old.v1.bc"], "/bundle/ck/", exact_match=False
+        )
+        assert result == "/bundle/ck/old_collection.xml"
+        mock_glob.assert_called_once_with("/bundle/ck/old.v1.xml")
+
+    def test_pick_val_label_substring_bundle_branch(self, label_for, mocker):
+        label = label_for()
+        label.name = f"/staging{os.sep}bundle_label.xml"
+        mock_glob = mocker.patch(_PATCH_GLOB, return_value=["/bundle/bundle_v1.xml"])
+        result = label._pick_val_label([], "/bundle/", exact_match=False)
+        assert result == "/bundle/bundle_v1.xml"
+        mock_glob.assert_called_once_with("/bundle/bundle_*.xml")
+
+    def test_pick_val_label_substring_else_branch_keeps_multidot_stem(self, label_for, mocker):
+        """Also a regression test for the .split('.')[0] truncation bug:
+        the stem must keep everything but the final extension, not just
+        the text before the first dot.
+        """
+        label = label_for()
+        label.name = f"/staging/ck{os.sep}kernel.xml"
+        mock_glob = mocker.patch(_PATCH_GLOB, return_value=["/bundle/ck/kernel.v01.xml"])
+        result = label._pick_val_label(
+            ["/bundle/ck/kernel.v01.bc"], "/bundle/ck/", exact_match=False
+        )
+        assert result == "/bundle/ck/kernel.v01.xml"
+        mock_glob.assert_called_once_with("/bundle/ck/kernel.v01.xml")
+
+    # -- _pick_val_label: exact_match=True (level-3 exact-component rule)
+
+    def test_pick_val_label_exact_match_collection_branch(self, label_for, mocker):
+        label = label_for()
+        label.name = f"/staging{os.sep}collection{os.sep}label.xml"
+        mock_glob = mocker.patch(_PATCH_GLOB, return_value=["/insight/ck/old_collection.xml"])
+        result = label._pick_val_label(
+            ["/insight/ck/inventory_old.bc"], "/insight/ck/", exact_match=True
+        )
+        assert result == "/insight/ck/old_collection.xml"
+        mock_glob.assert_called_once_with("/insight/ck/old.xml")
+
+    def test_pick_val_label_exact_match_bundle_branch(self, label_for, mocker):
+        label = label_for()
+        label.name = f"/staging{os.sep}bundle{os.sep}label.xml"
+        mock_glob = mocker.patch(_PATCH_GLOB, return_value=["/insight/bundle_v1.xml"])
+        result = label._pick_val_label([], "/insight/", exact_match=True)
+        assert result == "/insight/bundle_v1.xml"
+        mock_glob.assert_called_once_with("/insight/bundle_*.xml")
+
+    def test_pick_val_label_exact_match_requires_full_path_component(self, label_for, mocker):
+        """Documents the preserved level-2/level-3 discrepancy: a basename
+        that merely CONTAINS "collection" must NOT trigger the collection
+        branch when exact_match=True -- only an exact path component does.
+        """
+        label = label_for()
+        label.name = f"/staging/spice_kernels{os.sep}collection_inventory.xml"
+        mock_glob = mocker.patch(_PATCH_GLOB, return_value=["/insight/ck/kernel.xml"])
+        result = label._pick_val_label(
+            ["/insight/ck/kernel.bc"], "/insight/ck/", exact_match=True
+        )
+        # "collection_inventory.xml" contains "collection" as a substring but
+        # is not an exact path component, so this falls to the else branch,
+        # unlike the equivalent exact_match=False case above.
+        assert result == "/insight/ck/kernel.xml"
+        mock_glob.assert_called_once_with("/insight/ck/kernel.xml")
+
+    # -- _pick_val_label: failure paths ---------------------------------
+
+    def test_pick_val_label_raises_when_result_falsy(self, label_for, mocker):
+        label = label_for()
+        label.name = f"/staging/ck{os.sep}kernel.xml"
+        mocker.patch(_PATCH_GLOB, return_value=[""])
+        with pytest.raises(Exception, match="No label for comparison found."):
+            label._pick_val_label(["/bundle/ck/kernel.bc"], "/bundle/ck/", exact_match=False)
+
+    def test_pick_val_label_raises_indexerror_on_empty_products(self, label_for):
+        label = label_for()
+        label.name = f"/staging/ck{os.sep}kernel.xml"
+        with pytest.raises(IndexError):
+            label._pick_val_label([], "/bundle/ck/", exact_match=False)
+
+    # -- _find_prior_version_label ---------------------------------------
+
+    def test_find_prior_version_label_returns_hit(self, label_for, mocker):
+        label = label_for()
+        hit = "/bundle/spice_kernels/ck/kernel_old.xml"
+        mocker.patch(_PATCH_GLOB, side_effect=self._level1_hit(hit))
+        assert label._find_prior_version_label() == hit
+
+    def test_find_prior_version_label_returns_none_on_no_match(self, label_for, mocker):
+        label = label_for()
+        mocker.patch(_PATCH_GLOB, return_value=[])
+        assert label._find_prior_version_label() is None
+
+    # -- _find_similar_type_label -----------------------------------------
+
+    def test_find_similar_type_label_returns_hit(self, label_for, mocker):
+        label = label_for()
+        mocker.patch(_PATCH_GLOB, side_effect=[
+            ["/bundle/spice_kernels/ck/kern.bc"],
+            ["/bundle/spice_kernels/ck/kern.xml"],
+        ])
+        assert label._find_similar_type_label() == "/bundle/spice_kernels/ck/kern.xml"
+
+    def test_find_similar_type_label_returns_none_when_val_products_empty(self, label_for, mocker):
+        label = label_for()
+        mocker.patch(_PATCH_GLOB, return_value=[])
+        assert label._find_similar_type_label() is None
+
+    # -- _find_insight_fallback_label -------------------------------------
+
+    def test_find_insight_fallback_label_returns_hit_and_logs(self, label_for, mocker):
+        label = label_for()
+        mocker.patch(_PATCH_GLOB, side_effect=[
+            ["/root/data/insight_spice/spice_kernels/ck/insight_ck.bc"],
+            ["/root/data/insight_spice/spice_kernels/ck/insight_ck.xml"],
+        ])
+        mock_log = mocker.patch("pds.naif_pds4_bundler.classes.label.label.logging.warning")
+        result = label._find_insight_fallback_label()
+        assert result == "/root/data/insight_spice/spice_kernels/ck/insight_ck.xml"
+        # The "Comparing with..." message must only fire on success, and
+        # must be the ONLY warning logged (no leftover "not found" message).
+        mock_log.assert_called_once_with("-- Comparing with InSight test label.")
+
+    def test_find_insight_fallback_label_returns_none_when_val_products_empty(self, label_for, mocker):
+        label = label_for()
+        mocker.patch(_PATCH_GLOB, return_value=[])
+        mock_log = mocker.patch("pds.naif_pds4_bundler.classes.label.label.logging.warning")
+        assert label._find_insight_fallback_label() is None
+        mock_log.assert_called_once_with("-- No label for comparison found.")


### PR DESCRIPTION
## 🗒️ Summary
Decomposes `PDSLabel.compare()`'s three fallback strategies (prior-version lookup, same-type lookup, InSight-test-data fallback) into three private methods — `_find_prior_version_label`, `_find_similar_type_label`, `_find_insight_fallback_label`
— plus two shared helpers extracted from their common scaffolding:
`_val_label_directory` (the identical path-building block, triplicated across the three strategies) and `_pick_val_label` (the collection/bundle/other glob-selection block, duplicated between strategies 2 and 3). `compare()` is reduced to
`_find_prior_version_label() or _find_similar_type_label() or _find_insight_fallback_label()`, per the return-`None` control-flow style resolved in the issue.

Three real bugs found and fixed beyond the pure decomposition:
- The three bare `except BaseException:` blocks silently swallowed `SystemExit`/`KeyboardInterrupt`/`GeneratorExit`; narrowed to `except Exception:`.
- `val_products[-1].split(".")[0]` truncated the filename stem at the *first* dot in the path rather than the last one before the extension — wrong for any product name with more than one dot. Replaced with `Path(...).with_suffix("")`.
- The "collection"/"bundle" matching rule in the selection block genuinely differed between strategies 2 and 3 (substring-of-basename vs. exact-path-component). Checked against this codebase's actual generated filenames
  (`bundle_{mission}_spice_v{release}.xml`, `collection_{name}_inventory_v*.csv`) — the exact-component rule could never match a real file, so it was a bug (most likely a missing `[-1]`), not a deliberate stricter check. Unified on the substring rule that actually matches production naming.

A Windows CI run on this branch then surfaced a portability bug in the path-building itself: hardcoded `"/"` concatenation and plain `self.name.split(os.sep)` don't round-trip correctly through `pathlib`'s native-separator rendering on Windows. Replaced the remaining hardcoded `/` and `str.split(os.sep)` calls with `Path` joins and
`Path(...).name`/`.parent.name`.

## ⚙️ Test Data and/or Report
Regression tests included: new `TestPDSLabelCompareHelpers` class in `test_classes_label.py` (direct unit tests for all five extracted helpers), alongside the existing `TestPDSLabelCompare` integration tests (all three fallback levels, all branches), which still pass.

    pytest tests/npb/test_classes_label.py --cov-branch -v
    56 passed

    Name                                                  Stmts   Miss Branch BrPart  Cover
    ----------------------------------------------------------------------------------------
    src/pds/naif_pds4_bundler/classes/label/label.py        144      0     50      0   100%

    Full merge-gate suite (pytest tests/npb/ --cov-branch):
    1840 passed, 7 skipped, 1 xfailed, 99% overall coverage

Manual verification:
* `grep -n "except BaseException" src/pds/naif_pds4_bundler/classes/label/label.py` → no output
* `grep -n "split(os.sep)" src/pds/naif_pds4_bundler/classes/label/label.py` (scoped to
  `compare()`'s helpers, lines 161-328) → no output
* Windows CI (`windows-latest`): initial push failed 4 tests on path-separator
  assumptions in test literals (not production code); fixed by switching remaining
  hardcoded `/` and `str.split(os.sep)` in `label.py` to `pathlib`, verified against
  `pathlib`'s Windows semantics, pushed for re-verification.

## ♻️ Related Issues
Fixes #323