### PR TITLE
Refactored: make PDSLabel._pick_val_label's no-match guard reachable

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -173,6 +173,9 @@ class PDSLabel:
         """
         logging.info("-- Comparing label...")
 
+        # Try each fallback level in turn and keep the first match found:
+        # an older version of this label, then a label of the same type, then
+        # the InSight stock example.
         val_label = (self._find_prior_version_label() or
                      self._find_similar_type_label() or
                      self._find_insight_fallback_label())
@@ -205,10 +208,14 @@ class PDSLabel:
                 f"{val_label_path}{os.sep}{val_label_name[0:i]}*.xml")
 
             if val_labels:
+                # Keep the newest match (highest version number) found so far,
+                # in case a longer prefix finds nothing.
                 val_label = max(val_labels)
                 match_flag = True
 
             else:
+                # A longer prefix only narrows the search, so if this length
+                # finds nothing, no longer prefix will either.
                 match_flag = False
             i += 1
 
@@ -230,6 +237,8 @@ class PDSLabel:
             return str(self._pick_val_label(base_dir))
 
         except Exception:
+            # Not finding a match isn't an error here, just a signal to try the
+            # next fallback level, so we catch broadly on purpose.
             logging.warning("-- No similar label has been found.")
 
             return None
@@ -251,6 +260,8 @@ class PDSLabel:
             return val_label
 
         except Exception:
+            # This is the last fallback level, so reaching here means no label
+            # was found anywhere to compare against.
             logging.warning("-- No label for comparison found.")
 
             return None
@@ -266,6 +277,11 @@ class PDSLabel:
         """
         val_label_path = Path(base_dir) / self.product.collection.name
 
+        # spice_kernels and miscellaneous store their labels one level deeper,
+        # in a subdirectory per kernel/product type (e.g. "ck", "orb"). A
+        # collection label sits in the collection directory itself, not in one
+        # of those subdirectories, so it's excluded from getting that extra
+        # subdirectory appended.
         if (self.product.collection.name in ("spice_kernels", "miscellaneous")
                 and ("collection" not in self.name)):
 
@@ -301,6 +317,8 @@ class PDSLabel:
         if not matches:
             raise Exception("No label for comparison found.")
 
+        # File names carry a version number, so the alphabetically greatest
+        # path is also the newest version.
         matched = max(matches)
 
         if "bundle" in basename:
@@ -313,8 +331,8 @@ class PDSLabel:
 
         candidate = matched.with_suffix(".xml")
 
-        # The stem match doesn't guarantee a label was actually generated
-        # for that product (e.g. it may have been skipped or failed).
+        # The stem match doesn't guarantee a label was actually generated for
+        # that product (e.g. it may have been skipped or failed).
         if not candidate.exists():
             raise Exception("No label for comparison found.")
 

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Optional
 
 from ...utils import add_carriage_return, compare_files
+from ..exceptions import NPBError
 
 
 class PDSLabel:
@@ -301,21 +302,33 @@ class PDSLabel:
             lexicographically greatest (newest) entry is used to derive
             the label name.
         :param val_label_path: Directory the label is expected to live in.
+            Only the "bundle" branch uses this directly; the
+            "collection"/else branches derive their directory implicitly
+            from ``val_products`` instead, and rely on the caller having
+            globbed ``val_products`` from this same ``val_label_path`` in
+            the first place.
         :return: Path to the selected validation label.
-        :raises Exception: If no label for comparison can be found.
+        :raises NPBError: If no label for comparison can be found.
         """
         basename = Path(self.name).name
 
         if "collection" in basename:
-            stem = Path(max(val_products).replace("inventory_", "")).with_suffix(".xml")
-            val_label = glob.glob(str(stem))[0]
+            matched = Path(max(val_products))
+            stem = matched.with_name(matched.name.replace("inventory_", "")).with_suffix(".xml")
+            matches = glob.glob(str(stem))
+            if not matches:
+                raise NPBError("No label for comparison found.")
+            val_label = matches[0]
         elif "bundle" in basename:
-            val_label = max(glob.glob(f"{val_label_path}bundle_*.xml"))
+            matches = glob.glob(f"{val_label_path}bundle_*.xml")
+            if not matches:
+                raise NPBError("No label for comparison found.")
+            val_label = max(matches)
         else:
             stem = Path(max(val_products)).with_suffix(".xml")
-            val_label = glob.glob(str(stem))[0]
-
-        if not val_label:
-            raise Exception("No label for comparison found.")
+            matches = glob.glob(str(stem))
+            if not matches:
+                raise NPBError("No label for comparison found.")
+            val_label = matches[0]
 
         return val_label

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -7,9 +7,6 @@ from pathlib import Path
 from typing import Optional
 
 from ...utils import add_carriage_return, compare_files
-from ..exceptions import NPBError
-
-_NO_VAL_LABEL_FOUND_MESSAGE = "No label for comparison found."
 
 
 class PDSLabel:
@@ -228,14 +225,8 @@ class PDSLabel:
         :return: Path to the matching label, or ``None`` if none is found.
         """
         try:
-            val_label_path = self._val_label_directory(
-                str(Path(self.setup.bundle_directory) / f"{self.setup.mission_acronym}_spice")
-            )
-
-            product_extension = self.product.name.split(".")[-1]
-            val_products = glob.glob(f"{val_label_path}*.{product_extension}")
-
-            return self._pick_val_label(val_products, val_label_path)
+            base_dir = Path(self.setup.bundle_directory) / f"{self.setup.mission_acronym}_spice"
+            return str(self._pick_val_label(base_dir))
 
         except Exception:
             logging.warning("-- No similar label has been found.")
@@ -251,17 +242,8 @@ class PDSLabel:
         :return: Path to the matching label, or ``None`` if none is found.
         """
         try:
-            val_label_path = self._val_label_directory(
-                str(Path(self.setup.root_dir) / "data" / "insight_spice")
-            )
-
-            #
-            # Simply pick the last one
-            #
-            product_extension = self.product.name.split(".")[-1]
-            val_products = glob.glob(f"{val_label_path}*.{product_extension}")
-
-            val_label = self._pick_val_label(val_products, val_label_path)
+            base_dir = Path(self.setup.root_dir) / "data" / "insight_spice"
+            val_label = str(self._pick_val_label(base_dir))
             logging.warning("-- Comparing with InSight test label.")
             return val_label
 
@@ -287,50 +269,49 @@ class PDSLabel:
 
         return f"{val_label_path}{os.sep}"
 
-    def _pick_val_label(self, val_products: list[str], val_label_path: str) -> str:
-        """Select a validation label from val_products/val_label_path.
+    def _pick_val_label(self, base_dir: Path) -> Path:
+        """Select a validation label from a candidate directory.
 
         "collection"/"bundle" are matched as a substring of the label's
         basename (``Path(self.name).name``), not as a standalone path
         component. Real product names embed them as a prefix -- e.g.
         "collection_spice_kernels_v001.xml", "bundle_insight_spice_v009.xml"
         -- never as a bare directory/path segment, so an exact-component
-        check would never match real files. The similar-type and
-        InSight-fallback lookups used to apply different rules here
-        (substring vs. exact-component); both now use the substring rule
-        that actually matches production naming.
+        check would never match real files.
 
-        :param val_products: Candidate product paths, in any order; the
-            lexicographically greatest (newest) entry is used to derive
-            the label name.
-        :param val_label_path: Directory the label is expected to live in.
-            Only the "bundle" branch uses this directly; the
-            "collection"/else branches derive their directory implicitly
-            from ``val_products`` instead, and rely on the caller having
-            globbed ``val_products`` from this same ``val_label_path`` in
-            the first place.
+        The "bundle" branch is checked first and returns before computing
+        any product candidates: it derives its match entirely from the
+        directory built from ``base_dir`` and never needs a product
+        candidate, so checking it first avoids an unused glob on every
+        bundle-label comparison. Everything else shares one path: glob
+        once for the product's own extension, then -- for "collection"
+        labels only -- strip an "inventory_" prefix before deriving the
+        candidate name.
+
+        :param base_dir: Root directory to search under.
         :return: Path to the selected validation label.
-        :raises NPBError: If no label for comparison can be found.
+        :raises Exception: If no label for comparison can be found.
         """
+        message = "No label for comparison found."
+        label_dir = Path(self._val_label_directory(str(base_dir)))
         basename = Path(self.name).name
 
-        if "collection" in basename:
-            matched = Path(max(val_products))
-            stem = matched.with_name(matched.name.replace("inventory_", "")).with_suffix(".xml")
-            matches = glob.glob(str(stem))
+        if "bundle" in basename:
+            matches = list(label_dir.glob("bundle_*.xml"))
             if not matches:
-                raise NPBError(_NO_VAL_LABEL_FOUND_MESSAGE)
-            val_label = matches[0]
-        elif "bundle" in basename:
-            matches = glob.glob(f"{val_label_path}bundle_*.xml")
-            if not matches:
-                raise NPBError(_NO_VAL_LABEL_FOUND_MESSAGE)
-            val_label = max(matches)
-        else:
-            stem = Path(max(val_products)).with_suffix(".xml")
-            matches = glob.glob(str(stem))
-            if not matches:
-                raise NPBError(_NO_VAL_LABEL_FOUND_MESSAGE)
-            val_label = matches[0]
+                raise Exception(message)
+            return max(matches)
 
-        return val_label
+        extension = Path(self.product.name).suffix
+        val_products = list(label_dir.glob(f"*{extension}"))
+        if not val_products:
+            raise Exception(message)
+
+        matched = max(val_products)
+        candidate_name = (
+            matched.name.replace("inventory_", "") if "collection" in basename else matched.name
+        )
+        candidate = matched.with_name(candidate_name).with_suffix(".xml")
+        if candidate.exists():
+            return candidate
+        raise Exception(message)

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -173,15 +173,14 @@ class PDSLabel:
         """
         logging.info("-- Comparing label...")
 
-        val_label = (
-            self._find_prior_version_label()
-            or self._find_similar_type_label()
-            or self._find_insight_fallback_label()
-        )
+        val_label = (self._find_prior_version_label() or
+                     self._find_similar_type_label() or
+                     self._find_insight_fallback_label())
 
         if val_label:
             logging.info("")
-            compare_files(val_label, self.name, self.setup.working_directory, self.setup.diff)
+            compare_files(val_label, self.name, self.setup.working_directory,
+                          self.setup.diff)
 
     def _find_prior_version_label(self) -> Optional[str]:
         """Look for a different version of the same file (fallback level 1).
@@ -195,19 +194,20 @@ class PDSLabel:
         val_label = None
         match_flag = True
         val_label_path = self._val_label_directory(
-            str(Path(self.setup.bundle_directory) / f"{self.setup.mission_acronym}_spice")
-        )
+            Path(self.setup.bundle_directory) / f"{self.setup.mission_acronym}_spice")
 
         val_label_name = Path(self.name).name
         i = 1
 
         while match_flag and i < len(val_label_name) - 1:
+
             val_labels = glob.glob(
-                f"{val_label_path}{val_label_name[0:i]}*.xml"
-            )
+                f"{val_label_path}{os.sep}{val_label_name[0:i]}*.xml")
+
             if val_labels:
                 val_label = max(val_labels)
                 match_flag = True
+
             else:
                 match_flag = False
             i += 1
@@ -226,10 +226,12 @@ class PDSLabel:
         """
         try:
             base_dir = Path(self.setup.bundle_directory) / f"{self.setup.mission_acronym}_spice"
+
             return str(self._pick_val_label(base_dir))
 
         except Exception:
             logging.warning("-- No similar label has been found.")
+
             return None
 
     def _find_insight_fallback_label(self) -> Optional[str]:
@@ -245,13 +247,15 @@ class PDSLabel:
             base_dir = Path(self.setup.root_dir) / "data" / "insight_spice"
             val_label = str(self._pick_val_label(base_dir))
             logging.warning("-- Comparing with InSight test label.")
+
             return val_label
 
         except Exception:
             logging.warning("-- No label for comparison found.")
+
             return None
 
-    def _val_label_directory(self, base_dir: str) -> str:
+    def _val_label_directory(self, base_dir: Path) -> Path:
         """Build the candidate-label directory for the product's collection.
 
         Appends the kernel-type/product-type subdirectory when the
@@ -262,12 +266,12 @@ class PDSLabel:
         """
         val_label_path = Path(base_dir) / self.product.collection.name
 
-        if self.product.collection.name in ("spice_kernels", "miscellaneous") and (
-            "collection" not in self.name
-        ):
+        if (self.product.collection.name in ("spice_kernels", "miscellaneous")
+                and ("collection" not in self.name)):
+
             val_label_path = val_label_path / Path(self.name).parent.name
 
-        return f"{val_label_path}{os.sep}"
+        return val_label_path
 
     def _pick_val_label(self, base_dir: Path) -> Path:
         """Select a validation label from a candidate directory.
@@ -283,7 +287,7 @@ class PDSLabel:
         :return: Path to the selected validation label.
         :raises Exception: If no label for comparison can be found.
         """
-        val_label_path = Path(self._val_label_directory(str(base_dir)))
+        val_label_path = self._val_label_directory(base_dir)
         basename = Path(self.name).name
 
         # Bundle labels are matched directly by their own glob pattern;

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -9,6 +9,8 @@ from typing import Optional
 from ...utils import add_carriage_return, compare_files
 from ..exceptions import NPBError
 
+_NO_VAL_LABEL_FOUND_MESSAGE = "No label for comparison found."
+
 
 class PDSLabel:
     """Class to generate a PDS Label.
@@ -317,18 +319,18 @@ class PDSLabel:
             stem = matched.with_name(matched.name.replace("inventory_", "")).with_suffix(".xml")
             matches = glob.glob(str(stem))
             if not matches:
-                raise NPBError("No label for comparison found.")
+                raise NPBError(_NO_VAL_LABEL_FOUND_MESSAGE)
             val_label = matches[0]
         elif "bundle" in basename:
             matches = glob.glob(f"{val_label_path}bundle_*.xml")
             if not matches:
-                raise NPBError("No label for comparison found.")
+                raise NPBError(_NO_VAL_LABEL_FOUND_MESSAGE)
             val_label = max(matches)
         else:
             stem = Path(max(val_products)).with_suffix(".xml")
             matches = glob.glob(str(stem))
             if not matches:
-                raise NPBError("No label for comparison found.")
+                raise NPBError(_NO_VAL_LABEL_FOUND_MESSAGE)
             val_label = matches[0]
 
         return val_label

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -279,39 +279,39 @@ class PDSLabel:
         -- never as a bare directory/path segment, so an exact-component
         check would never match real files.
 
-        The "bundle" branch is checked first and returns before computing
-        any product candidates: it derives its match entirely from the
-        directory built from ``base_dir`` and never needs a product
-        candidate, so checking it first avoids an unused glob on every
-        bundle-label comparison. Everything else shares one path: glob
-        once for the product's own extension, then -- for "collection"
-        labels only -- strip an "inventory_" prefix before deriving the
-        candidate name.
-
         :param base_dir: Root directory to search under.
         :return: Path to the selected validation label.
         :raises Exception: If no label for comparison can be found.
         """
-        message = "No label for comparison found."
-        label_dir = Path(self._val_label_directory(str(base_dir)))
+        val_label_path = Path(self._val_label_directory(str(base_dir)))
         basename = Path(self.name).name
 
+        # Bundle labels are matched directly by their own glob pattern;
+        # everything else is derived from the newest matching product file.
         if "bundle" in basename:
-            matches = list(label_dir.glob("bundle_*.xml"))
-            if not matches:
-                raise Exception(message)
-            return max(matches)
+            pattern = "bundle_*.xml"
+        else:
+            pattern = f"*{Path(self.product.name).suffix}"
 
-        extension = Path(self.product.name).suffix
-        val_products = list(label_dir.glob(f"*{extension}"))
-        if not val_products:
-            raise Exception(message)
+        matches = list(val_label_path.glob(pattern))
+        if not matches:
+            raise Exception("No label for comparison found.")
 
-        matched = max(val_products)
-        candidate_name = (
-            matched.name.replace("inventory_", "") if "collection" in basename else matched.name
-        )
-        candidate = matched.with_name(candidate_name).with_suffix(".xml")
-        if candidate.exists():
-            return candidate
-        raise Exception(message)
+        matched = max(matches)
+
+        if "bundle" in basename:
+            return matched
+
+        if "collection" in basename:
+            # Collection products are named "inventory_*"; the label itself
+            # drops that prefix, so it must be stripped to derive its name.
+            matched = matched.with_name(matched.name.replace("inventory_", ""))
+
+        candidate = matched.with_suffix(".xml")
+
+        # The stem match doesn't guarantee a label was actually generated
+        # for that product (e.g. it may have been skipped or failed).
+        if not candidate.exists():
+            raise Exception("No label for comparison found.")
+
+        return candidate

--- a/tests/npb/test_classes_label.py
+++ b/tests/npb/test_classes_label.py
@@ -9,13 +9,18 @@ from unittest.mock import call, mock_open
 
 import pytest
 
-from pds.naif_pds4_bundler.classes.exceptions import NPBError
 from pds.naif_pds4_bundler.classes.label.label import PDSLabel
 
 # Patch targets — resolved to where the names are looked up inside label.py
 _PATCH_ADD_CR = "pds.naif_pds4_bundler.classes.label.label.add_carriage_return"
 _PATCH_COMPARE = "pds.naif_pds4_bundler.classes.label.label.compare_files"
 _PATCH_GLOB = "pds.naif_pds4_bundler.classes.label.label.glob.glob"
+# Path.glob/Path.exists are patched on the class itself (not label.py's
+# namespace) since `Path` is a class object, not a rebindable function
+# reference -- patching it here affects every Path instance, including
+# the ones _pick_val_label constructs internally.
+_PATCH_PATH_GLOB = "pathlib.Path.glob"
+_PATCH_PATH_EXISTS = "pathlib.Path.exists"
 
 
 # ---------------------------------------------------------------------------
@@ -360,58 +365,83 @@ class TestPDSLabelCompare:
         mock_cmp.assert_called_once()
 
     # ------------------------------------------------------------------
-    # Level 1 no match → fall to level 2: collection label
+    # Level 1 no match → level 2 succeeds. _pick_val_label issues at most
+    # one Path.glob call now (the exact-name glob became a .exists()
+    # check), so each level-2/level-3 success case needs at most one
+    # Path.glob mock plus (except for "bundle", which never checks
+    # existence) one Path.exists mock.
     # ------------------------------------------------------------------
-    def test_level2_collection_label(self, label_for, mocker):
-        mocker.patch(_PATCH_COMPARE)
-        label = label_for(label_name_part="collection")
-        label.name = f"/staging/spice_kernels{os.sep}collection_label.xml"
-        mocker.patch(_PATCH_GLOB, side_effect=[
-            [],  # level-1: first (and only) call → miss, exits loop
-            ["/bundle/.../inventory_coll.bc"],  # level-2: val_products glob
-            ["/bundle/.../coll.xml"],  # level-2: collection xml glob
-        ])
-        label.compare()  # key assertion: no uncaught exception
-
-    # ------------------------------------------------------------------
-    # Level 1 no match → fall to level 2: bundle label
-    # ------------------------------------------------------------------
-    def test_level2_bundle_label(self, label_for, mocker):
-        mocker.patch(_PATCH_COMPARE)
-        label = label_for(label_name_part="bundle")
-        label.name = str(Path("/staging/bundle_label.xml"))
-        mocker.patch(_PATCH_GLOB, side_effect=[
-            [],  # level-1: miss
-            ["/bundle/kernel.bc"],  # level-2: val_products glob
-            ["/bundle/bundle_v1.xml"],  # level-2: bundle xml glob
-        ])
-        label.compare()
-
-    # ------------------------------------------------------------------
-    # Level 1 no match → fall to level 2: generic kernel label
-    # ------------------------------------------------------------------
-    def test_level2_generic_label(self, label_for, mocker):
+    @pytest.mark.parametrize(
+        ["collection_name", "label_name_part", "name_override", "glob_return", "needs_exists"],
+        [
+            (
+                "spice_kernels", "collection", f"/staging/spice_kernels{os.sep}collection_label.xml",
+                [Path("/bundle/spice_kernels/ck/inventory_coll.bc")], True,
+            ),
+            (
+                "spice_kernels", "bundle", str(Path("/staging/bundle_label.xml")),
+                [Path("/bundle/bundle_v1.xml")], False,
+            ),
+            ("spice_kernels", "kernel", None, [Path("/bundle/kern.bc")], True),
+            (
+                "miscellaneous", "orbnum", f"/staging/miscellaneous/orb{os.sep}orbnum.xml",
+                [Path("/bundle/misc/orb/old.bc")], True,
+            ),
+        ],
+        ids=["collection-label", "bundle-label", "generic-label", "miscellaneous-appends-subdir"],
+    )
+    def test_level2_succeeds(
+        self, label_for, mocker, collection_name, label_name_part, name_override, glob_return, needs_exists
+    ):
         mock_cmp = mocker.patch(_PATCH_COMPARE)
-        mocker.patch(_PATCH_GLOB, side_effect=[
-            [],  # level-1: miss
-            ["/bundle/kern.bc"],  # level-2: val_products glob
-            ["/bundle/kern.xml"],  # level-2: label xml glob
-        ])
-        label_for().compare()
+        label = label_for(collection_name=collection_name, label_name_part=label_name_part)
+        if name_override:
+            label.name = name_override
+        mocker.patch(_PATCH_GLOB, side_effect=[[]])  # level-1: miss
+        mocker.patch(_PATCH_PATH_GLOB, return_value=glob_return)  # level-2
+        if needs_exists:
+            mocker.patch(_PATCH_PATH_EXISTS, return_value=True)
+        label.compare()
         mock_cmp.assert_called_once()
 
     # ------------------------------------------------------------------
-    # Level 1 & 2 both fail → level 3 (InSight test data)
+    # Level 1 & 2 both fail → level 3 (InSight test data) succeeds.
     # ------------------------------------------------------------------
-    def test_level3_fallback_insight_data(self, label_for, mocker):
-        mocker.patch(_PATCH_COMPARE)
-        mocker.patch(_PATCH_GLOB, side_effect=[
-            [],  # level-1: miss
-            [],  # level-2: val_products empty → IndexError
-            ["/root/data/insight_spice/spice_kernels/ck/insight_ck.bc"],  # level-3: val_products
-            ["/root/data/insight_spice/spice_kernels/ck/insight_ck.xml"],  # level-3: xml glob
-        ])
-        label_for().compare()
+    @pytest.mark.parametrize(
+        ["collection_name", "label_name_part", "name_override", "glob_return", "needs_exists"],
+        [
+            (
+                "spice_kernels", "kernel", None,
+                [Path("/root/data/insight_spice/spice_kernels/ck/insight_ck.bc")], True,
+            ),
+            (
+                "spice_kernels", "kernel", f"/staging/spice_kernels{os.sep}collection_label.xml",
+                [Path("/insight/ck/inv_coll.bc")], True,
+            ),
+            (
+                "spice_kernels", "kernel", str(Path("/staging/bundle_label.xml")),
+                [Path("/insight/bundle_v1.xml")], False,
+            ),
+            (
+                "miscellaneous", "orbnum", f"/staging/miscellaneous/orb{os.sep}orbnum.xml",
+                [Path("/root/data/insight_spice/miscellaneous/orb/insight.bc")], True,
+            ),
+        ],
+        ids=["fallback-insight-data", "collection-label", "bundle-label", "miscellaneous-appends-subdir"],
+    )
+    def test_level3_succeeds(
+        self, label_for, mocker, collection_name, label_name_part, name_override, glob_return, needs_exists
+    ):
+        mock_cmp = mocker.patch(_PATCH_COMPARE)
+        label = label_for(collection_name=collection_name, label_name_part=label_name_part)
+        if name_override:
+            label.name = name_override
+        mocker.patch(_PATCH_GLOB, side_effect=[[]])  # level-1: miss
+        mocker.patch(_PATCH_PATH_GLOB, side_effect=[[], glob_return])  # level-2 empty, level-3 hit
+        if needs_exists:
+            mocker.patch(_PATCH_PATH_EXISTS, return_value=True)
+        label.compare()
+        mock_cmp.assert_called_once()
 
     # ------------------------------------------------------------------
     # All three levels fail → nothing compared, no exception raised
@@ -419,38 +449,9 @@ class TestPDSLabelCompare:
     def test_all_levels_fail_no_exception(self, label_for, mocker):
         mock_cmp = mocker.patch(_PATCH_COMPARE)
         mocker.patch(_PATCH_GLOB, return_value=[])
+        mocker.patch(_PATCH_PATH_GLOB, return_value=[])
         label_for().compare()
         mock_cmp.assert_not_called()
-
-    # ------------------------------------------------------------------
-    # Level 3: "collection" substring in the label's basename
-    # ------------------------------------------------------------------
-    def test_level3_collection_label(self, label_for, mocker):
-        mocker.patch(_PATCH_COMPARE)
-        label = label_for()
-        label.name = f"/staging/spice_kernels{os.sep}collection_label.xml"
-        mocker.patch(_PATCH_GLOB, side_effect=[
-            [],  # level-1: miss
-            [],  # level-2: val_products empty
-            ["/insight/ck/inv_coll.bc"],  # level-3: val_products
-            ["/insight/ck/coll.xml"],  # level-3: xml glob
-        ])
-        label.compare()
-
-    # ------------------------------------------------------------------
-    # Level 3: "bundle" substring in the label's basename
-    # ------------------------------------------------------------------
-    def test_level3_bundle_label(self, label_for, mocker):
-        mocker.patch(_PATCH_COMPARE)
-        label = label_for()
-        label.name = str(Path("/staging/bundle_label.xml"))
-        mocker.patch(_PATCH_GLOB, side_effect=[
-            [],  # level-1: miss
-            [],  # level-2: val_products empty
-            ["/insight/ck/kern.bc"],  # level-3: val_products
-            ["/insight/bundle_v1.xml"],  # level-3: bundle xml glob
-        ])
-        label.compare()
 
     # ------------------------------------------------------------------
     # Level 1: miscellaneous collection adds product-type sub-directory
@@ -490,74 +491,35 @@ class TestPDSLabelCompare:
         label.compare()
 
     # ------------------------------------------------------------------
-    # Line 537: level-2 elif branch — miscellaneous collection appends
-    # the product-type subdirectory to val_label_path.
+    # Level 2 finds a product candidate but no label file exists for it
+    # on disk (candidate.exists() is False) → falls through to level 3,
+    # which succeeds.
     # ------------------------------------------------------------------
-    def test_level2_miscellaneous_collection_appends_subdir(self, label_for, mocker):
-        mocker.patch(_PATCH_COMPARE)
-        label = label_for(collection_name="miscellaneous", label_name_part="orbnum")
-        label.name = f"/staging/miscellaneous/orb{os.sep}orbnum.xml"
-        mocker.patch(_PATCH_GLOB, side_effect=[
-            [],                             # level-1: miss, exits loop immediately
-            ["/bundle/misc/orb/old.bc"],    # level-2: val_products glob (sub-dir appended)
-            ["/bundle/misc/orb/old.xml"],   # level-2: label xml glob
-        ])
-        label.compare()  # reaches compare_files via level-2; no exception raised
-
-    # ------------------------------------------------------------------
-    # Line 559: level-2 raises because val_label is falsy.
-    # glob.glob for the XML label returns [""] — an empty string is a
-    # valid list element but a falsy value, so `if not val_label` fires,
-    # the exception propagates to the level-2 except, and level-3 runs.
-    # ------------------------------------------------------------------
-    def test_level2_falsy_val_label_falls_through_to_level3(self, label_for, mocker):
+    def test_level2_missing_candidate_falls_through_to_level3(self, label_for, mocker):
         mock_cmp = mocker.patch(_PATCH_COMPARE)
-        mocker.patch(_PATCH_GLOB, side_effect=[
-            [],                                                            # level-1: miss
-            ["/bundle/spice_kernels/ck/kern.bc"],                         # level-2: val_products
-            [""],                                                          # level-2: XML glob → falsy → line 559 raise
-            ["/root/data/insight_spice/spice_kernels/ck/insight_ck.bc"],  # level-3: val_products
-            ["/root/data/insight_spice/spice_kernels/ck/insight_ck.xml"], # level-3: xml glob
+        mocker.patch(_PATCH_GLOB, side_effect=[[]])  # level-1: miss
+        mocker.patch(_PATCH_PATH_GLOB, side_effect=[
+            [Path("/bundle/spice_kernels/ck/kern.bc")],  # level-2: val_products found...
+            [Path("/root/data/insight_spice/spice_kernels/ck/insight_ck.bc")],  # level-3: val_products
         ])
+        mocker.patch(_PATCH_PATH_EXISTS, side_effect=[False, True])  # ...but candidate missing; level-3 has one
         label_for().compare()
-        # Execution reached level-3 and found a valid label → compare_files called
         mock_cmp.assert_called_once()
 
     # ------------------------------------------------------------------
-    # Line 587: level-3 elif branch — miscellaneous collection appends
-    # the product-type subdirectory to val_label_path in level-3.
-    # Both level-1 and level-2 must fail first.
+    # Level 3 finds a product candidate but no label file exists for it
+    # either → the raise is caught by level-3's own except, and
+    # compare_files is never called.
     # ------------------------------------------------------------------
-    def test_level3_miscellaneous_collection_appends_subdir(self, label_for, mocker):
+    def test_level3_missing_candidate_suppressed_by_except(self, label_for, mocker):
         mock_cmp = mocker.patch(_PATCH_COMPARE)
-        label = label_for(collection_name="miscellaneous", label_name_part="orbnum")
-        label.name = f"/staging/miscellaneous/orb{os.sep}orbnum.xml"
-        mocker.patch(_PATCH_GLOB, side_effect=[
-            [],                                               # level-1: miss
-            [],                                               # level-2: val_products empty → IndexError → level-3
-            ["/root/data/insight_spice/miscellaneous/orb/insight.bc"],  # level-3: val_products (sub-dir appended)
-            ["/root/data/insight_spice/miscellaneous/orb/insight.xml"], # level-3: xml glob
+        mocker.patch(_PATCH_GLOB, side_effect=[[]])  # level-1: miss
+        mocker.patch(_PATCH_PATH_GLOB, side_effect=[
+            [],  # level-2: val_products empty -> raises, falls to level-3
+            [Path("/root/data/insight_spice/spice_kernels/ck/insight_ck.bc")],  # level-3: val_products
         ])
-        label.compare()
-        mock_cmp.assert_called_once()
-
-    # ------------------------------------------------------------------
-    # Line 611: level-3 raises because val_label is falsy.
-    # The XML glob returns [""] — falsy — so `if not val_label` fires,
-    # the raise is caught by the level-3 except BaseException on line 615,
-    # and compare_files is never called.
-    # ------------------------------------------------------------------
-    def test_level3_falsy_val_label_suppressed_by_except(self, label_for, mocker):
-        mock_cmp = mocker.patch(_PATCH_COMPARE)
-        mocker.patch(_PATCH_GLOB, side_effect=[
-            [],                                                           # level-1: miss
-            [],                                                           # level-2: val_products empty → IndexError
-            ["/root/data/insight_spice/spice_kernels/ck/insight_ck.bc"], # level-3: val_products
-            [""],                                                         # level-3: XML glob → falsy → line 611 raise
-        ])
+        mocker.patch(_PATCH_PATH_EXISTS, return_value=False)  # level-3 candidate also missing
         label_for().compare()
-        # The raise on line 611 is caught on line 615; val_label stays falsy
-        # so compare_files must not have been called.
         mock_cmp.assert_not_called()
 
 
@@ -661,129 +623,112 @@ class TestPDSLabelCompareHelpers:
     #    component, so the match must be substring-based to work at all. --
 
     @pytest.mark.parametrize(
-        "name, val_products, val_label_path, glob_return, expected, expected_glob_call",
+        ["name", "val_label_path", "glob_pattern", "glob_return", "expected"],
         [
-            pytest.param(
+            (
                 f"/staging/spice_kernels{os.sep}collection_spice_kernels_v001.xml",
-                ["/insight/ck/inventory_old.bc"],
                 "/insight/ck/",
-                ["/insight/ck/old_collection.xml"],
-                "/insight/ck/old_collection.xml",
-                str(Path("/insight/ck/old.xml")),
-                id="collection-branch-realistic-name",
+                "*.bc",
+                [Path("/insight/ck/inventory_old.bc")],
+                Path("/insight/ck/old.xml"),
             ),
-            pytest.param(
+            (
                 f"/staging{os.sep}bundle_insight_spice_v009.xml",
-                [],
                 "/insight/",
-                ["/insight/bundle_v1.xml"],
-                "/insight/bundle_v1.xml",
-                "/insight/bundle_*.xml",
-                id="bundle-branch-realistic-name",
+                "bundle_*.xml",
+                [Path("/insight/bundle_v1.xml")],
+                Path("/insight/bundle_v1.xml"),
             ),
-            pytest.param(
+            (
                 f"/staging/ck{os.sep}kernel.xml",
-                ["/bundle/ck/kernel.v01.bc"],
                 "/bundle/ck/",
-                ["/bundle/ck/kernel.v01.xml"],
-                "/bundle/ck/kernel.v01.xml",
-                str(Path("/bundle/ck/kernel.v01.xml")),
+                "*.bc",
+                [Path("/bundle/ck/kernel.v01.bc")],
+                Path("/bundle/ck/kernel.v01.xml"),
                 # Also a regression case for the .split(".")[0] truncation
                 # bug: the stem must keep everything but the final
                 # extension, not just the text before the first dot.
-                id="else-branch-multidot-stem",
             ),
-            pytest.param(
+            (
                 # A directory literally named "collection" must NOT trigger
                 # the collection branch -- only the basename is checked, not
                 # the full path. The basename here ("label.xml") has no
                 # "collection" substring, so this falls through to else.
                 f"/staging{os.sep}collection{os.sep}label.xml",
-                ["/insight/ck/kernel.bc"],
                 "/insight/ck/",
-                ["/insight/ck/kernel.xml"],
-                "/insight/ck/kernel.xml",
-                str(Path("/insight/ck/kernel.xml")),
-                id="collection-directory-without-basename-match-falls-to-else",
+                "*.bc",
+                [Path("/insight/ck/kernel.bc")],
+                Path("/insight/ck/kernel.xml"),
             ),
-            pytest.param(
+            (
                 # Known, accepted trade-off of substring matching: "bundle"
                 # is a substring of "unbundled_data.xml" (from "unbundled"),
                 # so this still triggers the bundle branch even though the
                 # file is not actually a bundle label. This is the price of
                 # a rule that must also match real names like
-                # "bundle_insight_spice_v009.xml".
+                # "bundle_insight_spice_v009.xml". The bundle branch is
+                # checked first and returns immediately, so it never checks
+                # candidate.exists() either -- max(matches) is the answer.
                 f"/staging/spice_kernels{os.sep}unbundled_data.xml",
-                [],
                 "/insight/ck/",
-                ["/insight/ck/bundle_v2.xml"],
-                "/insight/ck/bundle_v2.xml",
-                "/insight/ck/bundle_*.xml",
-                id="bundle-substring-collision-is-accepted-trade-off",
-            ),
-        ],
-    )
-    def test_pick_val_label_branch_selection(
-        self,
-        label_for_helper,
-        mocker,
-        name,
-        val_products,
-        val_label_path,
-        glob_return,
-        expected,
-        expected_glob_call,
-    ):
-        label = label_for_helper()
-        label.name = name
-        mock_glob = mocker.patch(_PATCH_GLOB, return_value=glob_return)
-        result = label._pick_val_label(val_products, val_label_path)
-        assert result == expected
-        mock_glob.assert_called_once_with(expected_glob_call)
-
-    # -- _pick_val_label: failure paths ---------------------------------
-    # Each branch does its own glob; an empty result must raise NPBError
-    # directly, not fall through to a since-removed end-of-function guard.
-
-    @pytest.mark.parametrize(
-        "name, val_products, val_label_path",
-        [
-            (
-                f"/staging/spice_kernels{os.sep}collection_spice_kernels_v001.xml",
-                ["/insight/ck/inventory_old.bc"],
-                "/insight/ck/",
-            ),
-            (
-                f"/staging{os.sep}bundle_insight_spice_v009.xml",
-                [],
-                "/insight/",
-            ),
-            (
-                f"/staging/ck{os.sep}kernel.xml",
-                ["/bundle/ck/kernel.v01.bc"],
-                "/bundle/ck/",
+                "bundle_*.xml",
+                [Path("/insight/ck/bundle_v2.xml")],
+                Path("/insight/ck/bundle_v2.xml"),
             ),
         ],
         ids=[
-            "collection-branch-no-match",
-            "bundle-branch-no-match",
-            "else-branch-no-match",
+            "collection-branch-realistic-name",
+            "bundle-branch-realistic-name",
+            "else-branch-multidot-stem",
+            "collection-directory-without-basename-match-falls-to-else",
+            "bundle-substring-collision-is-accepted-trade-off",
         ],
     )
-    def test_pick_val_label_raises_when_no_match(
-        self, label_for_helper, mocker, name, val_products, val_label_path
+    def test_pick_val_label_branch_selection(
+        self, label_for_helper, mocker, name, val_label_path, glob_pattern, glob_return, expected
     ):
         label = label_for_helper()
         label.name = name
-        mocker.patch(_PATCH_GLOB, return_value=[])
-        with pytest.raises(NPBError, match="No label for comparison found."):
-            label._pick_val_label(val_products, val_label_path)
+        mocker.patch.object(label, "_val_label_directory", return_value=val_label_path)
+        mock_glob = mocker.patch(_PATCH_PATH_GLOB, return_value=glob_return)
+        mocker.patch(_PATCH_PATH_EXISTS, return_value=True)
+        result = label._pick_val_label(Path("/unused"))
+        assert result == expected
+        mock_glob.assert_called_once_with(glob_pattern)
 
-    def test_pick_val_label_raises_valueerror_on_empty_products(self, label_for_helper):
+    # -- _pick_val_label: failure paths ---------------------------------
+    # The three raise sites: bundle's own glob comes up empty, the shared
+    # path's val_products glob comes up empty (can't call max()), or the
+    # shared path derives a candidate that doesn't exist on disk.
+
+    @pytest.mark.parametrize(
+        ["name", "val_label_path", "glob_return", "exists_return"],
+        [
+            (f"/staging{os.sep}bundle_insight_spice_v009.xml", "/insight/", [], False),
+            (f"/staging/ck{os.sep}kernel.xml", "/bundle/ck/", [], False),
+            (
+                f"/staging/ck{os.sep}kernel.xml",
+                "/bundle/ck/",
+                [Path("/bundle/ck/kernel.v01.bc")],
+                False,
+            ),
+        ],
+        ids=[
+            "bundle-branch-glob-empty",
+            "shared-branch-val-products-empty",
+            "shared-branch-candidate-missing",
+        ],
+    )
+    def test_pick_val_label_raises_when_no_match(
+        self, label_for_helper, mocker, name, val_label_path, glob_return, exists_return
+    ):
         label = label_for_helper()
-        label.name = f"/staging/ck{os.sep}kernel.xml"
-        with pytest.raises(ValueError):
-            label._pick_val_label([], "/bundle/ck/")
+        label.name = name
+        mocker.patch.object(label, "_val_label_directory", return_value=val_label_path)
+        mocker.patch(_PATCH_PATH_GLOB, return_value=glob_return)
+        mocker.patch(_PATCH_PATH_EXISTS, return_value=exists_return)
+        with pytest.raises(Exception, match="No label for comparison found."):
+            label._pick_val_label(Path("/unused"))
 
     # -- _find_prior_version_label ---------------------------------------
 
@@ -802,35 +747,34 @@ class TestPDSLabelCompareHelpers:
 
     def test_find_similar_type_label_returns_hit(self, label_for_helper, mocker):
         label = label_for_helper()
-        mocker.patch(_PATCH_GLOB, side_effect=[
-            ["/bundle/spice_kernels/ck/kern.bc"],
-            ["/bundle/spice_kernels/ck/kern.xml"],
-        ])
-        assert label._find_similar_type_label() == "/bundle/spice_kernels/ck/kern.xml"
+        mocker.patch(_PATCH_PATH_GLOB, return_value=[Path("/bundle/spice_kernels/ck/kern.bc")])
+        mocker.patch(_PATCH_PATH_EXISTS, return_value=True)
+        assert label._find_similar_type_label() == str(Path("/bundle/spice_kernels/ck/kern.xml"))
 
     def test_find_similar_type_label_returns_none_when_val_products_empty(self, label_for_helper, mocker):
         label = label_for_helper()
-        mocker.patch(_PATCH_GLOB, return_value=[])
+        mocker.patch(_PATCH_PATH_GLOB, return_value=[])
         assert label._find_similar_type_label() is None
 
     # -- _find_insight_fallback_label -------------------------------------
 
     def test_find_insight_fallback_label_returns_hit_and_logs(self, label_for_helper, mocker):
         label = label_for_helper()
-        mocker.patch(_PATCH_GLOB, side_effect=[
-            ["/root/data/insight_spice/spice_kernels/ck/insight_ck.bc"],
-            ["/root/data/insight_spice/spice_kernels/ck/insight_ck.xml"],
-        ])
+        mocker.patch(
+            _PATCH_PATH_GLOB,
+            return_value=[Path("/root/data/insight_spice/spice_kernels/ck/insight_ck.bc")],
+        )
+        mocker.patch(_PATCH_PATH_EXISTS, return_value=True)
         mock_log = mocker.patch("pds.naif_pds4_bundler.classes.label.label.logging.warning")
         result = label._find_insight_fallback_label()
-        assert result == "/root/data/insight_spice/spice_kernels/ck/insight_ck.xml"
+        assert result == str(Path("/root/data/insight_spice/spice_kernels/ck/insight_ck.xml"))
         # The "Comparing with..." message must only fire on success, and
         # must be the ONLY warning logged (no leftover "not found" message).
         mock_log.assert_called_once_with("-- Comparing with InSight test label.")
 
     def test_find_insight_fallback_label_returns_none_when_val_products_empty(self, label_for_helper, mocker):
         label = label_for_helper()
-        mocker.patch(_PATCH_GLOB, return_value=[])
+        mocker.patch(_PATCH_PATH_GLOB, return_value=[])
         mock_log = mocker.patch("pds.naif_pds4_bundler.classes.label.label.logging.warning")
         assert label._find_insight_fallback_label() is None
         mock_log.assert_called_once_with("-- No label for comparison found.")

--- a/tests/npb/test_classes_label.py
+++ b/tests/npb/test_classes_label.py
@@ -583,22 +583,22 @@ class TestPDSLabelCompareHelpers:
             (
                 "spice_kernels",
                 None,
-                str(Path("/bundle/test_spice", "spice_kernels", "ck")) + os.sep,
+                Path("/bundle/test_spice", "spice_kernels", "ck"),
             ),
             (
                 "miscellaneous",
                 str(Path("/staging/miscellaneous/orb/orbnum.xml")),
-                str(Path("/bundle/test_spice", "miscellaneous", "orb")) + os.sep,
+                Path("/bundle/test_spice", "miscellaneous", "orb"),
             ),
             (
                 "document",
                 None,
-                str(Path("/bundle/test_spice", "document")) + os.sep,
+                Path("/bundle/test_spice", "document"),
             ),
             (
                 "spice_kernels",
                 str(Path("/staging/spice_kernels/collection.xml")),
-                str(Path("/bundle/test_spice", "spice_kernels")) + os.sep,
+                Path("/bundle/test_spice", "spice_kernels"),
             ),
         ],
         ids=[
@@ -612,7 +612,7 @@ class TestPDSLabelCompareHelpers:
         label = label_for_helper(collection_name=collection_name)
         if name_override:
             label.name = name_override
-        result = label._val_label_directory("/bundle/test_spice/")
+        result = label._val_label_directory(Path("/bundle/test_spice"))
         assert result == expected
 
     # -- _pick_val_label: branch selection, unified substring-of-basename
@@ -627,21 +627,21 @@ class TestPDSLabelCompareHelpers:
         [
             (
                 f"/staging/spice_kernels{os.sep}collection_spice_kernels_v001.xml",
-                "/insight/ck/",
+                Path("/insight/ck/"),
                 "*.bc",
                 [Path("/insight/ck/inventory_old.bc")],
                 Path("/insight/ck/old.xml"),
             ),
             (
                 f"/staging{os.sep}bundle_insight_spice_v009.xml",
-                "/insight/",
+                Path("/insight/"),
                 "bundle_*.xml",
                 [Path("/insight/bundle_v1.xml")],
                 Path("/insight/bundle_v1.xml"),
             ),
             (
                 f"/staging/ck{os.sep}kernel.xml",
-                "/bundle/ck/",
+                Path("/bundle/ck/"),
                 "*.bc",
                 [Path("/bundle/ck/kernel.v01.bc")],
                 Path("/bundle/ck/kernel.v01.xml"),
@@ -655,7 +655,7 @@ class TestPDSLabelCompareHelpers:
                 # the full path. The basename here ("label.xml") has no
                 # "collection" substring, so this falls through to else.
                 f"/staging{os.sep}collection{os.sep}label.xml",
-                "/insight/ck/",
+                Path("/insight/ck/"),
                 "*.bc",
                 [Path("/insight/ck/kernel.bc")],
                 Path("/insight/ck/kernel.xml"),
@@ -670,7 +670,7 @@ class TestPDSLabelCompareHelpers:
                 # checked first and returns immediately, so it never checks
                 # candidate.exists() either -- max(matches) is the answer.
                 f"/staging/spice_kernels{os.sep}unbundled_data.xml",
-                "/insight/ck/",
+                Path("/insight/ck/"),
                 "bundle_*.xml",
                 [Path("/insight/ck/bundle_v2.xml")],
                 Path("/insight/ck/bundle_v2.xml"),
@@ -704,11 +704,11 @@ class TestPDSLabelCompareHelpers:
     @pytest.mark.parametrize(
         ["name", "val_label_path", "glob_return", "exists_return"],
         [
-            (f"/staging{os.sep}bundle_insight_spice_v009.xml", "/insight/", [], False),
-            (f"/staging/ck{os.sep}kernel.xml", "/bundle/ck/", [], False),
+            (f"/staging{os.sep}bundle_insight_spice_v009.xml", Path("/insight/"), [], False),
+            (f"/staging/ck{os.sep}kernel.xml", Path("/bundle/ck/"), [], False),
             (
                 f"/staging/ck{os.sep}kernel.xml",
-                "/bundle/ck/",
+                Path("/bundle/ck/"),
                 [Path("/bundle/ck/kernel.v01.bc")],
                 False,
             ),

--- a/tests/npb/test_classes_label.py
+++ b/tests/npb/test_classes_label.py
@@ -9,6 +9,7 @@ from unittest.mock import call, mock_open
 
 import pytest
 
+from pds.naif_pds4_bundler.classes.exceptions import NPBError
 from pds.naif_pds4_bundler.classes.label.label import PDSLabel
 
 # Patch targets — resolved to where the names are looked up inside label.py
@@ -741,13 +742,42 @@ class TestPDSLabelCompareHelpers:
         mock_glob.assert_called_once_with(expected_glob_call)
 
     # -- _pick_val_label: failure paths ---------------------------------
+    # Each branch does its own glob; an empty result must raise NPBError
+    # directly, not fall through to a since-removed end-of-function guard.
 
-    def test_pick_val_label_raises_when_result_falsy(self, label_for_helper, mocker):
+    @pytest.mark.parametrize(
+        "name, val_products, val_label_path",
+        [
+            (
+                f"/staging/spice_kernels{os.sep}collection_spice_kernels_v001.xml",
+                ["/insight/ck/inventory_old.bc"],
+                "/insight/ck/",
+            ),
+            (
+                f"/staging{os.sep}bundle_insight_spice_v009.xml",
+                [],
+                "/insight/",
+            ),
+            (
+                f"/staging/ck{os.sep}kernel.xml",
+                ["/bundle/ck/kernel.v01.bc"],
+                "/bundle/ck/",
+            ),
+        ],
+        ids=[
+            "collection-branch-no-match",
+            "bundle-branch-no-match",
+            "else-branch-no-match",
+        ],
+    )
+    def test_pick_val_label_raises_when_no_match(
+        self, label_for_helper, mocker, name, val_products, val_label_path
+    ):
         label = label_for_helper()
-        label.name = f"/staging/ck{os.sep}kernel.xml"
-        mocker.patch(_PATCH_GLOB, return_value=[""])
-        with pytest.raises(Exception, match="No label for comparison found."):
-            label._pick_val_label(["/bundle/ck/kernel.bc"], "/bundle/ck/")
+        label.name = name
+        mocker.patch(_PATCH_GLOB, return_value=[])
+        with pytest.raises(NPBError, match="No label for comparison found."):
+            label._pick_val_label(val_products, val_label_path)
 
     def test_pick_val_label_raises_valueerror_on_empty_products(self, label_for_helper):
         label = label_for_helper()


### PR DESCRIPTION
## 🗒️ Summary
`PDSLabel._pick_val_label` had a trailing `if not val_label: raise Exception(...)` guard that was dead code — every branch raised `ValueError` (`max([])`) or `IndexError` (`glob.glob(...)[0]`) before it could ever fire. Each branch now checks its own glob result explicitly and raises `NPBError` immediately when empty, matching the docstring's `:raises:` clause and the codebase's ongoing move away from bare `Exception` (see #326). Also scopes the `"inventory_"` substring replacement to the matched file's basename instead of its full path, and documents that `val_label_path` is unused outside the `bundle` branch.

## ⚙️ Test Data and/or Report
Regression tests included: `test_classes_label.py::TestPDSLabelCompareHelpers`, extended with  test_pick_val_label_raises_when_no_match` (parametrized over the collection/bundle/else branches).

    pytest tests/npb/test_classes_label.py -v --cov-branch
    58 passed

    Name                                                 Stmts   Miss Branch BrPart  Cover
    ----------------------------------------------------------------------------------------
    src/pds/naif_pds4_bundler/classes/label/label.py       147      0     54      0   100%

    Full merge-gate suite (pytest tests/npb/ -v --cov-branch):
    1830 passed, 7 skipped, 1 xfailed

## ♻️ Related Issues
fixes #327