### PR TITLE
Remove try/except from PDSLabel's label-comparison helpers

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -231,17 +231,18 @@ class PDSLabel:
 
         :return: Path to the matching label, or ``None`` if none is found.
         """
-        try:
-            base_dir = Path(self.setup.bundle_directory) / f"{self.setup.mission_acronym}_spice"
+        base_dir = Path(self.setup.bundle_directory) / f"{self.setup.mission_acronym}_spice"
+        val_label = self._pick_val_label(base_dir)
 
-            return str(self._pick_val_label(base_dir))
+        if not val_label:
 
-        except Exception:
-            # Not finding a match isn't an error here, just a signal to try the
-            # next fallback level, so we catch broadly on purpose.
+            # No match at this level -- expected, not an error; the next
+            # fallback level takes over.
             logging.warning("-- No similar label has been found.")
 
             return None
+
+        return str(val_label)
 
     def _find_insight_fallback_label(self) -> Optional[str]:
         """Fall back to an InSight test label (fallback level 3).
@@ -252,19 +253,19 @@ class PDSLabel:
 
         :return: Path to the matching label, or ``None`` if none is found.
         """
-        try:
-            base_dir = Path(self.setup.root_dir) / "data" / "insight_spice"
-            val_label = str(self._pick_val_label(base_dir))
-            logging.warning("-- Comparing with InSight test label.")
+        base_dir = Path(self.setup.root_dir) / "data" / "insight_spice"
+        val_label = self._pick_val_label(base_dir)
 
-            return val_label
-
-        except Exception:
-            # This is the last fallback level, so reaching here means no label
-            # was found anywhere to compare against.
+        if not val_label:
+            # This is the last fallback level, so reaching here means no
+            # label was found anywhere to compare against.
             logging.warning("-- No label for comparison found.")
 
             return None
+
+        logging.warning("-- Comparing with InSight test label.")
+
+        return str(val_label)
 
     def _val_label_directory(self, base_dir: Path) -> Path:
         """Build the candidate-label directory for the product's collection.
@@ -289,7 +290,7 @@ class PDSLabel:
 
         return val_label_path
 
-    def _pick_val_label(self, base_dir: Path) -> Path:
+    def _pick_val_label(self, base_dir: Path) -> Optional[Path]:
         """Select a validation label from a candidate directory.
 
         "collection"/"bundle" are matched as a substring of the label's
@@ -300,8 +301,8 @@ class PDSLabel:
         check would never match real files.
 
         :param base_dir: Root directory to search under.
-        :return: Path to the selected validation label.
-        :raises Exception: If no label for comparison can be found.
+        :return: Path to the selected validation label, or ``None`` if none
+            is found.
         """
         val_label_path = self._val_label_directory(base_dir)
         basename = Path(self.name).name
@@ -315,7 +316,9 @@ class PDSLabel:
 
         matches = list(val_label_path.glob(pattern))
         if not matches:
-            raise Exception("No label for comparison found.")
+
+            # Nothing in this directory to compare against.
+            return None
 
         # File names carry a version number, so the alphabetically greatest
         # path is also the newest version.
@@ -334,6 +337,6 @@ class PDSLabel:
         # The stem match doesn't guarantee a label was actually generated for
         # that product (e.g. it may have been skipped or failed).
         if not candidate.exists():
-            raise Exception("No label for comparison found.")
+            return None
 
         return candidate

--- a/src/pds/naif_pds4_bundler/classes/label/label.py
+++ b/src/pds/naif_pds4_bundler/classes/label/label.py
@@ -224,7 +224,7 @@ class PDSLabel:
 
         return val_label
 
-    def _find_similar_type_label(self) -> Optional[str]:
+    def _find_similar_type_label(self) -> Optional[Path]:
         """Look for the label of a product of the same type (fallback level 2).
 
         Used when a prior version of the same file cannot be found.
@@ -235,16 +235,13 @@ class PDSLabel:
         val_label = self._pick_val_label(base_dir)
 
         if not val_label:
-
             # No match at this level -- expected, not an error; the next
             # fallback level takes over.
             logging.warning("-- No similar label has been found.")
 
-            return None
+        return val_label
 
-        return str(val_label)
-
-    def _find_insight_fallback_label(self) -> Optional[str]:
+    def _find_insight_fallback_label(self) -> Optional[Path]:
         """Fall back to an InSight test label (fallback level 3).
 
         Used when no kernel of the same type can be found -- for example,
@@ -256,16 +253,14 @@ class PDSLabel:
         base_dir = Path(self.setup.root_dir) / "data" / "insight_spice"
         val_label = self._pick_val_label(base_dir)
 
-        if not val_label:
+        if val_label:
+            logging.warning("-- Comparing with InSight test label.")
+        else:
             # This is the last fallback level, so reaching here means no
             # label was found anywhere to compare against.
             logging.warning("-- No label for comparison found.")
 
-            return None
-
-        logging.warning("-- Comparing with InSight test label.")
-
-        return str(val_label)
+        return val_label
 
     def _val_label_directory(self, base_dir: Path) -> Path:
         """Build the candidate-label directory for the product's collection.

--- a/tests/npb/test_classes_label.py
+++ b/tests/npb/test_classes_label.py
@@ -697,7 +697,7 @@ class TestPDSLabelCompareHelpers:
         mock_glob.assert_called_once_with(glob_pattern)
 
     # -- _pick_val_label: failure paths ---------------------------------
-    # The three raise sites: bundle's own glob comes up empty, the shared
+    # The three no-match sites: bundle's own glob comes up empty, the shared
     # path's val_products glob comes up empty (can't call max()), or the
     # shared path derives a candidate that doesn't exist on disk.
 
@@ -719,7 +719,7 @@ class TestPDSLabelCompareHelpers:
             "shared-branch-candidate-missing",
         ],
     )
-    def test_pick_val_label_raises_when_no_match(
+    def test_pick_val_label_returns_none_when_no_match(
         self, label_for_helper, mocker, name, val_label_path, glob_return, exists_return
     ):
         label = label_for_helper()
@@ -727,8 +727,7 @@ class TestPDSLabelCompareHelpers:
         mocker.patch.object(label, "_val_label_directory", return_value=val_label_path)
         mocker.patch(_PATCH_PATH_GLOB, return_value=glob_return)
         mocker.patch(_PATCH_PATH_EXISTS, return_value=exists_return)
-        with pytest.raises(Exception, match="No label for comparison found."):
-            label._pick_val_label(Path("/unused"))
+        assert label._pick_val_label(Path("/unused")) is None
 
     # -- _find_prior_version_label ---------------------------------------
 

--- a/tests/npb/test_classes_label.py
+++ b/tests/npb/test_classes_label.py
@@ -748,7 +748,7 @@ class TestPDSLabelCompareHelpers:
         label = label_for_helper()
         mocker.patch(_PATCH_PATH_GLOB, return_value=[Path("/bundle/spice_kernels/ck/kern.bc")])
         mocker.patch(_PATCH_PATH_EXISTS, return_value=True)
-        assert label._find_similar_type_label() == str(Path("/bundle/spice_kernels/ck/kern.xml"))
+        assert label._find_similar_type_label() == Path("/bundle/spice_kernels/ck/kern.xml")
 
     def test_find_similar_type_label_returns_none_when_val_products_empty(self, label_for_helper, mocker):
         label = label_for_helper()
@@ -766,7 +766,7 @@ class TestPDSLabelCompareHelpers:
         mocker.patch(_PATCH_PATH_EXISTS, return_value=True)
         mock_log = mocker.patch("pds.naif_pds4_bundler.classes.label.label.logging.warning")
         result = label._find_insight_fallback_label()
-        assert result == str(Path("/root/data/insight_spice/spice_kernels/ck/insight_ck.xml"))
+        assert result == Path("/root/data/insight_spice/spice_kernels/ck/insight_ck.xml")
         # The "Comparing with..." message must only fire on success, and
         # must be the ONLY warning logged (no leftover "not found" message).
         mock_log.assert_called_once_with("-- Comparing with InSight test label.")


### PR DESCRIPTION
## 🗒️ Summary
`_pick_val_label` used to raise a bare `Exception` when no label could be found, purely so its two callers (`_find_similar_type_label`, `_find_insight_fallback_label`) could catch it as a "nothing found" signal. It now returns `None` instead, and both callers check the result directly instead of wrapping the call in `try/except Exception`.

## ⚙️ Test Data and/or Report
Regression tests included: `test_classes_label.py::TestPDSLabelCompareHelpers`, updated (`test_pick_val_label_raises_when_no_match` → `test_pick_val_label_returns_none_when_no_match`, asserting `None` instead of `pytest.raises`).

    pytest tests/npb/test_classes_label.py -v --cov-branch
    57 passed

    Name                                                 Stmts   Miss Branch BrPart  Cover
    ----------------------------------------------------------------------------------------
    src/pds/naif_pds4_bundler/classes/label/label.py       139      0     58      0   100%

    Full merge-gate suite (pytest tests/npb/ -v --cov-branch):
    1829 passed, 7 skipped, 1 xfailed

## ♻️ Related Issues
Fixes #328