### PR TITLE
Refactor(L-05): move checksum label construction to the pipeline

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/product/product_checksum.py
+++ b/src/pds/naif_pds4_bundler/classes/product/product_checksum.py
@@ -8,8 +8,6 @@ from typing import Optional
 
 from .product import Product
 from ..exceptions import NPBError
-from ..label import ChecksumPDS3Label
-from ..label import ChecksumPDS4Label
 from ...utils import add_carriage_return
 from ...utils import checksum_from_label
 from ...utils import checksum_from_registry
@@ -82,7 +80,7 @@ class ChecksumProduct(Product):
         self.write_product(history=None, set_coverage=True)
 
     def generate(self, history: Optional[list] = None) -> None:
-        """Write and label the Checksum file.
+        """Write the Checksum file.
 
         :param history: If not None, the checksum will be generated with the archive
                         history.
@@ -98,16 +96,6 @@ class ChecksumProduct(Product):
         #
         self.new_product = True
         Product.__init__(self)
-
-        #
-        # The checksum is labeled.
-        #
-        logging.info('-- Labeling %s...', self.name)
-
-        if self.setup.pds_version == "4":
-            self.label = ChecksumPDS4Label(self.setup, self)
-        else:
-            self.label = ChecksumPDS3Label(self.setup, self)
 
     def read_current_product(self, add_previous_checksum: bool = True) -> None:
         """Reads the current checksum file.

--- a/src/pds/naif_pds4_bundler/pipeline/npb.py
+++ b/src/pds/naif_pds4_bundler/pipeline/npb.py
@@ -12,6 +12,8 @@ from ..classes.collection import MiscellaneousCollection
 from ..classes.collection import SpiceKernelsCollection
 from ..classes.exceptions import NPBError
 from ..classes.label import BundlePDS4Label
+from ..classes.label import ChecksumPDS3Label
+from ..classes.label import ChecksumPDS4Label
 from ..classes.label import DocumentPDS4Label
 from ..classes.label import InventoryPDS3Label
 from ..classes.label import InventoryPDS4Label
@@ -440,6 +442,12 @@ def run_pipeline(args: PipelineArgs) -> None:
                         )
                         release_checksum.generate(history=release)
 
+                        # Labeling used to happen inside ChecksumProduct.generate()
+                        # itself. This whole branch only runs for PDS4, so
+                        # there's no PDS3 label to pick here.
+                        logging.info('-- Labeling %s...', release_checksum.name)
+                        release_checksum.label = ChecksumPDS4Label(setup, release_checksum)
+
                         #
                         # Initialize a miscellaneous collection for this previous
                         # release.
@@ -548,6 +556,13 @@ def run_pipeline(args: PipelineArgs) -> None:
             #   Miscellaneous Collection Inventory.
             #
             checksum.generate()
+
+            # Labeling used to happen inside ChecksumProduct.generate() itself.
+            # This branch only runs for PDS4, so there's no PDS3 label to pick
+            # here.
+            logging.info('-- Labeling %s...', checksum.name)
+            checksum.label = ChecksumPDS4Label(setup, checksum)
+
             miscellaneous_collection.add(checksum)
 
         else:  # if setup.pds_version == "3":
@@ -566,6 +581,13 @@ def run_pipeline(args: PipelineArgs) -> None:
                 setup, miscellaneous_collection, add_previous_checksum=False
             )
             checksum.generate()
+
+            # Labeling used to happen inside ChecksumProduct.generate() itself.
+            # This branch only runs for PDS3, so there's no PDS4 label to pick
+            # here.
+            logging.info('-- Labeling %s...', checksum.name)
+            checksum.label = ChecksumPDS3Label(setup, checksum)
+
             miscellaneous_collection.add(checksum)
 
         #

--- a/tests/npb/test_classes_product_checksum.py
+++ b/tests/npb/test_classes_product_checksum.py
@@ -53,8 +53,6 @@ PATCHES = dict(
     checksum_from_label=f"{MOD}.checksum_from_label",
     compare_files=f"{MOD}.compare_files",
     Product_init=f"{MOD}.Product.__init__",
-    ChecksumPDS4Label=f"{MOD}.ChecksumPDS4Label",
-    ChecksumPDS3Label=f"{MOD}.ChecksumPDS3Label",
     os_walk=f"{MOD}.os.walk",
     os_remove=f"{MOD}.os.remove",
     os_path_isfile=f"{MOD}.os.path.isfile",
@@ -332,40 +330,27 @@ class TestSetCoverage:
 class TestGenerate:
     """Tests for generate."""
 
-    def test_generate_pds4_creates_pds4_label(self):
-
+    def test_generate_writes_product_and_calls_parent_init(self):
+        # generate() used to also pick a label class and set self.label; that
+        # moved to npb.py, so this test checks what's left: writing the file
+        # and filling in the attributes Product.__init__ sets.
         obj, _ = _build_pds4(increment=False)
-        obj.new_product = False  # reset
-        fake_label = MagicMock()
+        obj.new_product = False  # reset, so we can check generate() flips it back to True
+        obj.label = None  # pre-set, so the assertion below proves generate() left it alone
 
         with patch.object(obj, "write_product") as m_wp, \
-             patch(PATCHES["Product_init"]) as m_parent, \
-             patch(PATCHES["ChecksumPDS4Label"], return_value=fake_label) as m_lbl4, \
-             patch(PATCHES["ChecksumPDS3Label"]) as m_lbl3:
+             patch(PATCHES["Product_init"]) as m_parent:
 
             obj.generate(history=['some_file'])
 
-        m_lbl4.assert_called_once_with(obj.setup, obj)
-        m_lbl3.assert_not_called()
         m_wp.assert_called_once_with(history=['some_file'])
         m_parent.assert_called_once()
 
-        # Generate sets new product and assigns the new label.
         assert obj.new_product is True
-        assert obj.label is fake_label
 
-    def test_generate_pds3_creates_pds3_label(self):
-        obj = _build_pds3()
-
-        with patch.object(obj, "write_product"), \
-             patch(PATCHES["Product_init"]), \
-             patch(PATCHES["ChecksumPDS4Label"]) as m_lbl4, \
-             patch(PATCHES["ChecksumPDS3Label"]) as m_lbl3:
-
-            obj.generate(history=None)
-
-        m_lbl3.assert_called_once_with(obj.setup, obj)
-        m_lbl4.assert_not_called()
+        # The regression guard for this whole refactor: if labeling ever creeps
+        # back into generate(), this is the assertion that catches it.
+        assert obj.label is None
 
 # ===========================================================================
 # ChecksumProduct.write_product

--- a/tests/npb/test_pipeline_npb.py
+++ b/tests/npb/test_pipeline_npb.py
@@ -49,6 +49,13 @@ class _StubChecksum:
     def __init__(self, _setup=None, _collection=None, **_kw):
         self.new_product = True
 
+        # This stub's own generate() below is a no-op, so it never needed a
+        # .name before. Now npb.py logs and reads release_checksum.name /
+        # checksum.name itself, right after calling generate() -- without this
+        # attribute, tests that swap in this stub would crash the pipeline with
+        # an AttributeError.
+        self.name = "checksum.tab"
+
     def set_coverage(self): pass  # no-op: test only observes new_product flag
     def generate(self, history=None): pass  # no-op: output generation not under test
     def read_current_product(self, **_kw): pass  # no-op: reading existing products not under test
@@ -76,6 +83,8 @@ _PATCH_TARGETS = [
     'DocumentCollection',
     'ReadmeProduct',
     'BundlePDS4Label',
+    'ChecksumPDS3Label',
+    'ChecksumPDS4Label',
     'DocumentPDS4Label',
     'InventoryPDS3Label',
     'InventoryPDS4Label',
@@ -946,6 +955,20 @@ class TestPhase9PDS4DocumentMiscChecksum:
         run_pipeline(_args())
         mocks.ChecksumProduct.return_value.generate.assert_called()
 
+    def test_checksum_labeled_with_pds4_label(self, mocks):
+        # generate() no longer builds the label itself -- npb.py must build it
+        # right after generate() returns and assign it back onto the product,
+        # the same way it already does for every other product type.
+        run_pipeline(_args())
+        checksum = mocks.ChecksumProduct.return_value
+
+        # Default mocks run no backfill loop, so this is the only checksum built
+        # in this test -- assert_called_once_with is safe here.
+        mocks.ChecksumPDS4Label.assert_called_once_with(
+            mocks.Setup.return_value, checksum)
+
+        assert checksum.label is mocks.ChecksumPDS4Label.return_value
+
     def test_readme_product_created(self, mocks):
         # A ReadmeProduct is created with the shared setup and bundle.
         run_pipeline(_args())
@@ -1015,6 +1038,24 @@ class TestPhase9PDS4DocumentMiscChecksum:
         # One InventoryPDS4Label call per historical release (backfill loop),
         # plus one for the current release's own inventory.
         assert mocks.InventoryPDS4Label.call_count == len(bundle.history) + 1
+
+    def test_release_checksum_labeled_during_backfill(self, mocks):
+        # Setting increment=True with no existing checksum directory forces the
+        # backfill loop to run once per historical release in bundle.history,
+        # rebuilding a ChecksumProduct -- and now labeling it too -- for each
+        # past release that predates this PDS4 archive.
+        setup = mocks.Setup.return_value
+        setup.increment = True
+        mocks.isdir.return_value = False
+        bundle = mocks.Bundle.return_value
+        bundle.history = {'release_01': ('data', 'label'),
+                          'release_02': ('data2', 'label2')}
+        run_pipeline(_args())
+
+        # One ChecksumPDS4Label call per historical release from the backfill
+        # loop, plus one more for the current release's own checksum, built
+        # later in the same run.
+        assert mocks.ChecksumPDS4Label.call_count == len(bundle.history) + 1
 
     def test_backfill_loop_skipped_when_checksum_dir_exists(self, mocks):
         # When the checksum directory already exists, the backfill loop does not run.
@@ -1119,6 +1160,21 @@ class TestPhase10PDS3Path:
         # The checksum file is written for the current PDS3 release.
         run_pipeline(_args())
         mocks.ChecksumProduct.return_value.generate.assert_called_once()
+
+    def test_checksum_labeled_with_pds3_label(self, mocks):
+        # This test class runs under pds_version="3" (set by the set_pds3
+        # fixture above). npb.py's PDS3 branch must pick ChecksumPDS3Label
+        # instead of ChecksumPDS4Label -- this is the same version choice
+        # that used to be an if/else inside ChecksumProduct.generate().
+        run_pipeline(_args())
+        checksum = mocks.ChecksumProduct.return_value
+
+        mocks.ChecksumPDS3Label.assert_called_once_with(
+            mocks.Setup.return_value, checksum)
+
+        mocks.ChecksumPDS4Label.assert_not_called()
+
+        assert checksum.label is mocks.ChecksumPDS3Label.return_value
 
     def test_set_increment_times_not_called_for_pds3(self, mocks):
         # Increment times are not computed for PDS3 archives.


### PR DESCRIPTION
## 🗒️ Summary
Moves ChecksumProduct's PDS3/PDS4 label construction out of ChecksumProduct.generate() and into the pipeline (npb.py). Products no longer decide their own label class; the pipeline picks and constructs the right label right after each ChecksumProduct.generate() call. product_checksum.py no longer imports or constructs any label class.

## ⚙️ Test Data and/or Report
Regression tests included: `test_classes_product_checksum.py` (generate() no longer sets self.label) and `test_pipeline_npb.py` (each of the 3 ChecksumProduct.generate() call sites builds and assigns the correct
label class).

    pytest tests/npb/test_classes_product_checksum.py tests/npb/test_pipeline_npb.py --cov-branch -q
    165 passed, 1 skipped

    Name                                                              Stmts   Miss Branch BrPart  Cover
    ----------------------------------------------------------------------------------------------------
    src/pds/naif_pds4_bundler/classes/product/product_checksum.py       214      4    100      1    98%
    src/pds/naif_pds4_bundler/pipeline/npb.py                           214      0     68      0   100%

    Full merge-gate suite (pytest tests/npb/ --cov-branch):
    1844 passed, 7 skipped, 1 xfailed, 99% overall coverage

Manual verification:
* `grep -rE "self\.label\s*=\s*\w+Label\(" classes/product/product_checksum.py` → no output
* `grep -rn "from ..label import" classes/product/product_checksum.py` → no output

## ♻️ Related Issues
Fixes #340
