### PR TITLE
Migrate setup.py to raise NPBError

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/setup.py
+++ b/src/pds/naif_pds4_bundler/classes/setup.py
@@ -15,7 +15,7 @@ import requests
 import spiceypy
 import xmlschema
 
-from ..pipeline.runtime import handle_npb_error
+from .exceptions import NPBError
 from ..utils import etree_to_dict
 from ..utils import kernel_name
 from ..utils import spice_exception_handler
@@ -200,7 +200,7 @@ class Setup:
         else:
             pattern = re.compile(r"\d{4}-\d{2}-\d{2}")
             if not pattern.match(self.release_date):
-                handle_npb_error(
+                raise NPBError(
                     "release_date parameter does not match "
                     "the required format: YYYY-MM-DD."
                 )
@@ -231,7 +231,7 @@ class Setup:
             self.eol = "\n"
             self.eol_len = 1
         else:
-            handle_npb_error("End of Line provided via configuration is not CRLF nor LF.")
+            raise NPBError("End of Line provided via configuration is not CRLF nor LF.")
 
         self.end_of_line_pds4 = "CRLF"
         self.eol_pds4 = "\r\n"
@@ -264,14 +264,14 @@ class Setup:
             ):
                 self.kernel_endianness = "big"
             else:
-                handle_npb_error(
+                raise NPBError(
                     "binary_endianness configuration parameter value must be"
                     " 'big', 'BIG-IEEE', 'little' or 'LTL-IEEE'. Case is not"
                     " sensitive."
                 )
 
         if sys.byteorder != self.kernel_endianness:
-            handle_npb_error(
+            raise NPBError(
                 f"binary_endianness configuration parameter value must be "
                 f"the same as your system endianness: {sys.byteorder}."
             )
@@ -392,24 +392,24 @@ class Setup:
         #
         if hasattr(self, "mission_start") and self.mission_start:
             if not pattern.match(self.mission_start):
-                handle_npb_error(
+                raise NPBError(
                     f"mission_start parameter does not match the "
                     f"required format: {time_format}."
                 )
         if hasattr(self, "mission_finish") and self.mission_finish:
             if not pattern.match(self.mission_finish):
-                handle_npb_error(
+                raise NPBError(
                     f"mission_finish does not match the required format: {time_format}."
                 )
         if hasattr(self, "increment_start") and self.increment_start:
             if not pattern.match(self.increment_start):
-                handle_npb_error(
+                raise NPBError(
                     f"increment_start parameter does not match the "
                     f"required format: {time_format}."
                 )
         if hasattr(self, "increment_finish") and self.increment_finish:
             if not pattern.match(self.increment_finish):
-                handle_npb_error(
+                raise NPBError(
                     f"increment_finish does not match the required "
                     f"format: {time_format}."
                 )
@@ -417,7 +417,7 @@ class Setup:
             if ((not self.increment_start) and (self.increment_finish)) or (
                 (self.increment_start) and (not self.increment_finish)
             ):
-                handle_npb_error(
+                raise NPBError(
                     "If provided via configuration, increment_start and "
                     "increment_finish parameters need to be provided "
                     "together."
@@ -437,7 +437,7 @@ class Setup:
             logging.error('  staging: %s', self.staging_directory)
             logging.error('  bundle:  %s', self.bundle_directory)
 
-            handle_npb_error("Update working, staging, or bundle directory.")
+            raise NPBError("Update working, staging, or bundle directory.")
 
         #
         # Sort out if directories are provided as relative paths and
@@ -458,7 +458,7 @@ class Setup:
         if os.path.isdir(cwd + os.sep + self.working_directory):
             self.working_directory = cwd + os.sep + self.working_directory
         if not os.path.isdir(self.working_directory):
-            handle_npb_error(f"Directory does not exist: {self.working_directory}.")
+            raise NPBError(f"Directory does not exist: {self.working_directory}.")
 
         if os.path.isdir(cwd + os.sep + self.staging_directory):
             self.staging_directory = (
@@ -483,7 +483,7 @@ class Setup:
                                     ' is not used with %s faucet.', self.faucet)
 
                 else:
-                    handle_npb_error(
+                    raise NPBError(
                         f"Staging directory cannot be created: {self.staging_directory}."
                     )
 
@@ -504,7 +504,7 @@ class Setup:
                                 " used with %s faucet.", self.faucet)
 
             else:
-                handle_npb_error(
+                raise NPBError(
                     f"Bundle directory does not exist: {self.bundle_directory}."
                 )
 
@@ -515,7 +515,7 @@ class Setup:
             if os.path.isdir(cwd + os.sep + kd_name):
                 self.kernels_directory[i] = cwd + os.sep + kd_name
             if not os.path.isdir(self.kernels_directory[i]):
-                handle_npb_error(f"Directory does not exist: {kd_name}.")
+                raise NPBError(f"Directory does not exist: {kd_name}.")
 
         os.chdir(cwd)
 
@@ -552,7 +552,7 @@ class Setup:
                     xml_model_version = xml_model_version.split(".sch")[0]
 
                     if xml_model_version != short_version:
-                        handle_npb_error(
+                        raise NPBError(
                             f"PDS4 Information Model "
                             f"{short_version} "
                             f"is incoherent with the XML Model version: "
@@ -577,7 +577,7 @@ class Setup:
                     schema_loc_version = schema_loc_version.split(".xsd")[0]
 
                     if schema_loc_version != short_version:
-                        handle_npb_error(
+                        raise NPBError(
                             f"PDS4 Information Model "
                             f"{short_version} "
                             f"is incoherent with the Schema location: "
@@ -594,7 +594,7 @@ class Setup:
                     logging.info('   %s', self.schema_location)
 
             else:
-                handle_npb_error(
+                raise NPBError(
                     f"PDS4 Information Model {self.information_model}"
                     f" format from configuration is incorrect."
                 )
@@ -682,7 +682,7 @@ class Setup:
 
         elif self.pds_version == "4":
             if not os.path.isdir(self.templates_directory):
-                handle_npb_error("Path provided/derived for templates is not available.")
+                raise NPBError("Path provided/derived for templates is not available.")
             labels_check = [
                 os.path.basename(x)
                 for x in glob.glob(f"{self.root_dir}templates/1.5.0.0/*")
@@ -784,7 +784,7 @@ class Setup:
                 for pattern in patterns:
                     name_pattern = pattern["#text"]
                     if name_pattern not in metak_name_check:
-                        handle_npb_error(
+                        raise NPBError(
                             f"The meta-kernel pattern "
                             f"{name_pattern} is not provided."
                         )
@@ -797,7 +797,7 @@ class Setup:
                 # the configuration file.
                 #
                 if "$" in metak_name_check:
-                    handle_npb_error(
+                    raise NPBError(
                         f"The MK patterns {metak['@name']} do not "
                         f"correspond to the present MKs."
                     )
@@ -835,11 +835,11 @@ class Setup:
                             "configuration."
                         )
                     else:
-                        handle_npb_error(
+                        raise NPBError(
                             "Readme elements not present in configuration file."
                         )
             else:
-                handle_npb_error("Readme elements not present in configuration file.")
+                raise NPBError("Readme elements not present in configuration file.")
 
         #
         # Check if there is any uppercase character in the kernel list
@@ -1038,7 +1038,7 @@ class Setup:
             logging.info('-- LSK     loaded: %s', lsks)
 
         if len(lsks) > 1:
-            handle_npb_error("Only one LSK should be obtained.")
+            raise NPBError("Only one LSK should be obtained.")
 
         pcks = []
         for pattern in pck_patterns:

--- a/tests/npb/test_classes_setup.py
+++ b/tests/npb/test_classes_setup.py
@@ -13,6 +13,7 @@ import requests
 import spiceypy
 from spiceypy import SpiceyPyError
 
+from pds.naif_pds4_bundler.classes.exceptions import NPBError
 from pds.naif_pds4_bundler.classes.setup import Setup
 
 
@@ -32,19 +33,6 @@ def make_setup(tmp_path, mission_acronym: str = "maven",
     setup.release = release
 
     return setup
-
-
-@pytest.fixture
-def patch_handle_npb_error(monkeypatch) -> None:
-    """Replace handle_npb_error by an exception so tests can assert errors."""
-
-    def raise_configuration_error(message):
-        raise RuntimeError(message)
-
-    monkeypatch.setattr(
-        'pds.naif_pds4_bundler.classes.setup.handle_npb_error',
-        raise_configuration_error,
-    )
 
 
 class TestSetupInit:
@@ -676,14 +664,12 @@ class TestSetupInit:
 
         # This test checks invalid values for release_date, end_of_line and
         # binary_endianness. When an invalid value is encountered for these
-        # attributes, handle_npb_error is called, which raises a RuntimeError
-        # exception.
+        # attributes, Setup.__init__ raises NPBError directly.
 
         entries = self.make_init_config(bundle_parameters=bundle_parameters)
 
-        # Capture the exception raised by handle_npb_error call, and check the
-        # provided message.
-        with pytest.raises(RuntimeError, match=re.escape(expected_message)):
+        # Capture the raised exception and check the provided message.
+        with pytest.raises(NPBError, match=re.escape(expected_message)):
             self.instantiate_setup(tmp_path, monkeypatch, entries)
 
     @pytest.mark.parametrize('binary_endianness, system_byteorder', [
@@ -705,9 +691,8 @@ class TestSetupInit:
             f'the same as your system endianness: {system_byteorder}.'
         )
 
-        # Capture the exception raised by handle_npb_error call, and check the
-        # provided message.
-        with pytest.raises(RuntimeError, match=re.escape(expected_message)):
+        # Capture the raised exception and check the provided message.
+        with pytest.raises(NPBError, match=re.escape(expected_message)):
             self.instantiate_setup(tmp_path, monkeypatch, entries,
                                    system_byteorder=system_byteorder)
 
@@ -977,9 +962,9 @@ class TestSetupCheckConfiguration:
             Mock(side_effect=OSError('permission denied')),
         )
 
-        # This behaviour will be handled by handle_npb_error, which will raise a
-        # RuntimeError. Also, checks the returned message.
-        with pytest.raises(RuntimeError,
+        # check_configuration raises NPBError directly. Also, checks the
+        # returned message.
+        with pytest.raises(NPBError,
                            match='Staging directory cannot be created: '
                                  'missing_staging\\.'):
             setup.check_configuration()
@@ -995,9 +980,9 @@ class TestSetupCheckConfiguration:
         # Forces a non-existent bundle directory.
         setup.bundle_directory = 'missing_bundle'
 
-        # This behaviour will be handled by handle_npb_error, which will raise a
-        # RuntimeError. Also, checks the returned message.
-        with pytest.raises(RuntimeError,
+        # check_configuration raises NPBError directly. Also, checks the
+        # returned message.
+        with pytest.raises(NPBError,
                            match='Bundle directory does not exist:'
                                  ' missing_bundle\\.'):
             setup.check_configuration()
@@ -1010,10 +995,10 @@ class TestSetupCheckConfiguration:
         # Forces a non-existent kernel directory.
         setup.kernels_directory = [str(tmp_path / 'missing_kernels')]
 
-        # This behaviour will be handled by handle_npb_error, which will raise a
-        # RuntimeError. Also, checks the returned message.
-        with pytest.raises(RuntimeError, match=re.escape(f'Directory does not exist: '
-                                                         f'{tmp_path / "missing_kernels"}.')):
+        # check_configuration raises NPBError directly. Also, checks the
+        # returned message.
+        with pytest.raises(NPBError, match=re.escape(f'Directory does not exist: '
+                                                      f'{tmp_path / "missing_kernels"}.')):
             setup.check_configuration()
 
     def test_logs_directory_collision_before_raising(self, tmp_path, caplog) -> None:
@@ -1023,10 +1008,14 @@ class TestSetupCheckConfiguration:
         # Forces that the staging directory is the same as the working directory.
         setup.staging_directory = setup.working_directory
 
-        # Captures the logging and the RuntimeException. And also check the
-        # message returned by handle_npb_error.
+        # Captures the logging and the raised NPBError. Also checks the
+        # provided message. Note: the final "-- Update working, staging, or
+        # bundle directory." log line used to appear here too, but it was
+        # emitted by handle_npb_error itself; now that check_configuration
+        # raises NPBError directly, that line is only logged by the
+        # pipeline's except-handler (npb.py), not at this unit level.
         with caplog.at_level(logging.INFO):
-            with pytest.raises(RuntimeError,
+            with pytest.raises(NPBError,
                                match='Update working, staging, or bundle '
                                      'directory\\.'):
                 setup.check_configuration()
@@ -1037,8 +1026,7 @@ class TestSetupCheckConfiguration:
             (logging.ERROR, '--The working, staging, and bundle directories must be different:'),
             (logging.ERROR, f'  working: {setup.working_directory}'),
             (logging.ERROR, f'  staging: {setup.working_directory}'),
-            (logging.ERROR, f'  bundle:  {setup.bundle_directory}'),
-            (logging.ERROR, '-- Update working, staging, or bundle directory.')]
+            (logging.ERROR, f'  bundle:  {setup.bundle_directory}')]
 
         results = [(r[1], r[2]) for r in caplog.record_tuples]
 
@@ -1051,10 +1039,10 @@ class TestSetupCheckConfiguration:
         # Forces a non-existent working directory.
         setup.working_directory = str(tmp_path / 'missing_work')
 
-        # This behaviour will be handled by handle_npb_error, which will raise a
-        # RuntimeError. Also, checks the returned message.
-        with pytest.raises(RuntimeError, match=re.escape(f'Directory does not exist: '
-                                                         f'{tmp_path / "missing_work"}.')):
+        # check_configuration raises NPBError directly. Also, checks the
+        # returned message.
+        with pytest.raises(NPBError, match=re.escape(f'Directory does not exist: '
+                                                      f'{tmp_path / "missing_work"}.')):
             setup.check_configuration()
 
     @pytest.mark.parametrize('date_format, values, expected_message', [
@@ -1085,11 +1073,10 @@ class TestSetupCheckConfiguration:
         for field, value in values.items():
             setattr(setup, field, value)
 
-        # In case of invalid dates, this behaviour will be handled by
-        # handle_npb_error, which will raise a RuntimeError. Also, checks the
-        # returned message.
+        # In case of invalid dates, check_configuration raises NPBError
+        # directly. Also, checks the returned message.
         if expected_message:
-            with pytest.raises(RuntimeError, match=expected_message):
+            with pytest.raises(NPBError, match=expected_message):
                 setup.check_configuration()
 
         # In case of valid dates, check that the method completed successfully
@@ -1110,9 +1097,9 @@ class TestSetupCheckConfiguration:
         setup.increment_start = increment_start
         setup.increment_finish = increment_finish
 
-        # This behaviour will be handled by handle_npb_error, which will raise a
-        # RuntimeError. Also, checks the returned message.
-        with pytest.raises(RuntimeError,
+        # check_configuration raises NPBError directly. Also, checks the
+        # returned message.
+        with pytest.raises(NPBError,
                            match='If provided via configuration, increment_start '
                                  'and increment_finish parameters need to be '
                                  'provided together\\.'):
@@ -1166,9 +1153,9 @@ class TestSetupCheckConfiguration:
         setup = self.make_check_setup(tmp_path)
         setattr(setup, attribute, value)
 
-        # This behaviour will be handled by handle_npb_error, which will raise a
-        # RuntimeError. Also, checks the returned message.
-        with pytest.raises(RuntimeError, match=expected_message):
+        # check_configuration raises NPBError directly. Also, checks the
+        # returned message.
+        with pytest.raises(NPBError, match=expected_message):
             setup.check_configuration()
 
     @pytest.mark.parametrize('information_model, xml_model, schema_location, expected_template_version', [
@@ -1227,10 +1214,10 @@ class TestSetupCheckConfiguration:
                                       templates_directory=str(tmp_path / 'missing_templates'),
                                       root_dir=root_dir)
 
-        # This behaviour will be handled by handle_npb_error, which will raise a
-        # RuntimeError. Also, checks the returned message.
-        with pytest.raises(RuntimeError, match='Path provided/derived for '
-                                               'templates is not available\\.'):
+        # check_configuration raises NPBError directly. Also, checks the
+        # returned message.
+        with pytest.raises(NPBError, match='Path provided/derived for '
+                                           'templates is not available\\.'):
             setup.check_configuration()
 
     def test_uses_custom_templates_and_fills_missing_templates_from_default(
@@ -1535,9 +1522,9 @@ class TestSetupCheckConfiguration:
         setup = self.make_check_setup(tmp_path)
         setup.mk = mk
 
-        # This behaviour will be handled by handle_npb_error, which will raise a
-        # RuntimeError. Also, checks the returned message.
-        with pytest.raises(RuntimeError, match=expected_message):
+        # check_configuration raises NPBError directly. Also, checks the
+        # returned message.
+        with pytest.raises(NPBError, match=expected_message):
             setup.check_configuration()
 
     @pytest.mark.parametrize('readme, create_input_file, expected_message', [
@@ -1564,13 +1551,12 @@ class TestSetupCheckConfiguration:
 
         setup.readme = readme
 
-        # In case of readme cannot be found or generated, this behaviour will be
-        # handled by handle_npb_error, which will raise a RuntimeError. Also,
-        # checks the returned message.
+        # In case the readme cannot be found or generated, check_configuration
+        # raises NPBError directly. Also, checks the returned message.
         if expected_message:
 
-            with pytest.raises(RuntimeError, match='Readme elements not present in '
-                                                   'configuration file\\.'):
+            with pytest.raises(NPBError, match='Readme elements not present in '
+                                               'configuration file\\.'):
                 setup.check_configuration()
 
         # In case of readme can be created, check that the method completed
@@ -1590,10 +1576,10 @@ class TestSetupCheckConfiguration:
         if hasattr(setup, 'readme'):
             del setup.readme
 
-        # This behaviour will be handled by handle_npb_error, which will raise a
-        # RuntimeError. Also, checks the returned message.
-        with pytest.raises(RuntimeError, match='Readme elements not present in '
-                                               'configuration file\\.'):
+        # check_configuration raises NPBError directly. Also, checks the
+        # returned message.
+        with pytest.raises(NPBError, match='Readme elements not present in '
+                                           'configuration file\\.'):
             setup.check_configuration()
 
 
@@ -2308,7 +2294,7 @@ class TestSetupLoadKernels:
         assert results == expected
 
     def test_raises_when_more_than_one_lsk_is_loaded(
-            self, tmp_path, monkeypatch, patch_handle_npb_error) -> None:
+            self, tmp_path, monkeypatch) -> None:
         # This test checks the specific validation rule for load_kernels:
         # multiple non-LSK kernels can be loaded, but no more than one LSK can
         # be loaded.
@@ -2333,7 +2319,7 @@ class TestSetupLoadKernels:
         monkeypatch.setattr('pds.naif_pds4_bundler.classes.setup.spiceypy.furnsh',
                             furnsh)
 
-        with pytest.raises(RuntimeError, match='Only one LSK should be obtained\\.'):
+        with pytest.raises(NPBError, match='Only one LSK should be obtained\\.'):
             setup_instance.load_kernels()
 
         # Both LSK files are loaded before the final validation fails.

--- a/tests/npb/test_classes_setup.py
+++ b/tests/npb/test_classes_setup.py
@@ -1008,10 +1008,11 @@ class TestSetupCheckConfiguration:
         # Forces that the staging directory is the same as the working directory.
         setup.staging_directory = setup.working_directory
 
-        # Captures the logging and the raised NPBError. Also checks the provided
-        # message. Now check_configuration raises NPBError directly, that line
-        # is only logged by the pipeline's except-handler (npb.py), not at this
-        # unit level.
+        # Captures the logging and the raised NPBError. Also checks the
+        # provided message. check_configuration no longer logs the final
+        # "-- Update working, staging, or bundle directory." line itself —
+        # that now only happens in the pipeline's except-handler (npb.py),
+        # not at this unit level.
         with caplog.at_level(logging.INFO):
             with pytest.raises(NPBError,
                                match='Update working, staging, or bundle '

--- a/tests/npb/test_classes_setup.py
+++ b/tests/npb/test_classes_setup.py
@@ -1008,12 +1008,10 @@ class TestSetupCheckConfiguration:
         # Forces that the staging directory is the same as the working directory.
         setup.staging_directory = setup.working_directory
 
-        # Captures the logging and the raised NPBError. Also checks the
-        # provided message. Note: the final "-- Update working, staging, or
-        # bundle directory." log line used to appear here too, but it was
-        # emitted by handle_npb_error itself; now that check_configuration
-        # raises NPBError directly, that line is only logged by the
-        # pipeline's except-handler (npb.py), not at this unit level.
+        # Captures the logging and the raised NPBError. Also checks the provided
+        # message. Now check_configuration raises NPBError directly, that line
+        # is only logged by the pipeline's except-handler (npb.py), not at this
+        # unit level.
         with caplog.at_level(logging.INFO):
             with pytest.raises(NPBError,
                                match='Update working, staging, or bundle '


### PR DESCRIPTION
## 🗒️ Summary
Replaces all 23 `handle_npb_error()` calls in `Setup` (`classes/setup.py`) — spread across `__init__()`, `check_configuration()`, and `load_kernels()` — with `raise NPBError(...)`. No call site passed `setup=`, so nothing to drop. The pipeline's existing except-NPBError handlers in `run_pipeline` already cover every site: the narrow block around `Setup()` construction catches the 4 `__init__` sites, and the broad block covering the rest of `run_pipeline` catches the other 19, raised from `check_configuration()`/`load_kernels()` which run after `Setup()` returns.

Updates `test_classes_setup.py` to match: asserts `NPBError` instead of `RuntimeError` at all 23 call sites, drops the now-dead `patch_handle_npb_error` fixture (its only consumer no longer needs it), and drops one `caplog`-expected log line in `test_logs_directory_collision_before_raising` that used to come from `handle_npb_error`'s own `logging.error()` call and is no longer emitted at this unit level.

## ⚙️ Test Data and/or Report
Regression tests included: existing `test_classes_setup.py` suite, updated to match the direct raise.

    pytest tests/npb/test_classes_setup.py -v --cov-branch
    152 passed

    Name                                         Stmts   Miss Branch BrPart  Cover
    -----------------------------------------------------------------------------
    src/pds/naif_pds4_bundler/classes/setup.py     546      0    298      0   100%

    Full merge-gate suite (pytest tests/npb/ -v --cov-branch):
    1829 passed, 7 skipped, 1 xfailed

Manual verification:
* `grep -n "handle_npb_error\|from.*pipeline.runtime" src/pds/naif_pds4_bundler/classes/setup.py` → no output

## ♻️ Related Issues
Fixes NASA-PDS/naif-pds4-bundler#333
