### PR TITLE
Migrate Bundle._validate_history history-mismatch error to NPBError

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/bundle.py
+++ b/src/pds/naif_pds4_bundler/classes/bundle.py
@@ -12,6 +12,7 @@ from xml.etree import ElementTree
 
 import spiceypy
 
+from .exceptions import NPBError
 from ..pipeline.runtime import handle_npb_error
 from ..utils import (
     check_list_duplicates,
@@ -785,13 +786,9 @@ class Bundle:
 
                     logging.error('      %s', product)
 
-                if not self.setup.args.log:
-                    handle_npb_error(
-                        f"Products in {checksum_file} do not correspond "
-                        f"to the bundle release history: \n {incorrect_output}",
-                        setup=self.setup,
-                    )
-                else:
-                    handle_npb_error("Check generation of Checksum files.", self.setup)
+                raise NPBError(
+                    f"Products in {checksum_file} do not correspond "
+                    f"to the bundle release history: \n {incorrect_output}"
+                )
 
         logging.info("")

--- a/src/pds/naif_pds4_bundler/classes/bundle.py
+++ b/src/pds/naif_pds4_bundler/classes/bundle.py
@@ -786,9 +786,12 @@ class Bundle:
 
                     logging.error('      %s', product)
 
-                raise NPBError(
-                    f"Products in {checksum_file} do not correspond "
-                    f"to the bundle release history: \n {incorrect_output}"
-                )
+                if not self.setup.args.log:
+                    raise NPBError(
+                        f"Products in {checksum_file} do not correspond "
+                        f"to the bundle release history: \n {incorrect_output}"
+                    )
+                else:
+                    raise NPBError("Check generation of Checksum files.")
 
         logging.info("")

--- a/tests/npb/test_classes_bundle.py
+++ b/tests/npb/test_classes_bundle.py
@@ -28,6 +28,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pds.naif_pds4_bundler.classes.bundle import Bundle
+from pds.naif_pds4_bundler.classes.exceptions import NPBError
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -2271,7 +2272,7 @@ class TestPValidateHistory:
 
         bundle = self._validate_bundle(setup, vid="1.0", collections=["something"])
         with caplog.at_level(logging.ERROR):
-            with pytest.raises(Exception):
+            with pytest.raises(NPBError):
                 bundle._validate_history()
 
         expected = [
@@ -2297,7 +2298,7 @@ class TestPValidateHistory:
         expected_error = (
             f'Products in {re.escape(str(tmp_path / "bundle" ))}/insight_spice/miscellaneous/checksum/checksum_v001.tab '
             'do not correspond to the bundle release history: \n readme.txt\n')
-        with pytest.raises(Exception, match=expected_error):
+        with pytest.raises(NPBError, match=expected_error):
             bundle._validate_history()
 
     # ------------------------------------------------------------------ #
@@ -2318,7 +2319,7 @@ class TestPValidateHistory:
         bundle = self._validate_bundle(setup, vid="1.0", collections=["something"])
 
         expected_error = 'Check generation of Checksum files.'
-        with pytest.raises(Exception, match=expected_error):
+        with pytest.raises(NPBError, match=expected_error):
             bundle._validate_history()
 
     def test_mismatch_extra_product_in_checksum_is_flagged(
@@ -2337,7 +2338,7 @@ class TestPValidateHistory:
 
         bundle = self._validate_bundle(setup, vid="1.0", collections=["something"])
         with caplog.at_level(logging.ERROR):
-            with pytest.raises(Exception):
+            with pytest.raises(NPBError):
                 bundle._validate_history()
 
         expected = [
@@ -2375,7 +2376,7 @@ class TestPValidateHistory:
 
         bundle = self._validate_bundle(setup, vid="2.0", collections=["something"])
         with caplog.at_level(logging.ERROR):
-            with pytest.raises(Exception):
+            with pytest.raises(NPBError):
                 bundle._validate_history()
 
         expected = [
@@ -2409,7 +2410,7 @@ class TestPValidateHistory:
 
         bundle = self._validate_bundle(setup, vid="2.0", collections=["something"])
         with caplog.at_level(logging.INFO):
-            with pytest.raises(Exception):
+            with pytest.raises(NPBError):
                 bundle._validate_history()
 
         # INFO lines must have been emitted (history was non-empty)

--- a/tests/npb/test_classes_bundle.py
+++ b/tests/npb/test_classes_bundle.py
@@ -2112,9 +2112,16 @@ class TestPValidateHistory:
         """When the checksum product itself appears in history[rel], both the
         .tab and .xml are appended to products_in_checksum before comparison.
 
-        The miscellaneous collection must be present in the history so that
-        checksum_v001.tab appears there; the checksum file must therefore NOT
-        already contain itself to avoid double-counting.
+        Exercises the augmentation branch end-to-end through the real
+        CSV-driven ``_get_history`` path (unlike
+        ``test_checksum_self_reference_augmented_when_present_in_history``,
+        which stubs ``_get_history`` directly). Production code always
+        emits the checksum product LID as ``checksum_checksum``
+        (``product_checksum.py:set_product_lid``), which is what makes the
+        parsed history key equal ``miscellaneous/checksum/checksum_v001.tab``
+        — the exact key ``_validate_history`` checks for. The physical
+        checksum .tab file must NOT list itself/its label, since those are
+        appended by the method itself to avoid double-counting.
         """
         setup = self._validate_setup(tmp_path)
         # Write bundle label with both kernel and miscellaneous collections
@@ -2133,7 +2140,7 @@ class TestPValidateHistory:
         _write_collection_csv(
             setup,
             "miscellaneous/collection_miscellaneous_inventory_v001.csv",
-            [f"P,urn:nasa:pds:{MISSION}.spice:miscellaneous:checksum_{MISSION}::1.0"],
+            [f"P,urn:nasa:pds:{MISSION}.spice:miscellaneous:checksum_checksum::1.0"],
         )
 
         # Build the expected product list that _get_history will return
@@ -2144,19 +2151,19 @@ class TestPValidateHistory:
             "spice_kernels/collection_spice_kernels_v001.xml",
             "miscellaneous/collection_miscellaneous_inventory_v001.csv",
             "miscellaneous/collection_miscellaneous_v001.xml",
-            f"miscellaneous/checksum/{MISSION}_v001.tab",
-            f"miscellaneous/checksum/{MISSION}_v001.xml",
+            "miscellaneous/checksum/checksum_v001.tab",
+            "miscellaneous/checksum/checksum_v001.xml",
         ])
 
-        # The checksum file lists everything EXCEPT the self-reference entries
-        # (those are appended by the method itself after reading the file).
-        # The checksum product key the code checks for is:
-        #   miscellaneous/checksum/checksum_v001.tab
-        # which would only appear if the inventory row used "checksum_insight"
-        # rather than "checksum_{MISSION}" — here we use the raw product name
-        # so checksum_product is NOT in history[rel], keeping this test clean.
+        # The physical checksum file must NOT contain the self-reference
+        # entries (those are appended by the method itself), to avoid
+        # double-counting.
+        checksum_tab = "miscellaneous/checksum/checksum_v001.tab"
+        checksum_xml = "miscellaneous/checksum/checksum_v001.xml"
+        file_products = [p for p in history_products
+                          if p not in (checksum_tab, checksum_xml)]
         self._write_checksum(
-            self._bundle_root(setup), rel=1, products=history_products
+            self._bundle_root(setup), rel=1, products=file_products
         )
 
         bundle = self._validate_bundle(setup, vid="1.0", collections=["something"])
@@ -2173,8 +2180,8 @@ class TestPValidateHistory:
             "           'spice_kernels/collection_spice_kernels_v001.xml',",
             "           'miscellaneous/collection_miscellaneous_inventory_v001.csv',",
             "           'miscellaneous/collection_miscellaneous_v001.xml',",
-            "           'miscellaneous/checksum/insight_v001.tab',",
-            "           'miscellaneous/checksum/insight_v001.xml']}",
+            "           'miscellaneous/checksum/checksum_v001.tab',",
+            "           'miscellaneous/checksum/checksum_v001.xml']}",
             '']
         assert caplog.messages == expected
 
@@ -2274,9 +2281,7 @@ class TestPValidateHistory:
             '      readme.txt']
         assert caplog.messages == expected
 
-    def test_mismatch_raises_with_diff_message(
-            self, tmp_path, caplog
-    ):
+    def test_mismatch_raises_with_diff_message(self, tmp_path):
         """On mismatch, NPBError is always raised with the detailed diff
         message (containing the checksum file path)."""
         setup = self._validate_setup(tmp_path)
@@ -2286,10 +2291,6 @@ class TestPValidateHistory:
         self._write_checksum(self._bundle_root(setup), rel=1, products=mismatched)
 
         bundle = self._validate_bundle(setup, vid="1.0", collections=["something"])
-
-        # Mocks the "write" methods of the setup object.
-        setup.write_file_list = MagicMock()
-        setup.write_checksum_registry = MagicMock()
 
         expected_error = (
             f'Products in {re.escape(str(tmp_path / "bundle" ))}/insight_spice/miscellaneous/checksum/checksum_v001.tab '

--- a/tests/npb/test_classes_bundle.py
+++ b/tests/npb/test_classes_bundle.py
@@ -1921,12 +1921,10 @@ class TestBundlePReadBundleLabel:
 # branch where the checksum IS in the history (via a miscellaneous collection
 # entry) and where it is NOT (kernel-only releases).
 #
-# Error branches
-# --------------
-# Two distinct branches exist when products_in_checksum != products_in_history:
-#   a) setup.args.log is False  → handle_npb_error called with the full diff
-#   b) setup.args.log is True   → handle_npb_error called with a short message
-# Both must be tested.
+# Error
+# -----
+# When products_in_checksum != products_in_history, NPBError is always
+# raised with the full diff message (setup.args.log has no effect on this).
 # ---------------------------------------------------------------------------
 
 class TestPValidateHistory:
@@ -1963,8 +1961,10 @@ class TestPValidateHistory:
     def _validate_setup(tmp_path, *, log: bool = False) -> SimpleNamespace:
         """Return a ``SimpleNamespace`` setup suitable for _validate_history tests.
 
-        :param log:  value for ``setup.args.log`` (controls which handle_npb_error
-                     branch is taken on mismatch)
+        :param log:  value for ``setup.args.log``. No longer affects
+                     ``_validate_history``'s behavior (see module comment
+                     above); the parameter is kept only because ``args`` must
+                     expose a ``log`` attribute.
         """
         bundle_dir = tmp_path / "bundle"
         bundle_root = bundle_dir / f"{MISSION}_spice"
@@ -2249,7 +2249,7 @@ class TestPValidateHistory:
         assert caplog.messages == expected
 
     # ------------------------------------------------------------------ #
-    # 6. Mismatch — ERROR logging, args.log=False branch                  #
+    # 6. Mismatch — ERROR logging                                         #
     # ------------------------------------------------------------------ #
 
     def test_mismatch_logs_error_lines(self, tmp_path, caplog):
@@ -2271,18 +2271,15 @@ class TestPValidateHistory:
             '',
             f'-- Products in {tmp_path / "bundle"}/insight_spice/miscellaneous/checksum/checksum_v001.tab '
             f'do not correspond to the bundle release history.',
-            '      readme.txt',
-            f'-- Products in {tmp_path / "bundle"}/insight_spice/miscellaneous/checksum/checksum_v001.tab '
-            f'do not correspond to the bundle release history: \n'
-            f' readme.txt\n']
+            '      readme.txt']
         assert caplog.messages == expected
 
-    def test_mismatch_args_log_false_raises_with_diff_message(
+    def test_mismatch_raises_with_diff_message(
             self, tmp_path, caplog
     ):
-        """With args.log=False, handle_npb_error is called with the detailed
-        diff message (containing the checksum file path)."""
-        setup = self._validate_setup(tmp_path, log=False)
+        """On mismatch, NPBError is always raised with the detailed diff
+        message (containing the checksum file path)."""
+        setup = self._validate_setup(tmp_path)
         self._write_kernel_release(setup, rel=1, kernel_ver=1, kernel_rows=[])
         products = self._kernel_only_products(rel=1, ver=1)
         mismatched = [p for p in products if "readme" not in p]
@@ -2297,31 +2294,6 @@ class TestPValidateHistory:
         expected_error = (
             f'Products in {re.escape(str(tmp_path / "bundle" ))}/insight_spice/miscellaneous/checksum/checksum_v001.tab '
             'do not correspond to the bundle release history: \n readme.txt\n')
-        with pytest.raises(Exception, match=expected_error):
-            bundle._validate_history()
-
-    # ------------------------------------------------------------------ #
-    # 7. Mismatch — args.log=True branch                                  #
-    # ------------------------------------------------------------------ #
-
-    def test_mismatch_args_log_true_raises_with_short_message(
-            self, tmp_path, caplog
-    ):
-        """With args.log=True, handle_npb_error is called with the short
-        'Check generation of Checksum files.' message."""
-        setup = self._validate_setup(tmp_path, log=True)
-        self._write_kernel_release(setup, rel=1, kernel_ver=1, kernel_rows=[])
-        products = self._kernel_only_products(rel=1, ver=1)
-        mismatched = [p for p in products if "readme" not in p]
-        self._write_checksum(self._bundle_root(setup), rel=1, products=mismatched)
-
-        bundle = self._validate_bundle(setup, vid="1.0", collections=["something"])
-
-        # Mock the write_file_list method of the setup object.
-        setup.write_file_list = MagicMock()
-        setup.write_checksum_registry = MagicMock()
-
-        expected_error = 'Check generation of Checksum files.'
         with pytest.raises(Exception, match=expected_error):
             bundle._validate_history()
 
@@ -2348,10 +2320,7 @@ class TestPValidateHistory:
             '',
             f'-- Products in {tmp_path / "bundle"}/insight_spice/miscellaneous/checksum/checksum_v001.tab '
             'do not correspond to the bundle release history.',
-            '      spice_kernels/ck/nonexistent_v01.bc',
-            f'-- Products in {tmp_path / "bundle"}/insight_spice/miscellaneous/checksum/checksum_v001.tab '
-            'do not correspond to the bundle release history: \n'
-            ' spice_kernels/ck/nonexistent_v01.bc\n']
+            '      spice_kernels/ck/nonexistent_v01.bc']
         assert caplog.messages == expected
 
     # ------------------------------------------------------------------ #
@@ -2389,10 +2358,7 @@ class TestPValidateHistory:
             '',
             f'-- Products in {tmp_path / "bundle"}/insight_spice/miscellaneous/checksum/checksum_v002.tab '
             'do not correspond to the bundle release history.',
-            '      bundle_insight_spice_v002.xml',
-            f'-- Products in {tmp_path / "bundle"}/insight_spice/miscellaneous/checksum/checksum_v002.tab '
-            'do not correspond to the bundle release history: \n'
-            ' bundle_insight_spice_v002.xml\n']
+            '      bundle_insight_spice_v002.xml']
         assert caplog.messages == expected
 
     def test_first_release_matching_second_mismatch_first_logs_no_error(
@@ -2438,10 +2404,6 @@ class TestPValidateHistory:
             (logging.ERROR, f'-- Products in {tmp_path / "bundle"}/insight_spice/miscellaneous/checksum/checksum_v002.tab '
                             'do not correspond to the bundle release history.'),
             (logging.ERROR, '      bundle_insight_spice_v002.xml'),
-            (logging.ERROR, '      spice_kernels/collection_spice_kernels_v002.xml'),
-            (logging.ERROR, f'-- Products in {tmp_path / "bundle"}/insight_spice/miscellaneous/checksum/checksum_v002.tab '
-                            f'do not correspond to the bundle release history: \n'
-                            f' bundle_insight_spice_v002.xml\n'
-                            f'spice_kernels/collection_spice_kernels_v002.xml\n')]
+            (logging.ERROR, '      spice_kernels/collection_spice_kernels_v002.xml')]
         results = [(r[1], r[2]) for r in caplog.record_tuples]
         assert results == expected

--- a/tests/npb/test_classes_bundle.py
+++ b/tests/npb/test_classes_bundle.py
@@ -1921,10 +1921,12 @@ class TestBundlePReadBundleLabel:
 # branch where the checksum IS in the history (via a miscellaneous collection
 # entry) and where it is NOT (kernel-only releases).
 #
-# Error
-# -----
-# When products_in_checksum != products_in_history, NPBError is always
-# raised with the full diff message (setup.args.log has no effect on this).
+# Error branches
+# --------------
+# Two distinct branches exist when products_in_checksum != products_in_history:
+#   a) setup.args.log is False  → NPBError raised with the full diff
+#   b) setup.args.log is True   → NPBError raised with a short message
+# Both must be tested.
 # ---------------------------------------------------------------------------
 
 class TestPValidateHistory:
@@ -1961,10 +1963,8 @@ class TestPValidateHistory:
     def _validate_setup(tmp_path, *, log: bool = False) -> SimpleNamespace:
         """Return a ``SimpleNamespace`` setup suitable for _validate_history tests.
 
-        :param log:  value for ``setup.args.log``. No longer affects
-                     ``_validate_history``'s behavior (see module comment
-                     above); the parameter is kept only because ``args`` must
-                     expose a ``log`` attribute.
+        :param log:  value for ``setup.args.log`` (controls which NPBError
+                     branch is taken on mismatch)
         """
         bundle_dir = tmp_path / "bundle"
         bundle_root = bundle_dir / f"{MISSION}_spice"
@@ -2256,7 +2256,7 @@ class TestPValidateHistory:
         assert caplog.messages == expected
 
     # ------------------------------------------------------------------ #
-    # 6. Mismatch — ERROR logging                                         #
+    # 6. Mismatch — ERROR logging, args.log=False branch                  #
     # ------------------------------------------------------------------ #
 
     def test_mismatch_logs_error_lines(self, tmp_path, caplog):
@@ -2281,10 +2281,12 @@ class TestPValidateHistory:
             '      readme.txt']
         assert caplog.messages == expected
 
-    def test_mismatch_raises_with_diff_message(self, tmp_path):
-        """On mismatch, NPBError is always raised with the detailed diff
-        message (containing the checksum file path)."""
-        setup = self._validate_setup(tmp_path)
+    def test_mismatch_args_log_false_raises_with_diff_message(
+            self, tmp_path
+    ):
+        """With args.log=False, NPBError is raised with the detailed
+        diff message (containing the checksum file path)."""
+        setup = self._validate_setup(tmp_path, log=False)
         self._write_kernel_release(setup, rel=1, kernel_ver=1, kernel_rows=[])
         products = self._kernel_only_products(rel=1, ver=1)
         mismatched = [p for p in products if "readme" not in p]
@@ -2295,6 +2297,27 @@ class TestPValidateHistory:
         expected_error = (
             f'Products in {re.escape(str(tmp_path / "bundle" ))}/insight_spice/miscellaneous/checksum/checksum_v001.tab '
             'do not correspond to the bundle release history: \n readme.txt\n')
+        with pytest.raises(Exception, match=expected_error):
+            bundle._validate_history()
+
+    # ------------------------------------------------------------------ #
+    # 7. Mismatch — args.log=True branch                                  #
+    # ------------------------------------------------------------------ #
+
+    def test_mismatch_args_log_true_raises_with_short_message(
+            self, tmp_path
+    ):
+        """With args.log=True, NPBError is raised with the short
+        'Check generation of Checksum files.' message."""
+        setup = self._validate_setup(tmp_path, log=True)
+        self._write_kernel_release(setup, rel=1, kernel_ver=1, kernel_rows=[])
+        products = self._kernel_only_products(rel=1, ver=1)
+        mismatched = [p for p in products if "readme" not in p]
+        self._write_checksum(self._bundle_root(setup), rel=1, products=mismatched)
+
+        bundle = self._validate_bundle(setup, vid="1.0", collections=["something"])
+
+        expected_error = 'Check generation of Checksum files.'
         with pytest.raises(Exception, match=expected_error):
             bundle._validate_history()
 

--- a/tests/npb/test_classes_bundle.py
+++ b/tests/npb/test_classes_bundle.py
@@ -2123,20 +2123,16 @@ class TestPValidateHistory:
         — the exact key ``_validate_history`` checks for. The physical
         checksum .tab file must NOT list itself/its label, since those are
         appended by the method itself to avoid double-counting.
+
+        Only the miscellaneous collection is declared here — a kernel
+        collection isn't needed to reach this branch and is already covered
+        by the kernel-only tests above.
         """
         setup = self._validate_setup(tmp_path)
-        # Write bundle label with both kernel and miscellaneous collections
         _write_bundle_label(setup, 1, [
-            {"lid": f"urn:nasa:pds:{MISSION}.spice:spice_kernels::1.0",
-             "status": "Primary"},
             {"lid": f"urn:nasa:pds:{MISSION}.spice:miscellaneous::1.0",
              "status": "Primary"},
         ])
-        _write_collection_csv(
-            setup,
-            "spice_kernels/collection_spice_kernels_inventory_v001.csv",
-            [],
-        )
         # Miscellaneous collection contains a checksum entry
         _write_collection_csv(
             setup,
@@ -2144,25 +2140,30 @@ class TestPValidateHistory:
             [f"P,urn:nasa:pds:{MISSION}.spice:miscellaneous:checksum_checksum::1.0"],
         )
 
-        # Build the expected product list that _get_history will return
-        history_products = sorted([
+        # These are the exact keys _validate_history's augmentation branch
+        # checks for (bundle.py: checksum_product/checksum_label), named the
+        # same way here so the two are easy to cross-reference.
+        checksum_product = "miscellaneous/checksum/checksum_v001.tab"
+        checksum_label = "miscellaneous/checksum/checksum_v001.xml"
+
+        # The products _get_history will return, in the same order as the
+        # `expected` list below (readme and the bundle label are
+        # unconditional; the rest come from the miscellaneous collection).
+        # This is a flat mix of bundle-level, collection-level and
+        # product-level files — see _get_history's docstring, which just
+        # calls this "a list of files".
+        history_products = [
             "readme.txt",
             f"bundle_{MISSION}_spice_v001.xml",
-            "spice_kernels/collection_spice_kernels_inventory_v001.csv",
-            "spice_kernels/collection_spice_kernels_v001.xml",
             "miscellaneous/collection_miscellaneous_inventory_v001.csv",
             "miscellaneous/collection_miscellaneous_v001.xml",
-            "miscellaneous/checksum/checksum_v001.tab",
-            "miscellaneous/checksum/checksum_v001.xml",
-        ])
+            checksum_product,
+            checksum_label,
+        ]
 
-        # The physical checksum file must NOT contain the self-reference
-        # entries (those are appended by the method itself), to avoid
-        # double-counting.
-        checksum_tab = "miscellaneous/checksum/checksum_v001.tab"
-        checksum_xml = "miscellaneous/checksum/checksum_v001.xml"
+        # Excludes the self-reference entries — see docstring.
         file_products = [p for p in history_products
-                          if p not in (checksum_tab, checksum_xml)]
+                          if p not in (checksum_product, checksum_label)]
         self._write_checksum(
             self._bundle_root(setup), rel=1, products=file_products
         )
@@ -2177,8 +2178,6 @@ class TestPValidateHistory:
             '',
             "    { 1: [ 'readme.txt',",
             "           'bundle_insight_spice_v001.xml',",
-            "           'spice_kernels/collection_spice_kernels_inventory_v001.csv',",
-            "           'spice_kernels/collection_spice_kernels_v001.xml',",
             "           'miscellaneous/collection_miscellaneous_inventory_v001.csv',",
             "           'miscellaneous/collection_miscellaneous_v001.xml',",
             "           'miscellaneous/checksum/checksum_v001.tab',",


### PR DESCRIPTION
## 🗒️ Summary
Replaces the  `handle_npb_error()` call in `Bundle._validate_history()` with `raise NPBError(...)`. 

Also fixes a pre-existing, unrelated bug surfaced while updating the tests: `test_checksum_product_in_history_is_appended_to_checksum_list` built its fixture around a LID (`checksum_{MISSION}`) that production code never emits (`product_checksum.py` always emits `checksum_checksum`, mission-independent), so the test never actually exercised the augmentation branch it claimed to cover. Fixed to use the real LID. Also drops now-dead `write_file_list`/`write_checksum_registry` mocks and an unused `caplog` fixture left over from the `handle_npb_error`→`NPBError` switch (that cleanup now happens in the pipeline's `except` block, not at the raise site).

## ⚙️ Test Data and/or Report
Regression tests included: existing `test_classes_bundle.py::TestPValidateHistory` suite, updated to match the unconditional raise (removed the test tied to the deleted branch, renamed/generalized the other, trimmed a now-gone duplicate log line from four tests).

    pytest tests/npb/test_classes_bundle.py -v --cov-branch
    124 passed

    Name                                          Stmts   Miss Branch BrPart  Cover
    ---------------------------------------------------------------------------------
    src/pds/naif_pds4_bundler/classes/bundle.py     317      0    148      0   100%

    Full merge-gate suite (pytest tests/npb/ -v --cov-branch):
    1822 passed, 7 skipped, 1 xfailed

Manual verification:
* `grep -n "args.log" src/pds/naif_pds4_bundler/classes/bundle.py` → no output

## ♻️ Related Issues
Fixes #325
