### PR TITLE
Migrate remaining Bundle handle_npb_error calls to raise NPBError

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/bundle.py
+++ b/src/pds/naif_pds4_bundler/classes/bundle.py
@@ -13,7 +13,6 @@ from xml.etree import ElementTree
 import spiceypy
 
 from .exceptions import NPBError
-from ..pipeline.runtime import handle_npb_error
 from ..utils import (
     check_list_duplicates,
     etree_to_dict,
@@ -311,10 +310,9 @@ class Bundle:
             or (et_inc_stop > et_msn_stop)
             or (et_msn_strt >= et_msn_stop)
         ):
-            handle_npb_error(
+            raise NPBError(
                 "The resulting Mission and Increment start and finish dates "
-                "are incoherent."
-            )
+                "are incoherent.")
 
     @staticmethod
     def _get_collection_versions_from_label(label: dict) -> dict[str, list[int]]:
@@ -579,7 +577,7 @@ class Bundle:
                         # TODO: Perform these checks elsewhere, probably at setup loading.
                         #       Maybe it is worth using a "derived" attribute similar to
                         #       "version_length".
-                        handle_npb_error(
+                        raise NPBError(
                             f"Meta-kernel version length of {version_length} "
                             "digits is incorrect.")
 

--- a/tests/npb/test_classes_bundle.py
+++ b/tests/npb/test_classes_bundle.py
@@ -851,8 +851,8 @@ class TestBundlePCheckTimes:
     ])
     def test_invalid_ordering(self, lsk, m_start, i_start, i_end, m_end):
         bundle = self._make_times_bundle(m_start, i_start, i_end, m_end)
-        with pytest.raises(RuntimeError, match="The resulting Mission and Increment start "
-                                               "and finish dates are incoherent."):
+        with pytest.raises(NPBError, match="The resulting Mission and Increment start "
+                                           "and finish dates are incoherent."):
             bundle._check_times()
 
 
@@ -1530,7 +1530,7 @@ class TestBundlePGetKernelCollectionProducts:
         )
         bundle = _make_bundle(fake_setup, vid="1.0",
                               name=f"bundle_{MISSION}_spice_v001.xml")
-        with pytest.raises(Exception, match='Meta-kernel version length of 4 digits is incorrect.'):
+        with pytest.raises(NPBError, match='Meta-kernel version length of 4 digits is incorrect.'):
             bundle._get_kernel_collection_products(1)
 
     def test_mk_fallback_to_mk_inputs_dict(self, fake_setup):
@@ -1647,7 +1647,7 @@ class TestBundlePGetMetakernelProductFromConfig:
         setup = self._mk_setup(fake_setup, 4)
         bundle = _make_bundle(setup, vid="1.0",
                               name=f"bundle_{MISSION}_spice_v001.xml")
-        with pytest.raises(Exception, match='Meta-kernel version length of 4 digits is incorrect.'):
+        with pytest.raises(NPBError, match='Meta-kernel version length of 4 digits is incorrect.'):
             bundle._get_metakernel_product_from_config(1, self._csv_line())
 
     def test_version_number_embedded_correctly(self, fake_setup):


### PR DESCRIPTION
## 🗒️ Summary
Replaces the last two `handle_npb_error()` calls in `bundle.py` — `_check_times()` (incoherent mission/increment start and finish dates) and `_get_metakernel_product_from_config()` (unsupported meta-kernel VERSION length) — with `raise NPBError(...)`. Both methods already run inside the pipeline's broad except-NPBError block, so no additional
wrapping is needed here. Neither call site passed `setup=`, so there is no cleanup-coverage change. This was the last file under `classes/` importing `handle_npb_error`, so the import is dropped.

Also tightens the three tests covering these paths, which asserted against bare `RuntimeError`/`Exception` with a message match instead of `NPBError` specifically — those assertions would have passed identically whether or not the migration happened.

## ⚙️ Test Data and/or Report
Regression tests included: existing `test_classes_bundle.py` suite, updated to assert `NPBError` at the three affected call sites.

    pytest tests/npb/test_classes_bundle.py -v --cov-branch
    125 passed
    src/pds/naif_pds4_bundler/classes/bundle.py   318   0   150   0   100%

    Full merge-gate suite (pytest tests/npb/ -v --cov-branch):
    1844 passed, 7 skipped, 1 xfailed

Manual verification:
* `grep -rn "handle_npb_error" src/pds/naif_pds4_bundler/classes/` → no output

## ♻️ Related Issues
Fixes NASA-PDS/naif-pds4-bundler#342
