### PR TITLE
Refactor(L-04): move label instantiation out of product constructors

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/product/product_inventory.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_inventory.py
@@ -104,24 +104,30 @@ class InventoryProduct(Product):
 
         Product.__init__(self)
 
-        # Labeling used to happen here (PDS3/PDS4 label picked and built). It
-        # now happens in the pipeline, right after this product is built.
-        if setup.pds_version == "3":
-            #
-            # Generate dsindex files.
-            #
-            shutil.copy2(self.path, self.setup.staging_directory + "/../dsindex.tab")
-            shutil.copy2(
-                self.path.replace(".tab", ".lbl"),
-                self.setup.staging_directory + "/../dsindex.lbl",
-            )
+        # Labeling used to happen here (PDS3/PDS4 label picked and built), and
+        # so did the PDS3 dsindex-file copy below it. Both moved out:
+        # labeling to the pipeline, dsindex copying to its own method,
+        # generate_dsindex_files(), also called from the pipeline.
 
-            replace_string_in_file(
-                self.setup.staging_directory + "/../dsindex.lbl",
-                '"INDEX.TAB"',
-                '"DSINDEX.TAB"',
-                self.setup,
-            )
+    def generate_dsindex_files(self) -> None:
+        """Copy the PDS3 index file and its label to dsindex.tab/.lbl.
+
+        PDS3 only. This is a separate method, not folded into __init__,
+        because it copies ``index.lbl`` -- a file this class doesn't write.
+        ``InventoryPDS3Label`` writes it, and that label is now built by the
+        pipeline after this product's __init__ returns. Call this only
+        after that label exists, or the copy fails with a FileNotFoundError.
+        """
+        shutil.copy2(self.path, self.setup.staging_directory + "/../dsindex.tab")
+        shutil.copy2(
+            self.path.replace(".tab", ".lbl"),
+            self.setup.staging_directory + "/../dsindex.lbl")
+
+        replace_string_in_file(
+            self.setup.staging_directory + "/../dsindex.lbl",
+            '"INDEX.TAB"',
+            '"DSINDEX.TAB"',
+            self.setup)
 
     def set_product_lid(self) -> None:
         """Set the Product LID."""

--- a/src/pds/naif_pds4_bundler/classes/product/product_inventory.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_inventory.py
@@ -11,7 +11,6 @@ from ...utils import add_carriage_return
 from ...utils import compare_files
 from ...utils import replace_string_in_file
 from ...utils import type_to_extension
-from ..label import InventoryPDS3Label, InventoryPDS4Label
 
 
 class InventoryProduct(Product):
@@ -105,11 +104,9 @@ class InventoryProduct(Product):
 
         Product.__init__(self)
 
-        if setup.pds_version == "4":
-            self.label = InventoryPDS4Label(setup, collection, self)
-        else:  # setup.pds_version == "3":
-            self.label = InventoryPDS3Label(setup, collection, self)
-
+        # Labeling used to happen here (PDS3/PDS4 label picked and built). It
+        # now happens in the pipeline, right after this product is built.
+        if setup.pds_version == "3":
             #
             # Generate dsindex files.
             #

--- a/src/pds/naif_pds4_bundler/classes/product/product_inventory.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_inventory.py
@@ -117,6 +117,11 @@ class InventoryProduct(Product):
         ``InventoryPDS3Label`` writes it, and that label is now built by the
         pipeline after this product's __init__ returns. Call this only
         after that label exists, or the copy fails with a FileNotFoundError.
+
+        TODO: this ordering is only enforced by the comment in npb.py next to
+              the call site, not by the type system, and no test checks the call
+              order. If the pipeline is ever reordered, this will fail with a
+              FileNotFoundError that gives no hint the real cause is ordering.
         """
         shutil.copy2(self.path, self.setup.staging_directory + "/../dsindex.tab")
         shutil.copy2(

--- a/src/pds/naif_pds4_bundler/classes/product/product_kernel.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_kernel.py
@@ -14,8 +14,6 @@ from ...utils import pck_coverage
 from ...utils import product_mapping
 from ...utils import safe_make_directory
 from ...utils import spk_coverage
-from ..label import SpiceKernelPDS3Label
-from ..label import SpiceKernelPDS4Label
 
 
 class SpiceKernelProduct(Product):
@@ -155,16 +153,10 @@ class SpiceKernelProduct(Product):
         self.targets = targets
         self.observers = observers
 
-        #
-        # The kernel is labeled.
-        #
-        logging.info('-- Labeling %s...', self.name)
-
-        if setup.pds_version == "4":
-            self.label = SpiceKernelPDS4Label(setup, self)
-        else:
+        # PDS3 labeling reads this back off the product; PDS4 doesn't need it.
+        # Labeling itself now happens in the pipeline, not here.
+        if setup.pds_version == "3":
             self.maklabel_options = self.read_maklabel_options()
-            self.label = SpiceKernelPDS3Label(setup, self)
 
     def product_lid(self) -> str:
         """Determine product logical identifier (LID).

--- a/src/pds/naif_pds4_bundler/classes/product/product_metakernel.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_metakernel.py
@@ -25,7 +25,6 @@ from ...utils import safe_make_directory
 from ...utils import spice_exception_handler
 from ...utils import spk_coverage
 from ...utils import type_to_extension
-from ..label import MetaKernelPDS4Label
 
 
 class MetaKernelProduct(Product):
@@ -232,13 +231,6 @@ class MetaKernelProduct(Product):
             self.observers = observers
 
         super().__init__()
-
-        if self.setup.pds_version == "4":
-
-            logging.info('')
-            logging.info('-- Labeling meta-kernel: %s...', self.name)
-
-            self.label = MetaKernelPDS4Label(setup, self)
 
     def check_version(self) -> None:
         """Check if the provided Meta-kernel version is correct."""

--- a/src/pds/naif_pds4_bundler/classes/product/product_orbnum.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_orbnum.py
@@ -15,7 +15,6 @@ from ...utils import get_latest_kernel
 from ...utils import safe_make_directory
 from ...utils import spk_coverage
 from ...utils import utf8len
-from ..label import OrbnumFilePDS4Label
 
 
 class OrbnumFileProduct(Product):
@@ -140,14 +139,6 @@ class OrbnumFileProduct(Product):
                 self.targets = [self._orbnum_type["target"]]
 
         super().__init__()
-
-        #
-        # The kernel is labeled.
-        #
-        if self.setup.pds_version == "4":
-            logging.info('-- Labeling %s...', self.name)
-
-            self.label = OrbnumFilePDS4Label(setup, self)
 
     def set_product_lid(self) -> None:
         """Set the Product LID."""

--- a/src/pds/naif_pds4_bundler/classes/product/product_readme.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_readme.py
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 
 from .product import Product
 from ..exceptions import NPBError
-from ..label import BundlePDS4Label
 from ...utils import add_carriage_return
 from ...utils import md5
 
@@ -57,9 +56,6 @@ class ReadmeProduct(Product):
         # Now we change the path for the difference of the name in the label
         #
         self.path = setup.staging_directory + os.sep + bundle.name
-
-        logging.info("-- Generating bundle label...")
-        self.label = BundlePDS4Label(setup, self)
 
     def _write_product(self) -> None:
         """Write the Readme product."""

--- a/src/pds/naif_pds4_bundler/classes/product/product_spiceds.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_spiceds.py
@@ -125,10 +125,8 @@ class SpicedsProduct(Product):
         # too, under this same self.generated check; it's built in the pipeline
         # now, which reads self.generated to decide whether to.
         #
-        if self.generated:
-
-            if self.setup.diff:
-                self._compare()
+        if self.generated and self.setup.diff:
+            self._compare()
 
     def set_product_lid(self) -> None:
         """Set the Product LID."""

--- a/src/pds/naif_pds4_bundler/classes/product/product_spiceds.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_spiceds.py
@@ -11,7 +11,6 @@ from .product import Product
 from ..exceptions import NPBError
 from ...utils import add_carriage_return
 from ...utils import compare_files
-from ..label import DocumentPDS4Label
 
 
 class SpicedsProduct(Product):
@@ -122,13 +121,14 @@ class SpicedsProduct(Product):
         self.generated = self._check_product()
 
         #
-        # Validate the product by comparing it and then generate the label.
+        # Validate the product by comparing it. Labeling used to happen here
+        # too, under this same self.generated check; it's built in the pipeline
+        # now, which reads self.generated to decide whether to.
         #
         if self.generated:
+
             if self.setup.diff:
                 self._compare()
-
-            self.label = DocumentPDS4Label(setup, collection, self)
 
     def set_product_lid(self) -> None:
         """Set the Product LID."""

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -1,5 +1,6 @@
 """Implementation of the NAIF PDS4 Bundler pipeline.
 """
+import logging
 from os.path import isdir
 from pathlib import Path
 
@@ -10,6 +11,7 @@ from ..classes.collection import DocumentCollection
 from ..classes.collection import MiscellaneousCollection
 from ..classes.collection import SpiceKernelsCollection
 from ..classes.exceptions import NPBError
+from ..classes.label import BundlePDS4Label
 from ..classes.list import KernelList
 from ..classes.log import Log
 from ..classes.plan import ReleasePlan
@@ -466,6 +468,9 @@ def run_pipeline(args: PipelineArgs) -> None:
             #
             log_step(setup, title='Generation of bundle products')
             bundle.readme = ReadmeProduct(setup, bundle)
+
+            logging.info("-- Generating bundle label...")
+            bundle.readme.label = BundlePDS4Label(setup, bundle.readme)
 
             #
             # * Generate the Checksum product a posteriori in such a way

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -14,6 +14,7 @@ from ..classes.exceptions import NPBError
 from ..classes.label import BundlePDS4Label
 from ..classes.label import InventoryPDS3Label
 from ..classes.label import InventoryPDS4Label
+from ..classes.label import OrbnumFilePDS4Label
 from ..classes.label import SpiceKernelPDS3Label
 from ..classes.label import SpiceKernelPDS4Label
 from ..classes.list import KernelList
@@ -246,11 +247,17 @@ def run_pipeline(args: PipelineArgs) -> None:
                 # because it might require to update the kernel list if the
                 # orbnum file name is updated.
                 #
-                miscellaneous_collection.add(
-                    OrbnumFileProduct(
-                        setup, kernel, miscellaneous_collection, spice_kernels_collection
-                    )
-                )
+                orbnum_product = OrbnumFileProduct(
+                    setup, kernel, miscellaneous_collection, spice_kernels_collection)
+
+                # Labeling used to happen inside OrbnumFileProduct itself, PDS4
+                # only -- there's no PDS3 label for orbnum files.
+                if setup.pds_version == "4":
+                    logging.info('-- Labeling %s...', orbnum_product.name)
+                    orbnum_product.label = OrbnumFilePDS4Label(setup, orbnum_product)
+
+                miscellaneous_collection.add(orbnum_product)
+
             elif ".tm" not in kernel.lower():
                 kernel_product = SpiceKernelProduct(setup, kernel, spice_kernels_collection)
 

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -14,6 +14,7 @@ from ..classes.exceptions import NPBError
 from ..classes.label import BundlePDS4Label
 from ..classes.label import InventoryPDS3Label
 from ..classes.label import InventoryPDS4Label
+from ..classes.label import MetaKernelPDS4Label
 from ..classes.label import OrbnumFilePDS4Label
 from ..classes.label import SpiceKernelPDS3Label
 from ..classes.label import SpiceKernelPDS4Label
@@ -283,8 +284,17 @@ def run_pipeline(args: PipelineArgs) -> None:
                 meta_kernel = MetaKernelProduct(
                     setup, mk, spice_kernels_collection, user_input=meta_kernels[mk]
                 )
+
                 if setup.pds_version == "4":
+
+                    # Labeling used to happen inside MetaKernelProduct itself,
+                    # PDS4 only -- there's no PDS3 meta-kernel label.
+                    logging.info('')
+                    logging.info('-- Labeling meta-kernel: %s...', meta_kernel.name)
+                    meta_kernel.label = MetaKernelPDS4Label(setup, meta_kernel)
+
                     spice_kernels_collection.add(meta_kernel)
+
                 else:
                     miscellaneous_collection.add(meta_kernel)
 

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -14,6 +14,8 @@ from ..classes.exceptions import NPBError
 from ..classes.label import BundlePDS4Label
 from ..classes.label import InventoryPDS3Label
 from ..classes.label import InventoryPDS4Label
+from ..classes.label import SpiceKernelPDS3Label
+from ..classes.label import SpiceKernelPDS4Label
 from ..classes.list import KernelList
 from ..classes.log import Log
 from ..classes.plan import ReleasePlan
@@ -250,9 +252,19 @@ def run_pipeline(args: PipelineArgs) -> None:
                     )
                 )
             elif ".tm" not in kernel.lower():
-                spice_kernels_collection.add(
-                    SpiceKernelProduct(setup, kernel, spice_kernels_collection)
-                )
+                kernel_product = SpiceKernelProduct(setup, kernel, spice_kernels_collection)
+
+                # Labeling used to happen inside SpiceKernelProduct itself; it's
+                # picked here now, same PDS3/PDS4 choice as before.
+                logging.info('-- Labeling %s...', kernel_product.name)
+
+                if setup.pds_version == "4":
+                    kernel_product.label = SpiceKernelPDS4Label(setup, kernel_product)
+
+                else:
+                    kernel_product.label = SpiceKernelPDS3Label(setup, kernel_product)
+
+                spice_kernels_collection.add(kernel_product)
 
         #
         # * Generate the Meta-kernel(s).

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -364,7 +364,11 @@ def run_pipeline(args: PipelineArgs) -> None:
             else:
                 spice_kernels_collection_inventory.label = InventoryPDS3Label(
                     setup, spice_kernels_collection, spice_kernels_collection_inventory)
-                
+
+                # Must come after the label line above, not before: this copies
+                # index.lbl, which InventoryPDS3Label just wrote.
+                spice_kernels_collection_inventory.generate_dsindex_files()
+
             spice_kernels_collection.add(spice_kernels_collection_inventory)
 
         if setup.pds_version == "4":

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -12,6 +12,7 @@ from ..classes.collection import MiscellaneousCollection
 from ..classes.collection import SpiceKernelsCollection
 from ..classes.exceptions import NPBError
 from ..classes.label import BundlePDS4Label
+from ..classes.label import DocumentPDS4Label
 from ..classes.label import InventoryPDS3Label
 from ..classes.label import InventoryPDS4Label
 from ..classes.label import MetaKernelPDS4Label
@@ -384,6 +385,11 @@ def run_pipeline(args: PipelineArgs) -> None:
             #   Documents Collection Inventory.
             #
             if spiceds.generated:
+                # Labeling used to happen inside SpicedsProduct itself, under
+                # the same generated check -- a spiceds file that hasn't changed
+                # since the last release isn't relabeled.
+                spiceds.label = DocumentPDS4Label(setup, document_collection, spiceds)
+
                 document_collection.add(spiceds)
 
                 document_collection.set_collection_vid()

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -12,6 +12,8 @@ from ..classes.collection import MiscellaneousCollection
 from ..classes.collection import SpiceKernelsCollection
 from ..classes.exceptions import NPBError
 from ..classes.label import BundlePDS4Label
+from ..classes.label import InventoryPDS3Label
+from ..classes.label import InventoryPDS4Label
 from ..classes.list import KernelList
 from ..classes.log import Log
 from ..classes.plan import ReleasePlan
@@ -322,6 +324,17 @@ def run_pipeline(args: PipelineArgs) -> None:
             spice_kernels_collection_inventory = InventoryProduct(
                 setup, spice_kernels_collection
             )
+
+            # Only inventory built for both PDS versions, so both label classes
+            # are still picked here, same as InventoryProduct used to.
+            if setup.pds_version == "4":
+                spice_kernels_collection_inventory.label = InventoryPDS4Label(
+                    setup, spice_kernels_collection, spice_kernels_collection_inventory)
+
+            else:
+                spice_kernels_collection_inventory.label = InventoryPDS3Label(
+                    setup, spice_kernels_collection, spice_kernels_collection_inventory)
+                
             spice_kernels_collection.add(spice_kernels_collection_inventory)
 
         if setup.pds_version == "4":
@@ -348,6 +361,11 @@ def run_pipeline(args: PipelineArgs) -> None:
 
                 log_step(setup, title=f'Generation of {document_collection.name} collection')
                 document_collection_inventory = InventoryProduct(setup, document_collection)
+
+                # This branch only runs for PDS4, so there's no PDS3 label to pick.
+                document_collection_inventory.label = InventoryPDS4Label(
+                    setup, document_collection, document_collection_inventory)
+
                 document_collection.add(document_collection_inventory)
 
             #
@@ -410,6 +428,13 @@ def run_pipeline(args: PipelineArgs) -> None:
                             setup, release_miscellaneous_collection
                         )
 
+                        # This runs once per past release, always PDS4-only,
+                        # same as the site above.
+                        release_miscellaneous_collection_inventory.label = InventoryPDS4Label(
+                            setup,
+                            release_miscellaneous_collection,
+                            release_miscellaneous_collection_inventory)
+
                         release_miscellaneous_collection.add(
                             release_miscellaneous_collection_inventory
                         )
@@ -461,6 +486,11 @@ def run_pipeline(args: PipelineArgs) -> None:
             miscellaneous_collection_inventory = InventoryProduct(
                 setup, miscellaneous_collection
             )
+
+            # The current release's own miscellaneous inventory, PDS4-only.
+            miscellaneous_collection_inventory.label = InventoryPDS4Label(
+                setup, miscellaneous_collection, miscellaneous_collection_inventory)
+
             miscellaneous_collection.add(miscellaneous_collection_inventory)
 
             #

--- a/tests/npb/test_classes_product_inventory.py
+++ b/tests/npb/test_classes_product_inventory.py
@@ -95,7 +95,6 @@ class TestInventoryProductInitPDS4:
         collection = make_collection()
 
         with patch(f"{MODULE}.InventoryProduct.write_product"), \
-             patch(f"{MODULE}.InventoryPDS4Label"), \
              patch(f"{MODULE}.Product.__init__", return_value=None):
             obj = InventoryProduct(setup, collection)
 
@@ -119,12 +118,10 @@ class TestInventoryProductInitPDS4:
         collection = make_collection()
 
         with patch(f"{MODULE}.InventoryProduct.write_product") as mock_write_product, \
-             patch(f"{MODULE}.InventoryPDS4Label") as mock_label_cls, \
              patch(f"{MODULE}.Product.__init__", return_value=None):
             InventoryProduct(setup, collection)
 
         mock_write_product.assert_called_once()
-        mock_label_cls.assert_called_once()
 
         assert mock_glob.call_count == glob_call_count
 
@@ -141,7 +138,6 @@ class TestInventoryProductInitPDS3:
         collection = make_collection()
 
         with patch(f"{MODULE}.InventoryProduct.write_product"), \
-             patch(f"{MODULE}.InventoryPDS3Label"), \
              patch(f"{MODULE}.shutil.copy2"), \
              patch(f"{MODULE}.replace_string_in_file"), \
              patch(f"{MODULE}.Product.__init__", return_value=None):
@@ -152,19 +148,17 @@ class TestInventoryProductInitPDS3:
         assert obj.new_product is True
 
     def test_pds4_init_logic_testing(self):
-        """InventoryPDS3Label is instantiated for pds_version == '3'."""
+        """dsindex files are generated for pds_version == '3'."""
         setup = make_setup(pds_version="3")
         collection = make_collection()
 
         with patch(f"{MODULE}.InventoryProduct.write_product") as mock_write_product, \
-             patch(f"{MODULE}.InventoryPDS3Label") as mock_label_cls, \
              patch(f"{MODULE}.shutil.copy2") as mock_copy, \
              patch(f"{MODULE}.replace_string_in_file") as mock_replace, \
              patch(f"{MODULE}.Product.__init__", return_value=None):
             InventoryProduct(setup, collection)
 
         mock_write_product.assert_called_once()
-        mock_label_cls.assert_called_once()
 
         assert mock_copy.call_count == 2
 

--- a/tests/npb/test_classes_product_inventory.py
+++ b/tests/npb/test_classes_product_inventory.py
@@ -138,8 +138,6 @@ class TestInventoryProductInitPDS3:
         collection = make_collection()
 
         with patch(f"{MODULE}.InventoryProduct.write_product"), \
-             patch(f"{MODULE}.shutil.copy2"), \
-             patch(f"{MODULE}.replace_string_in_file"), \
              patch(f"{MODULE}.Product.__init__", return_value=None):
             obj = InventoryProduct(setup, collection)
 
@@ -147,25 +145,55 @@ class TestInventoryProductInitPDS3:
         assert obj.path == "staging/index/index.tab"
         assert obj.new_product is True
 
-    def test_pds4_init_logic_testing(self):
-        """dsindex files are generated for pds_version == '3'."""
+    def test_pds3_write_product_called_once(self):
+        """write_product() is called exactly once during __init__.
+
+        dsindex generation is no longer part of __init__ -- see
+        TestInventoryProductGenerateDsindexFiles below.
+        """
         setup = make_setup(pds_version="3")
         collection = make_collection()
 
         with patch(f"{MODULE}.InventoryProduct.write_product") as mock_write_product, \
-             patch(f"{MODULE}.shutil.copy2") as mock_copy, \
-             patch(f"{MODULE}.replace_string_in_file") as mock_replace, \
              patch(f"{MODULE}.Product.__init__", return_value=None):
             InventoryProduct(setup, collection)
 
         mock_write_product.assert_called_once()
 
-        assert mock_copy.call_count == 2
 
-        mock_replace.assert_called_once_with('staging/../dsindex.lbl',
-                                             '"INDEX.TAB"',
-                                             '"DSINDEX.TAB"',
-                                             setup)
+# ---------------------------------------------------------------------------
+# InventoryProduct.generate_dsindex_files
+# ---------------------------------------------------------------------------
+
+class TestInventoryProductGenerateDsindexFiles:
+    """Tests for generate_dsindex_files().
+
+    PDS3 only. Called by the pipeline after the PDS3 label has been built
+    and written to disk -- see the method's own docstring for why.
+    """
+
+    @staticmethod
+    def _make_obj():
+        obj = InventoryProduct.__new__(InventoryProduct)
+        obj.setup = make_setup(pds_version="3")
+        obj.path = "staging/index/index.tab"
+        return obj
+
+    def test_copies_index_and_label_to_dsindex(self):
+        obj = self._make_obj()
+
+        with patch(f"{MODULE}.shutil.copy2") as mock_copy, \
+             patch(f"{MODULE}.replace_string_in_file") as mock_replace:
+            obj.generate_dsindex_files()
+
+        assert mock_copy.call_count == 2
+        mock_copy.assert_any_call(obj.path, "staging/../dsindex.tab")
+        mock_copy.assert_any_call("staging/index/index.lbl", "staging/../dsindex.lbl")
+
+        mock_replace.assert_called_once_with(
+            "staging/../dsindex.lbl", '"INDEX.TAB"', '"DSINDEX.TAB"', obj.setup
+        )
+
 
 # ---------------------------------------------------------------------------
 # InventoryProduct.write_product

--- a/tests/npb/test_classes_product_kernel.py
+++ b/tests/npb/test_classes_product_kernel.py
@@ -134,8 +134,6 @@ def build_product(env, name="test.bsp", pds_version="4", extra_setup_kwargs=None
         patch(f"{_MODULE}.pck_coverage", return_value=["2000-01-01T00:00:00Z", "2020-01-01T00:00:00Z"]),
         patch(f"{_MODULE}.dsk_coverage", return_value=["2000-01-01T00:00:00Z", "2020-01-01T00:00:00Z"]),
         patch(f"{_MODULE}.Product.__init__", return_value=None),
-        patch(f"{_MODULE}.SpiceKernelPDS4Label", return_value=MagicMock()),
-        patch(f"{_MODULE}.SpiceKernelPDS3Label", return_value=MagicMock()),
     ):
         product = SpiceKernelProduct(setup, name, collection)
 
@@ -181,7 +179,6 @@ class TestSpiceKernelProductInit:
             patch(f"{_MODULE}.shutil.copy2"),
             patch(f"{_MODULE}.spk_coverage", return_value=["2000T", "2020T"]),
             patch(f"{_MODULE}.Product.__init__", return_value=None),
-            patch(f"{_MODULE}.SpiceKernelPDS4Label", return_value=MagicMock()),
         ):
             product = SpiceKernelProduct.__new__(SpiceKernelProduct)
             product.__init__(setup, "test.bsp", collection)
@@ -229,7 +226,6 @@ class TestSpiceKernelProductInit:
             patch(f"{_MODULE}.safe_make_directory"),
             patch(f"{_MODULE}.spk_coverage", return_value=["2000T", "2020T"]),
             patch(f"{_MODULE}.Product.__init__", return_value=None),
-            patch(f"{_MODULE}.SpiceKernelPDS4Label", return_value=MagicMock()),
         ):
             product = SpiceKernelProduct(setup, "test.bsp", collection)
 
@@ -255,7 +251,6 @@ class TestSpiceKernelProductInit:
             patch(f"{_MODULE}.shutil.copy2"),
             patch(f"{_MODULE}.spk_coverage", return_value=["2000T", "2020T"]),
             patch(f"{_MODULE}.Product.__init__", return_value=None),
-            patch(f"{_MODULE}.SpiceKernelPDS4Label", return_value=MagicMock()),
         ):
             product = SpiceKernelProduct(setup, "test.bsp", collection)
 
@@ -288,51 +283,17 @@ class TestSpiceKernelProductInit:
         assert product.observers == ["SPACECRAFT"]
         assert product.targets == ["MARS"]
 
-    def test_pds4_label_is_created(self, tmp_env):
-        with (
-            patch(f"{_MODULE}.extension_to_type", return_value="spk"),
-            patch(f"{_MODULE}.safe_make_directory"),
-            patch(f"{_MODULE}.shutil.copy2"),
-            patch(f"{_MODULE}.spk_coverage", return_value=["2000T", "2020T"]),
-            patch(f"{_MODULE}.Product.__init__", return_value=None),
-            patch(f"{_MODULE}.SpiceKernelPDS4Label") as mock_label,
-        ):
-            setup = make_setup(
-                pds_version="4",
-                staging_directory=tmp_env["staging"],
-                kernels_directory=[tmp_env["kernel_dir"]],
-                working_directory=tmp_env["work"],
-            )
-            write_kernel_file(tmp_env, "test.bsp")
-            write_kernel_list(tmp_env, setup, "test.bsp")
-            collection = make_collection()
+    def test_pds3_reads_maklabel_options(self, tmp_env):
+        # Labeling itself moved to the pipeline, but PDS3 labeling reads
+        # maklabel_options back off the product, so it still has to be set
+        # here.
+        product, _, _ = build_product(tmp_env, name="test.bsp", pds_version="3")
+        assert product.maklabel_options == ['MAKLABEL_OPT']
 
-            SpiceKernelProduct(setup, "test.bsp", collection)
-
-        mock_label.assert_called_once()
-
-    def test_pds3_label_is_created(self, tmp_env):
-        with (
-            patch(f"{_MODULE}.extension_to_type", return_value="spk"),
-            patch(f"{_MODULE}.safe_make_directory"),
-            patch(f"{_MODULE}.shutil.copy2"),
-            patch(f"{_MODULE}.spk_coverage", return_value=["2000T", "2020T"]),
-            patch(f"{_MODULE}.Product.__init__", return_value=None),
-            patch(f"{_MODULE}.SpiceKernelPDS3Label") as mock_label,
-        ):
-            setup = make_setup(
-                pds_version="3",
-                staging_directory=tmp_env["staging"],
-                kernels_directory=[tmp_env["kernel_dir"]],
-                working_directory=tmp_env["work"],
-            )
-            write_kernel_file(tmp_env, "test.bsp")
-            write_kernel_list(tmp_env, setup, "test.bsp")
-            collection = make_collection()
-
-            SpiceKernelProduct(setup, "test.bsp", collection)
-
-        mock_label.assert_called_once()
+    def test_pds4_does_not_set_maklabel_options(self, tmp_env):
+        # PDS4 labeling doesn't use maklabel_options at all.
+        product, _, _ = build_product(tmp_env, name="test.bsp", pds_version="4")
+        assert not hasattr(product, "maklabel_options")
 
 
 # ===========================================================================

--- a/tests/npb/test_classes_product_metakernel.py
+++ b/tests/npb/test_classes_product_metakernel.py
@@ -143,7 +143,6 @@ def base_init_patches():
         patch(f"{_MODULE}.MetaKernelProduct.compare"),
         patch(f"{_MODULE}.shutil.copy2"),
         patch(f"{_MODULE}.Product.__init__", return_value=None),
-        patch(f"{_MODULE}.MetaKernelPDS4Label", return_value=MagicMock()),
     ]
 
 
@@ -345,7 +344,6 @@ class TestMetaKernelProductInit:
             patch(f"{_MODULE}.mk_to_list", return_value=[]),
             patch(f"{_MODULE}.MetaKernelProduct.coverage"),
             patch(f"{_MODULE}.Product.__init__", return_value=None),
-            patch(f"{_MODULE}.MetaKernelPDS4Label", return_value=MagicMock()),
             patch(f"{_MODULE}.get_latest_kernel", return_value=[]),
         ):
             product = MetaKernelProduct(setup, "insight_v01.tm", collection)
@@ -374,19 +372,6 @@ class TestMetaKernelProductInit:
             extra_patches=[patch(f"{_MODULE}.MetaKernelProduct.compare", compare_mock)],
         )
         assert compare_mock.called == expect_compare
-
-    @pytest.mark.parametrize("pds_version, expect_label", [
-        ("4", True),
-        ("3", False)
-    ])
-    def test_pds4_label_created_only_for_pds4(self, tmp_path, pds_version, expect_label):
-        label_mock = MagicMock()
-        self._make_product(
-            tmp_path,
-            pds_version=pds_version,
-            extra_patches=[patch(f"{_MODULE}.MetaKernelPDS4Label", label_mock)],
-        )
-        assert label_mock.called == expect_label
 
     def test_no_matching_mk_config_raises(self, tmp_path):
         staging = str(tmp_path / "staging")
@@ -530,7 +515,6 @@ class TestMetaKernelProductInit:
             patch(f"{_MODULE}.MetaKernelProduct.write_product"),
             patch(f"{_MODULE}.MetaKernelProduct.coverage"),
             patch(f"{_MODULE}.Product.__init__", return_value=None),
-            patch(f"{_MODULE}.MetaKernelPDS4Label", return_value=MagicMock()),
             patch(f"{_MODULE}.MetaKernelProduct.check_version") as mock_check_version,
         ):
             MetaKernelProduct(setup, "insight_v01.tm", collection)
@@ -553,6 +537,9 @@ class TestMetaKernelProductInit:
         with caplog.at_level(logging.INFO):
             self._make_product(tmp_path)
 
+        # The "Labeling meta-kernel..." message and its leading blank line moved
+        # to the pipeline along with label construction, so they're not logged
+        # by the product's own __init__ anymore.
         expected = [
             (logging.INFO, '-- Generate meta-kernel: insight_v01.tm'),
             (logging.WARNING, f'-- Meta-kernel already exists: {tmp_path / "staging/spice_kernels/mk/insight_v01.tm"}'),
@@ -560,9 +547,7 @@ class TestMetaKernelProductInit:
                               'staging are will be overwritten.'),
             (logging.WARNING, '-- Note that to provide a meta-kernel as an input, it must be provided '
                               'via configuration file.'),
-            (logging.INFO, ''),
-            (logging.INFO, ''),
-            (logging.INFO, '-- Labeling meta-kernel: insight_v01.tm...')]
+            (logging.INFO, '')]
 
         results = [(r[1], r[2]) for r in caplog.record_tuples]
         assert expected == results

--- a/tests/npb/test_classes_product_orbnum.py
+++ b/tests/npb/test_classes_product_orbnum.py
@@ -101,14 +101,13 @@ class TestOrbnumFileProductInit:
             OrbnumFileProduct(mock_setup, "test_file.orb", mock_collection, mock_kernels_collection)
 
     @patch.object(Product, "register")
-    @patch(f"{MOD}.OrbnumFilePDS4Label")
     @patch(f"{MOD}.safe_make_directory")
     @patch(f"{MOD}.shutil.copy2")
     @patch(f"{MOD}.os.path.isfile", return_value=False)
     @patch(f"{MOD}.check_eol", return_value=True)
     def test_init_pds4_new_file(
         self,
-        mock_check_eol, _mock_isfile, _mock_copy2, _mock_safe_mkdir, _mock_label, _mock_register,
+        mock_check_eol, _mock_isfile, _mock_copy2, _mock_safe_mkdir, _mock_register,
         pds4_init_mocks,
         mock_setup, mock_collection, mock_kernels_collection,
     ):
@@ -144,13 +143,12 @@ class TestOrbnumFileProductInit:
         assert not hasattr(obj, "lid")
 
     @patch.object(Product, "register")
-    @patch(f"{MOD}.OrbnumFilePDS4Label")
     @patch(f"{MOD}.safe_make_directory")
     @patch(f"{MOD}.os.path.isfile", return_value=True)
     @patch(f"{MOD}.check_eol", return_value=False)
     def test_init_pds4_existing_file_no_overrides(
         self,
-        _mock_check_eol, _mock_isfile, _mock_safe_mkdir, _mock_label, _mock_register,
+        _mock_check_eol, _mock_isfile, _mock_safe_mkdir, _mock_register,
         pds4_init_mocks,
         mock_setup, mock_collection, mock_kernels_collection,
     ):
@@ -218,8 +216,7 @@ class TestOrbnumFileProductInit:
         for key in ("mission_name", "observer", "target"):
             mock_setup.orbnum[0].pop(key, None)
 
-        with patch(f"{MOD}.OrbnumFilePDS4Label") as mock_label, \
-                patch(f"{MOD}.get_latest_kernel", return_value=[]), \
+        with patch(f"{MOD}.get_latest_kernel", return_value=[]), \
                 patch.object(Product, "register"):
             obj = OrbnumFileProduct(mock_setup, "test_file.orb", mock_collection, mock_kernels_collection)
 
@@ -261,9 +258,6 @@ class TestOrbnumFileProductInit:
         assert obj.missions == ["mission1"]
         assert obj.observers == ["obs1"]
         assert obj.targets == ["target1"]
-
-        # The label was constructed exactly once.
-        mock_label.assert_called_once()
 
 
 class TestOrbnumFileProductSetPreviousOrbnum:

--- a/tests/npb/test_classes_product_readme.py
+++ b/tests/npb/test_classes_product_readme.py
@@ -64,21 +64,22 @@ def make_bundle(name='bundle_insight_spice_v001.xml', vid='1.0'):
 def build_product(setup, bundle):
     """Construct a ``ReadmeProduct`` with the heavy collaborators mocked.
 
-    ``Product.__init__`` and ``BundlePDS4Label`` are always patched so no
-    registration or labelling happens. ``md5`` is patched to a stable value.
-    ``_write_product`` is also patched out, isolating the constructor logic
-    from file generation.
+    ``Product.__init__`` is always patched so no registration happens.
+    ``md5`` is patched to a stable value. ``_write_product`` is also patched
+    out, isolating the constructor logic from file generation. Label
+    construction is no longer part of ``ReadmeProduct``'s own constructor
+    (it now happens in the pipeline right after the product is built), so
+    there is nothing label-related to patch here.
 
     :param setup:  mock Setup object
     :param bundle: mock Bundle object
     :return:       tuple ``(product, mocks_dict)``
     """
     with patch(f'{MOD}.Product.__init__', return_value=None) as m_init, \
-         patch(f'{MOD}.BundlePDS4Label') as m_label, \
          patch(f'{MOD}.md5', return_value='d' * 32) as m_md5, \
          patch.object(ReadmeProduct, '_write_product') as m_write:
         product = ReadmeProduct(setup, bundle)
-        mocks = {'init': m_init, 'label': m_label, 'md5': m_md5, 'write': m_write}
+        mocks = {'init': m_init, 'md5': m_md5, 'write': m_write}
         return product, mocks
 
 
@@ -114,9 +115,8 @@ class TestReadmeProductInit:
         # collection is a SimpleNamespace with an empty name attribute.
         assert product.collection.name == ''
 
-        # The base Product constructor and the bundle label are invoked once each.
+        # The base Product constructor is invoked once.
         mocks['init'].assert_called_once()
-        mocks['label'].assert_called_once_with(setup, product)
 
     def test_init_final_path_points_to_bundle_name(self, tmp_path):
         # After construction self.path is rewritten to staging + bundle.name so
@@ -154,7 +154,6 @@ class TestReadmeProductInit:
         # Final path is still rewritten to the bundle name for the label.
         expected = setup.staging_directory + os.sep + bundle.name
         assert product.path == expected
-        mocks['label'].assert_called_once_with(setup, product)
 
     def test_init_logs_existing_readme_message(self, tmp_path, caplog):
         # The "already exists" path logs the corresponding info message.
@@ -170,14 +169,15 @@ class TestReadmeProductInit:
 
         expected = [
             (logging.INFO, '-- Readme file already exists in final area.'),
-            (logging.INFO, ''),
-            (logging.INFO, '-- Generating bundle label...')]
+            (logging.INFO, '')]
 
         messages = [(r[1], r[2]) for r in caplog.record_tuples]
         assert messages == expected
 
     def test_init_logs_generating_readme_messages(self, tmp_path, caplog):
-        # The "generate" path logs the generation notice and the label notice.
+        # The "generate" path logs the generation notice. The bundle-label
+        # notice is no longer logged here -- it moved to the pipeline,
+        # alongside the label construction call it describes.
         setup = make_setup(tmp_path)
         bundle = make_bundle()
 
@@ -186,8 +186,7 @@ class TestReadmeProductInit:
 
         expected = [
             (logging.INFO, '-- Generating readme file...'),
-            (logging.INFO, ''),
-            (logging.INFO, '-- Generating bundle label...')]
+            (logging.INFO, '')]
 
         messages = [(r[1], r[2]) for r in caplog.record_tuples]
 

--- a/tests/npb/test_classes_product_spiceds.py
+++ b/tests/npb/test_classes_product_spiceds.py
@@ -64,17 +64,18 @@ def base_init_patches():
 
     Every constructor test that reaches the 'spiceds provided' tail needs the
     same external collaborators stubbed: the file copy into staging, the CR
-    normalisation, the product self-check, the optional comparison, the base
-    ``Product.__init__`` and the PDS4 label. A fresh list per call keeps the
-    patch objects single-use.
+    normalisation, the product self-check, the optional comparison and the
+    base ``Product.__init__``. Labeling is no longer part of this
+    constructor (it now happens in the pipeline), so there's nothing
+    label-related left to stub here. A fresh list per call keeps the patch
+    objects single-use.
     """
     return [
         patch(f'{_MODULE}.shutil.copy2'),
         patch.object(SpicedsProduct, '_check_cr'),
         patch.object(SpicedsProduct, '_check_product', return_value=True),
         patch.object(SpicedsProduct, '_compare'),
-        patch(f'{_MODULE}.Product.__init__', return_value=None),
-        patch(f'{_MODULE}.DocumentPDS4Label', return_value=MagicMock())]
+        patch(f'{_MODULE}.Product.__init__', return_value=None)]
 
 
 # ---------------------------------------------------------------------------
@@ -91,7 +92,7 @@ class TestSpicedsProductInit:
         # Common first-release path: no increment and a 'spiceds' provided.
         # Drives the whole tail of the constructor and pins down the derived
         # name/path/lid/vid plus the ordering side effects (copy, CR check,
-        # product check, label).
+        # product check).
         setup = make_setup(increment=False, diff=False)
         collection = make_collection(name='document')
 
@@ -100,8 +101,7 @@ class TestSpicedsProductInit:
                 patches[1] as check_cr, \
                 patches[2] as check_product, \
                 patches[3] as compare, \
-                patches[4] as base_init, \
-                patches[5] as label:
+                patches[4] as base_init:
             product = SpicedsProduct(setup, collection)
 
         # Version 1 because there is no previous increment.
@@ -130,43 +130,38 @@ class TestSpicedsProductInit:
         check_product.assert_called_once_with()
         base_init.assert_called_once()
 
-        # diff is False so _compare must be skipped, but the label is built.
+        # diff is False so _compare must be skipped.
         compare.assert_not_called()
-        label.assert_called_once_with(setup, collection, product)
 
     def test_init_runs_compare_when_diff_enabled(self):
-        # When setup.diff is truthy and the product is generated, _compare runs
-        # before the label is built.
+        # When setup.diff is truthy and the product is generated, _compare runs.
         setup = make_setup(increment=False, diff=True)
         collection = make_collection()
 
         patches = base_init_patches()
         with patches[0], patches[1], \
                 patches[2], patches[3] as compare, \
-                patches[4], patches[5] as label:
+                patches[4]:
             product = SpicedsProduct(setup, collection)
 
         compare.assert_called_once_with()
-        label.assert_called_once()
         assert product.generated is True
 
-    def test_init_skips_label_when_not_generated(self):
+    def test_init_skips_compare_when_not_generated(self):
         # When _check_product returns False the product is not generated, so
-        # neither the comparison nor the label run.
+        # the comparison doesn't run either -- self.generated is also what
+        # the pipeline reads to decide whether to build the label.
         setup = make_setup(increment=False, diff=True)
         collection = make_collection()
 
         patches = base_init_patches()
         with patches[0], patches[1], \
                 patch.object(SpicedsProduct, '_check_product', return_value=False), \
-                patches[3] as compare, patches[4], \
-                patches[5] as label:
+                patches[3] as compare, patches[4]:
             product = SpicedsProduct(setup, collection)
 
-        # Not generated => neither the comparison nor the label run.
         assert product.generated is False
         compare.assert_not_called()
-        label.assert_not_called()
 
     def test_init_increment_with_previous_version_and_new_spiceds(self):
         # Increment + previous 'spiceds' files + a new 'spiceds' provided. glob
@@ -185,7 +180,7 @@ class TestSpicedsProductInit:
         patches = base_init_patches()
         with patch(f'{_MODULE}.glob.glob', return_value=list(previous)) as glob_mock, \
                 patches[0] as copy2, patches[1], patches[2], \
-                patches[3], patches[4], patches[5]:
+                patches[3], patches[4]:
             product = SpicedsProduct(setup, collection)
 
         # The search path is bundle/<acronym>_spice/<collection>.
@@ -231,7 +226,7 @@ class TestSpicedsProductInit:
         patches = base_init_patches()
         with patch(f'{_MODULE}.glob.glob', return_value=[]), \
                 patches[0], patches[1], patches[2], \
-                patches[3], patches[4], patches[5]:
+                patches[3], patches[4]:
             product = SpicedsProduct(setup, collection)
 
         assert product.version == 1

--- a/tests/npb/test_pipeline_npb.py
+++ b/tests/npb/test_pipeline_npb.py
@@ -78,6 +78,8 @@ _PATCH_TARGETS = [
     'BundlePDS4Label',
     'InventoryPDS3Label',
     'InventoryPDS4Label',
+    'SpiceKernelPDS3Label',
+    'SpiceKernelPDS4Label',
     'clear_run',
     'finish_execution',
     'log_step',
@@ -496,6 +498,35 @@ class TestPhase6StagingBundleAndCollections:
         mocks.ReleasePlan.return_value.kernel_list = ['maven_2024.bsp']
         run_pipeline(_args())
         mocks.SpiceKernelProduct.assert_called_once()
+
+    def test_kernel_product_labeled_with_pds4_label(self, mocks):
+        # One kernel in the list, so exactly one product is dispatched and
+        # exactly one label call to check for.
+        mocks.ReleasePlan.return_value.kernel_list = ['maven_2024.bsp']
+        run_pipeline(_args())
+        kernel_product = mocks.SpiceKernelProduct.return_value
+
+        # Unlike InventoryPDS4Label, this label class is only ever used here, so
+        # assert_called_once_with is safe (no other site shares it).
+        mocks.SpiceKernelPDS4Label.assert_called_once_with(
+            mocks.Setup.return_value, kernel_product)
+
+        # The label built above is what ends up assigned back onto the product.
+        assert kernel_product.label is mocks.SpiceKernelPDS4Label.return_value
+
+    def test_kernel_product_labeled_with_pds3_label(self, mocks):
+        # Same setup as above, but switched to PDS3.
+        mocks.Setup.return_value.pds_version = '3'
+        mocks.ReleasePlan.return_value.kernel_list = ['maven_2024.bsp']
+        run_pipeline(_args())
+        kernel_product = mocks.SpiceKernelProduct.return_value
+
+        # PDS3 picks the PDS3 label class instead -- this is the branch that
+        # used to live inside SpiceKernelProduct.__init__.
+        mocks.SpiceKernelPDS3Label.assert_called_once_with(
+            mocks.Setup.return_value, kernel_product)
+
+        assert kernel_product.label is mocks.SpiceKernelPDS3Label.return_value
 
     def test_orbnum_product_dispatched_for_nrb_kernel(self, mocks):
         # .nrb files are dispatched to OrbnumFileProduct and added to the miscellaneous collection.

--- a/tests/npb/test_pipeline_npb.py
+++ b/tests/npb/test_pipeline_npb.py
@@ -76,6 +76,8 @@ _PATCH_TARGETS = [
     'DocumentCollection',
     'ReadmeProduct',
     'BundlePDS4Label',
+    'InventoryPDS3Label',
+    'InventoryPDS4Label',
     'clear_run',
     'finish_execution',
     'log_step',
@@ -682,6 +684,38 @@ class TestPhase8CollectionMetadata:
         assert len(calls_for_skc) == 1
         skc.add.assert_called()
 
+    def test_skc_inventory_labeled_with_pds4_label(self, mocks):
+        # Force the SKC inventory branch to run at all.
+        mocks.SpiceKernelsCollection.return_value.updated = True
+        run_pipeline(_args())
+        skc = mocks.SpiceKernelsCollection.return_value
+        inventory = mocks.InventoryProduct.return_value
+
+        # The label is built with (setup, collection, inventory product).
+        # assert_any_call, not assert_called_once: the misc inventory (built
+        # later in the same run, always PDS4) calls this same label class too,
+        # so InventoryPDS4Label fires more than once.
+        mocks.InventoryPDS4Label.assert_any_call(
+            mocks.Setup.return_value, skc, inventory)
+
+        # The label built above is what actually gets assigned back.
+        assert inventory.label is mocks.InventoryPDS4Label.return_value
+
+    def test_skc_inventory_labeled_with_pds3_label(self, mocks):
+        # Same setup as above, but switched to PDS3.
+        mocks.Setup.return_value.pds_version = '3'
+        mocks.SpiceKernelsCollection.return_value.updated = True
+        run_pipeline(_args())
+        skc = mocks.SpiceKernelsCollection.return_value
+        inventory = mocks.InventoryProduct.return_value
+
+        # PDS3 has no misc-inventory branch, so this is the only call --
+        # assert_called_once_with is safe here, unlike the PDS4 test above.
+        mocks.InventoryPDS3Label.assert_called_once_with(
+            mocks.Setup.return_value, skc, inventory)
+        
+        assert inventory.label is mocks.InventoryPDS3Label.return_value
+
 
 # ---------------------------------------------------------------------------
 # Phase 9 – PDS4 document + miscellaneous + checksum
@@ -733,6 +767,21 @@ class TestPhase9PDS4DocumentMiscChecksum:
             if c[0][1] is doc_col
         ]
         assert len(inventory_calls_for_doc) >= 1
+
+    def test_document_inventory_labeled_with_pds4_label(self, mocks):
+        # This inventory only gets built when spiceds was generated.
+        mocks.SpicedsProduct.return_value.generated = True
+        run_pipeline(_args())
+        doc_col = mocks.DocumentCollection.return_value
+        inventory = mocks.InventoryProduct.return_value
+
+        # PDS4 only -- there's no PDS3 branch for the document collection.
+        # assert_any_call: the misc inventory built later shares the same mock
+        # InventoryProduct/InventoryPDS4Label return values.
+        mocks.InventoryPDS4Label.assert_any_call(
+            mocks.Setup.return_value, doc_col, inventory)
+        
+        assert inventory.label is mocks.InventoryPDS4Label.return_value
 
     def test_document_inventory_not_created_when_spiceds_not_generated(self, mocks):
         # When SPICEDS is not generated, no inventory is created for the document collection.
@@ -809,6 +858,19 @@ class TestPhase9PDS4DocumentMiscChecksum:
         run_pipeline(_args())
         mocks.MiscellaneousCollection.return_value.set_collection_vid.assert_called()
 
+    def test_miscellaneous_inventory_labeled_with_pds4_label(self, mocks):
+        # Default mocks: SKC not updated, spiceds not generated, no  backfill
+        # -- this is the only inventory built in this run, so it's the only
+        # InventoryPDS4Label call to check for.
+        run_pipeline(_args())
+        misc = mocks.MiscellaneousCollection.return_value
+        inventory = mocks.InventoryProduct.return_value
+        
+        mocks.InventoryPDS4Label.assert_called_once_with(
+            mocks.Setup.return_value, misc, inventory)
+
+        assert inventory.label is mocks.InventoryPDS4Label.return_value
+
     def test_backfill_loop_runs_when_increment_and_no_checksum_dir(self, mocks):
         # When the checksum directory is absent, one ChecksumProduct is created per past release.
         setup = mocks.Setup.return_value
@@ -826,6 +888,22 @@ class TestPhase9PDS4DocumentMiscChecksum:
             if c[1].get('add_previous_checksum') is False
         ]
         assert len(backfill_calls) == len(bundle.history)
+
+    def test_release_miscellaneous_inventory_labeled_during_backfill(self, mocks):
+        # Same trigger as the ChecksumProduct backfill test above: an increment
+        # with no existing checksum dir runs the backfill loop once per past
+        # release.
+        setup = mocks.Setup.return_value
+        setup.increment = True
+        mocks.isdir.return_value = False
+        bundle = mocks.Bundle.return_value
+        bundle.history = {'release_01': ('data', 'label'),
+                          'release_02': ('data2', 'label2')}
+        run_pipeline(_args())
+
+        # One InventoryPDS4Label call per historical release (backfill loop),
+        # plus one for the current release's own inventory.
+        assert mocks.InventoryPDS4Label.call_count == len(bundle.history) + 1
 
     def test_backfill_loop_skipped_when_checksum_dir_exists(self, mocks):
         # When the checksum directory already exists, the backfill loop does not run.

--- a/tests/npb/test_pipeline_npb.py
+++ b/tests/npb/test_pipeline_npb.py
@@ -78,6 +78,7 @@ _PATCH_TARGETS = [
     'BundlePDS4Label',
     'InventoryPDS3Label',
     'InventoryPDS4Label',
+    'OrbnumFilePDS4Label',
     'SpiceKernelPDS3Label',
     'SpiceKernelPDS4Label',
     'clear_run',
@@ -540,6 +541,31 @@ class TestPhase6StagingBundleAndCollections:
         mocks.ReleasePlan.return_value.kernel_list = ['maven_2024.orb']
         run_pipeline(_args())
         mocks.OrbnumFileProduct.assert_called_once()
+
+    def test_orbnum_product_labeled_with_pds4_label(self, mocks):
+        # One kernel in the list, so exactly one product and one label call.
+        mocks.ReleasePlan.return_value.kernel_list = ['maven_2024.orb']
+        run_pipeline(_args())
+        orbnum_product = mocks.OrbnumFileProduct.return_value
+
+        # PDS4 only -- there's no PDS3 label for orbnum files at all, so this
+        # class is never shared with another call site.
+        mocks.OrbnumFilePDS4Label.assert_called_once_with(
+            mocks.Setup.return_value, orbnum_product)
+
+        # The label built above is what ends up assigned back onto the product.
+        assert orbnum_product.label is mocks.OrbnumFilePDS4Label.return_value
+
+    def test_orbnum_product_not_labeled_for_pds3(self, mocks):
+        # Product is still built for PDS3 (it archives to "extras", not
+        # "spice_kernels")...
+        mocks.Setup.return_value.pds_version = '3'
+        mocks.ReleasePlan.return_value.kernel_list = ['maven_2024.orb']
+        run_pipeline(_args())
+
+        # ...but this mirrors the guard that used to live inside
+        # OrbnumFileProduct itself: no label at all when not PDS4.
+        mocks.OrbnumFilePDS4Label.assert_not_called()
 
     def test_tm_kernel_skipped_in_product_dispatch_loop(self, mocks):
         # .tm files are skipped; meta-kernels are handled in a later dedicated step.

--- a/tests/npb/test_pipeline_npb.py
+++ b/tests/npb/test_pipeline_npb.py
@@ -75,6 +75,7 @@ _PATCH_TARGETS = [
     'SpicedsProduct',
     'DocumentCollection',
     'ReadmeProduct',
+    'BundlePDS4Label',
     'clear_run',
     'finish_execution',
     'log_step',
@@ -791,6 +792,17 @@ class TestPhase9PDS4DocumentMiscChecksum:
         mocks.ReadmeProduct.assert_called_once_with(
             mocks.Setup.return_value, mocks.Bundle.return_value
         )
+
+    def test_bundle_label_constructed_after_readme_product(self, mocks):
+        # Label construction now happens here, not inside ReadmeProduct, so
+        # this test is what guards it: built from the readme product and
+        # assigned back as product.label, which other modules read later.
+        run_pipeline(_args())
+        readme_product = mocks.ReadmeProduct.return_value
+        mocks.BundlePDS4Label.assert_called_once_with(
+            mocks.Setup.return_value, readme_product
+        )
+        assert readme_product.label is mocks.BundlePDS4Label.return_value
 
     def test_misc_collection_vid_set(self, mocks):
         # The miscellaneous collection version ID is updated after its products are finalized.

--- a/tests/npb/test_pipeline_npb.py
+++ b/tests/npb/test_pipeline_npb.py
@@ -76,6 +76,7 @@ _PATCH_TARGETS = [
     'DocumentCollection',
     'ReadmeProduct',
     'BundlePDS4Label',
+    'DocumentPDS4Label',
     'InventoryPDS3Label',
     'InventoryPDS4Label',
     'MetaKernelPDS4Label',
@@ -839,6 +840,30 @@ class TestPhase9PDS4DocumentMiscChecksum:
         mocks.SpicedsProduct.assert_called_once_with(
             mocks.Setup.return_value, mocks.DocumentCollection.return_value
         )
+
+    def test_spiceds_labeled_with_pds4_label_when_generated(self, mocks):
+        # Force the "spiceds changed" branch so labeling actually runs.
+        mocks.SpicedsProduct.return_value.generated = True
+        run_pipeline(_args())
+        spiceds = mocks.SpicedsProduct.return_value
+        doc_col = mocks.DocumentCollection.return_value
+
+        # DocumentPDS4Label is only ever used for spiceds, so
+        # assert_called_once_with is safe (no other call site shares it).
+        mocks.DocumentPDS4Label.assert_called_once_with(
+            mocks.Setup.return_value, doc_col, spiceds)
+
+        # The label built above is what ends up assigned back onto the product.
+        assert spiceds.label is mocks.DocumentPDS4Label.return_value
+
+    def test_spiceds_not_labeled_when_not_generated(self, mocks):
+        # generated=False is the default mock value (an unchanged spiceds file
+        # needs no new release), so no override is needed here.
+        run_pipeline(_args())
+        
+        # Mirrors the guard that used to live inside SpicedsProduct itself:
+        # nothing is labeled when the file hasn't changed.
+        mocks.DocumentPDS4Label.assert_not_called()
 
     def test_document_inventory_created_when_spiceds_generated(self, mocks):
         # When a SPICEDS document is generated, it and its inventory are added to the document collection.

--- a/tests/npb/test_pipeline_npb.py
+++ b/tests/npb/test_pipeline_npb.py
@@ -78,6 +78,7 @@ _PATCH_TARGETS = [
     'BundlePDS4Label',
     'InventoryPDS3Label',
     'InventoryPDS4Label',
+    'MetaKernelPDS4Label',
     'OrbnumFilePDS4Label',
     'SpiceKernelPDS3Label',
     'SpiceKernelPDS4Label',
@@ -598,6 +599,23 @@ class TestPhase6StagingBundleAndCollections:
         mocks.MetaKernelProduct.assert_called_once()
         mocks.SpiceKernelsCollection.return_value.add.assert_called()
 
+    def test_meta_kernel_labeled_with_pds4_label(self, mocks):
+        # One meta-kernel determined, so exactly one product and one label call.
+        mocks.SpiceKernelsCollection.return_value.determine_meta_kernels.return_value = {
+            'maven_v01.tm': None
+        }
+        mocks.Setup.return_value.pds_version = '4'
+        run_pipeline(_args())
+        meta_kernel = mocks.MetaKernelProduct.return_value
+
+        # PDS4 only -- there's no PDS3 meta-kernel label, so this class is never
+        # shared with another call site.
+        mocks.MetaKernelPDS4Label.assert_called_once_with(
+            mocks.Setup.return_value, meta_kernel)
+
+        # The label built above is what ends up assigned back onto the product.
+        assert meta_kernel.label is mocks.MetaKernelPDS4Label.return_value
+
     def test_meta_kernel_product_added_to_misc_for_pds3(self, mocks):
         # In PDS3 mode, a determined meta-kernel is added to the miscellaneous collection.
         mocks.SpiceKernelsCollection.return_value.determine_meta_kernels.return_value = {
@@ -607,6 +625,17 @@ class TestPhase6StagingBundleAndCollections:
         run_pipeline(_args())
         mocks.MetaKernelProduct.assert_called_once()
         mocks.MiscellaneousCollection.return_value.add.assert_called()
+
+    def test_meta_kernel_not_labeled_for_pds3(self, mocks):
+        # Product is still built for PDS3 (dispatched to the miscellaneous
+        # collection instead), but mirrors the guard that used to live inside
+        # MetaKernelProduct itself: no label at all when not PDS4.
+        mocks.SpiceKernelsCollection.return_value.determine_meta_kernels.return_value = {
+            'maven_v01.tm': None
+        }
+        mocks.Setup.return_value.pds_version = '3'
+        run_pipeline(_args())
+        mocks.MetaKernelPDS4Label.assert_not_called()
 
     def test_no_meta_kernel_product_when_none_determined(self, mocks):
         # When determine_meta_kernels returns empty, no MetaKernelProduct is constructed.


### PR DESCRIPTION
## 🗒️ Summary
Moves label construction out of product constructors and into the pipeline (`run_pipeline`), for the six product types where this was straightforward: `ReadmeProduct`, `InventoryProduct`, `SpiceKernelProduct`, `OrbnumFileProduct`, `MetaKernelProduct`, `SpicedsProduct`. Products no longer import or construct their own label classes; the pipeline decides when and which label to build, right after each product is constructed. `ChecksumProduct` is intentionally out of scope (see issue).

One regression surfaced and was fixed in the process: moving `InventoryProduct`'s PDS3 label construction out of `__init__` broke the PDS3 dsindex.tab/.lbl generation, which copies `index.lbl` -- a file the label writes, not the product. Fixed by pulling that copy into its own method, `generate_dsindex_files()`, called by the pipeline only after the
label exists.

## ⚙️ Test Data and/or Report
Regression tests included: new/updated tests across all six touched product test files and `test_pipeline_npb.py`, asserting each label call site fires with the right arguments and gets assigned back onto the product.

    pytest tests/npb/test_classes_product_readme.py tests/npb/test_classes_product_inventory.py \
           tests/npb/test_classes_product_kernel.py tests/npb/test_classes_product_orbnum.py \
           tests/npb/test_classes_product_metakernel.py tests/npb/test_classes_product_spiceds.py \
           tests/npb/test_pipeline_npb.py --cov-branch -v
    403 passed, 1 xfailed

    Name                                                              Stmts   Miss Branch BrPart  Cover
    ----------------------------------------------------------------------------------------------------
    src/pds/naif_pds4_bundler/classes/product/product_inventory.py      190      0     78      0   100%
    src/pds/naif_pds4_bundler/classes/product/product_kernel.py         163      0     72      0   100%
    src/pds/naif_pds4_bundler/classes/product/product_readme.py          66      0     24      0   100%
    src/pds/naif_pds4_bundler/classes/product/product_spiceds.py        111      0     28      0   100%
    src/pds/naif_pds4_bundler/pipeline/npb.py                           206      0     68      0   100%

    Full merge-gate suite (pytest tests/npb/ --cov-branch):
    1842 passed, 7 skipped, 1 xfailed, 99% overall coverage

Manual verification:
* `grep -rE "self\.label\s*=\s*\w+Label\(" classes/product/product_{readme,inventory,kernel,orbnum,metakernel,spiceds}.py` → no output (no in-scope product constructs its own label anymore)
* `grep -rn "from ..label import" classes/product/product_{readme,inventory,kernel,orbnum,metakernel,spiceds}.py` → no output
* Full functional/regression/unit suite (`python3 -m unittest discover -s tests/naif_pds4_bundler`, 132 tests, real pipeline runs against InSight/MAVEN/MRO/MSL/M2020/DART/CLPS/BC/LADEE configs): initially caught the PDS3 dsindex regression above (`test_mro_basic`, `test_msl`, `test_pds3_ltl_endianness`, `test_pds3_ltl_endianness_config` failed with `FileNotFoundError`); after the fix, `Ran 132 tests ... OK`.

## ♻️ Related Issues
Fixes #335
